### PR TITLE
Rezept-URL-Import: Textarea-Modal statt prompt(), Beta v0.107

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.106</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.107</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div class="dn">
       <button type="button" class="da" onclick="changeDay(-1)">‹</button>
       <div class="dl" id="dateLabel"></div>
@@ -456,7 +456,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.106</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.107</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -513,7 +513,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
       <div style="display:flex;gap:8px;">
         <button type="button" id="libTabRec" onclick="libSetTab('recipes')" style="flex:1;padding:9px;border-radius:10px;border:1.5px solid var(--g2);background:var(--g2);color:white;font-weight:700;font-size:13px;">📋 Rezepte</button>
         <button type="button" id="libTabFoods" onclick="libSetTab('foods')" style="flex:1;padding:9px;border-radius:10px;border:1.5px solid var(--br);background:white;color:var(--mu);font-weight:700;font-size:13px;">🥗 Lebensmittel</button>
-        <button type="button" onclick="openRecipeImport()" style="padding:9px 12px;border-radius:10px;border:1.5px solid var(--br);background:white;color:var(--mu);font-weight:700;font-size:13px;" title="Rezept per URL importieren">🔗</button>
+        <button type="button" onclick="openRecipeImport()" style="padding:9px 14px;border-radius:10px;border:1.5px solid var(--g2);background:white;color:var(--g2);font-weight:700;font-size:13px;" title="Rezept per URL importieren">🔗 Link</button>
       </div>
       <div id="libraryList" style="display:flex;flex-direction:column;gap:8px;"></div>
     </div>
@@ -838,6 +838,26 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
       <div class="mti" id="shoppingListTitle">🛒 Einkaufsliste</div>
     </div>
     <div class="mbd" id="shoppingListContent"></div>
+  </div>
+</div>
+
+<!-- ══ REZEPT URL-IMPORT ══ -->
+<div class="ov" id="recipeImportOv" onclick="bgClose(event,'recipeImportOv')">
+  <div class="mod">
+    <div class="mhan"></div>
+    <div class="mhd">
+      <button type="button" class="mcl" onclick="closeOv('recipeImportOv')">✕</button>
+      <div class="mti">🔗 Rezept importieren</div>
+      <div class="msu">URL oder kopierten Text einfügen</div>
+    </div>
+    <div class="mbd">
+      <textarea id="recipeImportInput" rows="5"
+        style="width:100%;box-sizing:border-box;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:14px;font-family:inherit;resize:vertical;min-height:100px;outline:none;color:var(--tx);"
+        placeholder="URL einfügen – oder beliebigen Text der Seite (z.B. Chefkoch kopiert manchmal Werbetext mit). Die URL wird automatisch erkannt."
+        oninput="recipeImportDetect()"></textarea>
+      <div id="recipeImportUrlInfo" style="margin-top:8px;min-height:36px;"></div>
+      <button type="button" class="cb2" id="recipeImportBtn" onclick="recipeImportStart()" disabled style="width:100%;margin-top:4px;opacity:.4;">Rezept importieren</button>
+    </div>
   </div>
 </div>
 
@@ -1337,14 +1357,46 @@ function renderNutrientAmpel(t){
 
 // ── Rezept-Import per URL ──
 function openRecipeImport(){
-  var url=prompt('Rezept-URL eingeben (z.B. chefkoch.de, essen-und-trinken.de):');
-  if(!url||!url.startsWith('http'))return;
+  var inp=document.getElementById('recipeImportInput');
+  inp.value='';
+  document.getElementById('recipeImportUrlInfo').innerHTML='';
+  document.getElementById('recipeImportBtn').disabled=true;
+  document.getElementById('recipeImportBtn').style.opacity='.4';
+  openOv('recipeImportOv');
+  setTimeout(function(){inp.focus();},300);
+}
+function recipeImportExtractUrl(text){
+  var m=text.match(/https?:\/\/[^\s"<>]+/);
+  return m?m[0].replace(/[.,;:!?)\]]+$/,''):null;
+}
+function recipeImportDetect(){
+  var raw=document.getElementById('recipeImportInput').value;
+  var url=recipeImportExtractUrl(raw);
+  var info=document.getElementById('recipeImportUrlInfo');
+  var btn=document.getElementById('recipeImportBtn');
+  if(url){
+    info.innerHTML='<div style="background:#f0faf4;border:1.5px solid var(--g2);border-radius:10px;padding:8px 12px;font-size:12px;word-break:break-all;">'
+      +'<span style="color:var(--g2);font-weight:800;">✓ URL erkannt</span><br>'
+      +'<span style="color:#555;">'+url+'</span></div>';
+    btn.disabled=false;btn.style.opacity='1';
+  } else if(raw.trim()){
+    info.innerHTML='<div style="background:#fff8e1;border:1.5px solid #f9a825;border-radius:10px;padding:8px 12px;font-size:12px;color:#888;">Keine URL gefunden – bitte Link einfügen.</div>';
+    btn.disabled=true;btn.style.opacity='.4';
+  } else {
+    info.innerHTML='';
+    btn.disabled=true;btn.style.opacity='.4';
+  }
+}
+function recipeImportStart(){
+  var raw=document.getElementById('recipeImportInput').value;
+  var url=recipeImportExtractUrl(raw);
+  if(!url)return;
   if(!S.apiKey||!isOnline){showToast('Internet & API Key benötigt');return;}
+  closeOv('recipeImportOv');
   showToast('⏳ Rezept wird importiert...');
   fetch('https://corsproxy.io/?'+encodeURIComponent(url))
     .then(function(r){return r.text();})
     .then(function(html){
-      // HTML auf relevante Teile kürzen
       var text=html.replace(/<script[\s\S]*?<\/script>/gi,'')
                    .replace(/<style[\s\S]*?<\/style>/gi,'')
                    .replace(/<[^>]+>/g,' ')
@@ -1359,7 +1411,6 @@ function openRecipeImport(){
             var a=resp.indexOf('{'),z=resp.lastIndexOf('}');
             var d=JSON.parse(resp.slice(a,z+1));
             if(!d.name||!d.zutaten||!d.zutaten.length)throw new Error();
-            // Nährwerte nachschlagen und Rezept speichern
             var rawItems=d.zutaten.map(function(z){
               var g=parseFloat((z.menge||'').replace(/[^\d.]/g,''))||100;
               return{name:z.name,g:g,emoji:emo(z.name)};

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.106';
+var VERSION = '0.107';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['anthropic.com','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 


### PR DESCRIPTION
## Was wurde geändert

- **Neues Import-Modal** statt dem nativen `prompt()`-Dialog: großes Textarea (5 Zeilen, vergrößerbar), in das man beliebigen Text einfügen kann
- **Automatische URL-Erkennung**: findet die URL auch wenn Werbetext davor steht (z.B. Chefkoch)
- **Live-Feedback**: grüne Anzeige der erkannten URL, gelbe Warnung wenn keine URL im Text
- **Import-Button** erst aktiv wenn eine URL erkannt wurde
- **Library-Button** neu: `🔗 Link` (beschriftet, grün) statt kleinem Icon ohne Text

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_