### PR TITLE
Link-Import im Picker + Textarea-Modal, Beta v0.108

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.107</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.108</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div class="dn">
       <button type="button" class="da" onclick="changeDay(-1)">‹</button>
       <div class="dl" id="dateLabel"></div>
@@ -456,7 +456,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.107</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.108</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -543,6 +543,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
         <button type="button" class="picker-tab" id="ptab-foto" onclick="pickerSetTab('foto')"><span>📷</span>Foto</button>
         <button type="button" class="picker-tab" id="ptab-barcode" onclick="pickerSetTab('barcode')"><span>📊</span>Barcode</button>
         <button type="button" class="picker-tab" id="ptab-own" onclick="pickerSetTab('own')"><span>✚</span>Eigenes</button>
+        <button type="button" class="picker-tab" id="ptab-link" onclick="pickerSetTab('link')"><span>🔗</span>Link</button>
         <button type="button" class="picker-tab" id="ptab-quick" onclick="pickerSetTab('quick')"><span>⚡</span>Quick</button>
       </div>
 
@@ -666,6 +667,30 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
           <div class="frow"><input type="number" class="finp" id="ownKcal" placeholder="kcal"><input type="number" class="finp" id="ownProtein" placeholder="Protein g"></div>
           <div class="frow"><input type="number" class="finp" id="ownCarbs" placeholder="Kohlenhydrate g"><input type="number" class="finp" id="ownFat" placeholder="Fett g"></div>
           <button type="button" class="fsave" onclick="pickerSaveOwn()">💾 Speichern & zur Suche</button>
+        </div>
+      </div>
+
+      <!-- Tab: Link/URL-Import -->
+      <div class="picker-panel" id="ppanel-link">
+        <textarea id="pickerLinkInput" rows="3"
+          style="width:100%;box-sizing:border-box;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:14px;font-family:inherit;resize:none;outline:none;color:var(--tx);"
+          placeholder="Rezept-URL einfügen – auch mit kopiertem Text drumherum (z.B. Chefkoch)"
+          oninput="pickerLinkDetect()"></textarea>
+        <div id="pickerLinkUrlInfo" style="margin-top:6px;min-height:30px;"></div>
+        <button type="button" class="abt" id="pickerLinkImportBtn" disabled onclick="pickerLinkImport()" style="opacity:.4;">🔗 Rezept laden</button>
+        <div id="pickerLinkResult" class="hidden" style="margin-top:10px;">
+          <div style="font-size:11px;font-weight:700;color:var(--mu);text-transform:uppercase;margin-bottom:6px;">Erkannte Zutaten</div>
+          <div style="margin-bottom:6px;"><input type="text" class="finp" id="pickerLinkRecipeName" placeholder="Rezeptname (optional)"></div>
+          <div class="ing-list" id="pickerLinkIngList"></div>
+          <div id="pickerLinkTotal" class="rec-total"></div>
+          <div class="ar" style="margin-top:0;">
+            <input type="number" class="ai2" id="pickerLinkPortions" value="1" min="0.1" step="0.1" onchange="pickerUpdateLinkTotal()">
+            <div class="au">Portion(en)</div>
+          </div>
+          <div style="display:flex;gap:8px;margin-top:10px;">
+            <button type="button" class="cb2" style="margin-top:0;" onclick="pickerLinkAdd(false)">✓ Eintragen</button>
+            <button type="button" class="cb2" style="margin-top:0;background:linear-gradient(135deg,#2d5f8a,#3d8bc4);" onclick="pickerLinkAdd(true)">📋 Als Rezept</button>
+          </div>
         </div>
       </div>
 
@@ -1817,6 +1842,12 @@ function openPicker(meal, defaultTab){
   document.getElementById('pickerBarcodeResult').innerHTML='';
   document.getElementById('pickerRecipeName').value='';
   document.getElementById('pickerChatRecipeName').value='';
+  document.getElementById('pickerLinkInput').value='';
+  document.getElementById('pickerLinkUrlInfo').innerHTML='';
+  document.getElementById('pickerLinkResult').classList.add('hidden');
+  document.getElementById('pickerLinkImportBtn').disabled=true;
+  document.getElementById('pickerLinkImportBtn').style.opacity='.4';
+  document.getElementById('pickerLinkImportBtn').textContent='🔗 Rezept laden';
   pickerStopScan();
   // Title
   document.getElementById('pickerTitle').textContent=(MEAL_NAMES[pickerMeal]||'Mahlzeit')+' – Zutat hinzufügen';
@@ -2470,6 +2501,84 @@ function pickerUpdateChatTotal(){
 }
 
 function pickerChatAdd(saveAsRecipe){_pickerAdd('💬','pickerChatRecipeName','pickerChatPortions','Chat-Eintrag',saveAsRecipe,false);}
+
+// ─── PICKER: LINK/URL TAB ───
+function pickerLinkDetect(){
+  var raw=document.getElementById('pickerLinkInput').value;
+  var url=recipeImportExtractUrl(raw);
+  var info=document.getElementById('pickerLinkUrlInfo');
+  var btn=document.getElementById('pickerLinkImportBtn');
+  if(url){
+    info.innerHTML='<div style="background:#f0faf4;border:1.5px solid var(--g2);border-radius:10px;padding:6px 10px;font-size:11px;word-break:break-all;">'
+      +'<span style="color:var(--g2);font-weight:800;">✓ URL erkannt: </span><span style="color:#555;">'+url+'</span></div>';
+    btn.disabled=false;btn.style.opacity='1';
+  } else if(raw.trim()){
+    info.innerHTML='<div style="background:#fff8e1;border:1.5px solid #f9a825;border-radius:10px;padding:6px 10px;font-size:11px;color:#888;">Keine URL gefunden – bitte Link einfügen.</div>';
+    btn.disabled=true;btn.style.opacity='.4';
+  } else {
+    info.innerHTML='';btn.disabled=true;btn.style.opacity='.4';
+  }
+}
+function pickerLinkImport(){
+  var raw=document.getElementById('pickerLinkInput').value;
+  var url=recipeImportExtractUrl(raw);
+  if(!url||!S.apiKey||!isOnline){showToast('Internet & API Key benötigt');return;}
+  var btn=document.getElementById('pickerLinkImportBtn');
+  btn.disabled=true;btn.textContent='⏳ Laden...';btn.style.opacity='.6';
+  fetch('https://corsproxy.io/?'+encodeURIComponent(url))
+    .then(function(r){return r.text();})
+    .then(function(html){
+      var text=html.replace(/<script[\s\S]*?<\/script>/gi,'')
+                   .replace(/<style[\s\S]*?<\/style>/gi,'')
+                   .replace(/<[^>]+>/g,' ')
+                   .replace(/\s+/g,' ')
+                   .slice(0,3000);
+      callClaude('claude-haiku-4-5',[{type:'text',text:
+        'Extrahiere das Rezept aus diesem Text und gib NUR gültiges JSON zurück:\n'
+        +'{"name":"Rezeptname","zutaten":[{"name":"Zutat","menge":"100g"}]}\n'
+        +'Text: '+text}],500,
+        function(resp){
+          try{
+            var a=resp.indexOf('{'),z=resp.lastIndexOf('}');
+            var d=JSON.parse(resp.slice(a,z+1));
+            if(!d.name||!d.zutaten||!d.zutaten.length)throw new Error();
+            var rawItems=d.zutaten.map(function(z){
+              var g=parseFloat((z.menge||'').replace(/[^\d.]/g,''))||100;
+              return{name:z.name,g:g,emoji:emo(z.name)};
+            });
+            lookupNutrients(rawItems,function(ings){
+              pickerIngredients=ings;
+              document.getElementById('pickerLinkRecipeName').value=d.name;
+              pickerRenderIngList('pickerLinkIngList',pickerIngredients,
+                function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateLinkTotal();},
+                function(i){pickerIngredients.splice(i,1);pickerUpdateLinkTotal();}
+              );
+              pickerUpdateLinkTotal();
+              document.getElementById('pickerLinkResult').classList.remove('hidden');
+              btn.disabled=false;btn.textContent='🔗 Neu laden';btn.style.opacity='1';
+            });
+          }catch(e){
+            showToast('Rezept konnte nicht erkannt werden');
+            btn.disabled=false;btn.textContent='🔗 Rezept laden';btn.style.opacity='1';
+          }
+        },
+        function(){
+          showToast('Import fehlgeschlagen');
+          btn.disabled=false;btn.textContent='🔗 Rezept laden';btn.style.opacity='1';
+        }
+      );
+    })
+    .catch(function(){
+      showToast('URL konnte nicht geladen werden');
+      btn.disabled=false;btn.textContent='🔗 Rezept laden';btn.style.opacity='1';
+    });
+}
+function pickerUpdateLinkTotal(){
+  var t=ingTotal(pickerIngredients);
+  var p=parseFloat(document.getElementById('pickerLinkPortions').value)||1;
+  document.getElementById('pickerLinkTotal').textContent='1 Portion: '+totalStr(t)+(p!==1?'  ·  '+p+'× = '+totalStr(scaleNutrients(t,p)):'');
+}
+function pickerLinkAdd(saveAsRecipe){_pickerAdd('🔗','pickerLinkRecipeName','pickerLinkPortions','Rezept',saveAsRecipe,false);}
 
 // ─── PICKER: EIGENES TAB ───
 function pickerSaveOwn(){

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.107';
+var VERSION = '0.108';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['anthropic.com','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 


### PR DESCRIPTION
## Änderungen

**Beta v0.107 – Rezept-URL-Import: Overlay mit Textarea statt prompt()**
- Neues Modal mit großem Textarea (URL oder kopierten Text einfügen)
- Live-URL-Erkennung per Regex – findet URL auch mitten im Werbetext (z.B. Chefkoch)
- Grüne/gelbe Rückmeldung + Import-Button erst aktiv wenn URL erkannt
- Library-Button neu: `🔗 Link` (beschriftet, grün)

**Beta v0.108 – Link-Tab direkt im Picker (+)**
- Neuer Tab `🔗 Link` im universellen Ingredient Picker
- URL einfügen → KI extrahiert Zutaten → inline anzeigen und anpassen
- `✓ Eintragen` und `📋 Als Rezept` wie bei Foto/Chat-Tab
- Reset beim Öffnen des Pickers

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_