### PR TITLE
feat: v0.110 – Verschieben, Rezept-Code, Kochanleitung, Screenshot, Einstellungen-Tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,8 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 .mmk{position:absolute;top:-2px;width:2px;height:7px;background:white;border-radius:1px;opacity:0.9;pointer-events:none;}
 .diet-btn{border:1.5px solid var(--br);background:white;border-radius:20px;padding:5px 10px;font-size:12px;font-weight:600;color:var(--mu);cursor:pointer;transition:all .2s;}
 .diet-btn.act{background:var(--g1);border-color:var(--g1);color:white;}
+.stab{border:1.5px solid var(--br);background:white;border-radius:10px;padding:7px 10px;font-size:12px;font-weight:700;color:var(--mu);white-space:nowrap;transition:all .15s;}
+.stab.act{background:var(--g2);border-color:var(--g2);color:white;}
 .mf{height:100%;border-radius:4px;background:white;transition:width .6s;}
 
 /* ── MEAL CARDS ── */
@@ -372,7 +374,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.109</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.110</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div class="dn">
       <button type="button" class="da" onclick="changeDay(-1)">‹</button>
       <div class="dl" id="dateLabel"></div>
@@ -456,7 +458,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.109</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.110</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -737,7 +739,13 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
         <button type="button" class="rec-search-btn" onclick="recEditSearch()">Suchen</button>
       </div>
       <div class="rec-results" id="recEditResults"></div>
+      <div id="recEditInstructionsWrap" style="margin-top:8px;">
+        <label class="lbl">📝 Kochanleitung (optional)</label>
+        <textarea id="recEditInstructions" rows="4" placeholder="Zubereitungsschritte hier eingeben..."
+          style="width:100%;border:1.5px solid var(--br);border-radius:12px;padding:10px;font-size:13px;font-family:inherit;resize:vertical;outline:none;margin-bottom:8px;min-height:80px;"></textarea>
+      </div>
       <button type="button" class="cb2" onclick="recEditSave()">💾 Rezept speichern</button>
+      <button type="button" class="seb" style="margin-bottom:8px;" onclick="openRecipeCodeShare(recEditId)">📤 Rezept teilen (Code)</button>
       <button type="button" class="del-btn" onclick="recEditDelete()">🗑️ Rezept löschen</button>
     </div>
   </div>
@@ -898,6 +906,31 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
   </div>
 </div>
 
+<!-- ══ REZEPT-CODE TEILEN ══ -->
+<div class="ov" id="recipeCodeOv" onclick="bgClose(event,'recipeCodeOv')">
+  <div class="mod">
+    <div class="mhan"></div>
+    <div class="mhd">
+      <button type="button" class="mcl" onclick="closeOv('recipeCodeOv')">✕</button>
+      <div class="mti">📤 Rezept teilen</div>
+      <div class="msu">Code kopieren oder einlösen</div>
+    </div>
+    <div class="mbd">
+      <div id="recipeCodeExportWrap" style="display:none;">
+        <label class="lbl">Dein Rezept-Code</label>
+        <textarea id="recipeCodeText" readonly rows="4"
+          style="width:100%;border:1.5px solid var(--g2);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;background:var(--gl);color:var(--tx);margin-bottom:8px;word-break:break-all;"></textarea>
+        <button type="button" class="cb2" onclick="copyRecipeCode()" style="margin-bottom:12px;">📋 Code kopieren</button>
+        <div style="border-top:1px solid var(--br);margin-bottom:12px;"></div>
+      </div>
+      <label class="lbl">Rezept-Code einlösen</label>
+      <textarea id="recipeImportCodeInput" rows="3" placeholder="Rezept-Code hier einfügen..."
+        style="width:100%;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;margin-bottom:8px;word-break:break-all;"></textarea>
+      <button type="button" class="svb" onclick="importRecipeCode()" style="margin-top:0;">✅ Rezept importieren</button>
+    </div>
+  </div>
+</div>
+
 <!-- ══ FASTEN ══ -->
 <div class="ov" id="fastOv" onclick="bgClose(event,'fastOv')">
   <div class="mod">
@@ -927,107 +960,106 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div class="ov" id="settOv" onclick="bgClose(event,'settOv')">
   <div class="mod">
     <div class="mhan"></div>
-    <div class="mhd"><button type="button" class="mcl" onclick="closeOv('settOv')">✕</button><div class="mti">Einstellungen</div></div>
-    <div class="mbd">
-      <div class="sf"><label class="lbl">Anthropic API Key</label>
-        <div style="position:relative;"><input type="password" class="sinp" id="sk"><button type="button" onclick="toggleEye('sk')" style="position:absolute;right:10px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:17px;color:var(--mu);">👁</button></div>
-      </div>
-      <div class="sf"><label class="lbl">Name</label><input type="text" class="sinp" id="sn"></div>
-      <div class="srow">
-        <div class="sf"><label class="lbl">Gewicht (kg)</label><input type="number" class="sinp" id="sw"></div>
-        <div class="sf"><label class="lbl">Größe (cm)</label><input type="number" class="sinp" id="sh"></div>
-      </div>
-      <div class="srow">
-        <div class="sf"><label class="lbl">Alter</label><input type="number" class="sinp" id="sa" placeholder="30"></div>
-        <div class="sf"><label class="lbl">Geschlecht</label>
-          <select class="sinp" id="sgender">
-            <option value="">Keine Angabe</option>
-            <option value="m">Männlich</option>
-            <option value="f">Weiblich</option>
-          </select>
+    <div class="mhd"><button type="button" class="mcl" onclick="closeOv('settOv')">✕</button><div class="mti">⚙️ Einstellungen</div></div>
+    <!-- Settings Tab Bar -->
+    <div style="display:flex;overflow-x:auto;gap:4px;padding:0 16px 8px;border-bottom:1px solid var(--br);flex-shrink:0;scrollbar-width:none;">
+      <button type="button" class="stab" id="stab-profil" onclick="settSetTab('profil')">👤 Profil</button>
+      <button type="button" class="stab" id="stab-ziele" onclick="settSetTab('ziele')">🎯 Ziele</button>
+      <button type="button" class="stab" id="stab-ernaehrung" onclick="settSetTab('ernaehrung')">🥗 Ernährung</button>
+      <button type="button" class="stab" id="stab-erinnerungen" onclick="settSetTab('erinnerungen')">⏰ Erinn.</button>
+      <button type="button" class="stab" id="stab-daten" onclick="settSetTab('daten')">🗂 Daten</button>
+    </div>
+    <div class="mbd" style="padding-top:12px;">
+
+      <!-- TAB: PROFIL -->
+      <div id="spanel-profil">
+        <div class="sf"><label class="lbl">Name</label><input type="text" class="sinp" id="sn"></div>
+        <div class="srow">
+          <div class="sf"><label class="lbl">Gewicht (kg)</label><input type="number" class="sinp" id="sw"></div>
+          <div class="sf"><label class="lbl">Größe (cm)</label><input type="number" class="sinp" id="sh"></div>
         </div>
-      </div>
-      <div class="sf"><label class="lbl">Aktivitätsgrad</label>
-        <select class="sinp" id="sactivity">
-          <option value="">Keine Angabe</option>
-          <option value="1.2">Wenig/keine Bewegung (Büro)</option>
-          <option value="1.375">Leichte Aktivität (1-3× Sport/Woche)</option>
-          <option value="1.55">Moderate Aktivität (3-5× Sport/Woche)</option>
-          <option value="1.725">Viel Aktivität (6-7× Sport/Woche)</option>
-          <option value="1.9">Sehr viel / körperliche Arbeit</option>
-        </select>
-      </div>
-      <div class="sf" id="pregnantRow" style="display:none;"><label class="lbl">🤰 Schwangerschaft</label>
-        <select class="sinp" id="spregnant" onchange="updatePregnantUI()">
-          <option value="0">Nicht schwanger</option>
-          <option value="1">1. Trimester (+0 kcal)</option>
-          <option value="2">2. Trimester (+300 kcal)</option>
-          <option value="3">3. Trimester (+500 kcal)</option>
-          <option value="et">Errechneter Termin eingeben</option>
-        </select>
-        <div id="etRow" style="display:none;margin-top:8px;">
-          <label class="lbl">Errechneter Termin (ET)</label>
-          <input type="date" class="sinp" id="set">
-          <div id="etInfo" style="font-size:12px;color:var(--g1);margin-top:4px;"></div>
-        </div>
-        <div id="pregWarnRow" style="display:none;margin-top:10px;padding:10px;background:var(--gl);border-radius:10px;border:1px solid var(--g3);">
-          <div style="display:flex;align-items:center;justify-content:space-between;">
-            <div>
-              <div style="font-size:13px;font-weight:700;">🚦 Lebensmittel-Ampel</div>
-              <div style="font-size:11px;color:var(--mu);margin-top:2px;">Hinweise bei Eingabe von Lebensmitteln</div>
-            </div>
-            <label style="position:relative;display:inline-block;width:44px;height:24px;">
-              <input type="checkbox" id="spregwarn" style="opacity:0;width:0;height:0;" onchange="updatePregnantUI()">
-              <span id="pregWarnToggle" style="position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#ccc;border-radius:24px;transition:.3s;"></span>
-              <span id="pregWarnThumb" style="position:absolute;content:'';height:18px;width:18px;left:3px;bottom:3px;background:white;border-radius:50%;transition:.3s;"></span>
-            </label>
+        <div class="srow">
+          <div class="sf"><label class="lbl">Alter</label><input type="number" class="sinp" id="sa" placeholder="30"></div>
+          <div class="sf"><label class="lbl">Geschlecht</label>
+            <select class="sinp" id="sgender">
+              <option value="">Keine Angabe</option>
+              <option value="m">Männlich</option>
+              <option value="f">Weiblich</option>
+            </select>
           </div>
         </div>
+        <div class="sf"><label class="lbl">Aktivitätsgrad</label>
+          <select class="sinp" id="sactivity">
+            <option value="">Keine Angabe</option>
+            <option value="1.2">Wenig/keine Bewegung (Büro)</option>
+            <option value="1.375">Leichte Aktivität (1-3× Sport/Woche)</option>
+            <option value="1.55">Moderate Aktivität (3-5× Sport/Woche)</option>
+            <option value="1.725">Viel Aktivität (6-7× Sport/Woche)</option>
+            <option value="1.9">Sehr viel / körperliche Arbeit</option>
+          </select>
+        </div>
+        <div class="sf" id="pregnantRow" style="display:none;"><label class="lbl">🤰 Schwangerschaft</label>
+          <select class="sinp" id="spregnant" onchange="updatePregnantUI()">
+            <option value="0">Nicht schwanger</option>
+            <option value="1">1. Trimester (+0 kcal)</option>
+            <option value="2">2. Trimester (+300 kcal)</option>
+            <option value="3">3. Trimester (+500 kcal)</option>
+            <option value="et">Errechneter Termin eingeben</option>
+          </select>
+          <div id="etRow" style="display:none;margin-top:8px;">
+            <label class="lbl">Errechneter Termin (ET)</label>
+            <input type="date" class="sinp" id="set">
+            <div id="etInfo" style="font-size:12px;color:var(--g1);margin-top:4px;"></div>
+          </div>
+          <div id="pregWarnRow" style="display:none;margin-top:10px;padding:10px;background:var(--gl);border-radius:10px;border:1px solid var(--g3);">
+            <div style="display:flex;align-items:center;justify-content:space-between;">
+              <div>
+                <div style="font-size:13px;font-weight:700;">🚦 Lebensmittel-Ampel</div>
+                <div style="font-size:11px;color:var(--mu);margin-top:2px;">Hinweise bei Eingabe von Lebensmitteln</div>
+              </div>
+              <label style="position:relative;display:inline-block;width:44px;height:24px;">
+                <input type="checkbox" id="spregwarn" style="opacity:0;width:0;height:0;" onchange="updatePregnantUI()">
+                <span id="pregWarnToggle" style="position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#ccc;border-radius:24px;transition:.3s;"></span>
+                <span id="pregWarnThumb" style="position:absolute;content:'';height:18px;width:18px;left:3px;bottom:3px;background:white;border-radius:50%;transition:.3s;"></span>
+              </label>
+            </div>
+          </div>
+        </div>
+        <button type="button" class="svb" onclick="saveSettings()">Speichern ✓</button>
       </div>
-      <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--br);">
+
+      <!-- TAB: ZIELE -->
+      <div id="spanel-ziele" style="display:none;">
         <label class="lbl" style="margin-bottom:6px;">🎯 Abnehmen</label>
         <div class="srow">
           <div class="sf"><label class="lbl">Zielgewicht (kg)</label><input type="number" class="sinp" id="sgoalweight" placeholder="70"></div>
           <div class="sf"><label class="lbl">Bis Datum</label><input type="date" class="sinp" id="sgoaldate"></div>
         </div>
-        <div id="weightLossInfo" style="font-size:12px;color:var(--mu);min-height:16px;margin-bottom:4px;"></div>
-      </div>
-      <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--br);">
-        <button type="button" class="seb" onclick="calcGoal()" style="margin-bottom:8px;">🧮 Kalorienbedarf berechnen</button>
-        <div class="sf"><label class="lbl">Kalorienziel (kcal/Tag)</label><input type="number" class="sinp" id="sg"></div>
-      </div>
-      <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--br);">
-        <label class="lbl" style="margin-bottom:6px;">🎯 Makro-Ziele</label>
-        <div style="display:flex;gap:6px;margin-bottom:8px;">
-          <button type="button" id="macroModePercent" onclick="setMacroMode('percent')" style="flex:1;padding:6px;border-radius:8px;border:1.5px solid var(--g2);background:var(--g2);color:white;font-size:12px;font-weight:700;">% vom Ziel</button>
-          <button type="button" id="macroModeGram" onclick="setMacroMode('gram')" style="flex:1;padding:6px;border-radius:8px;border:1.5px solid var(--br);background:white;color:var(--mu);font-size:12px;font-weight:700;">Eigene Gramm</button>
+        <div id="weightLossInfo" style="font-size:12px;color:var(--mu);min-height:16px;margin-bottom:8px;"></div>
+        <div style="padding-top:12px;border-top:1px solid var(--br);margin-bottom:12px;">
+          <button type="button" class="seb" onclick="calcGoal()" style="margin-bottom:8px;">🧮 Kalorienbedarf berechnen</button>
+          <div class="sf"><label class="lbl">Kalorienziel (kcal/Tag)</label><input type="number" class="sinp" id="sg"></div>
         </div>
-        <div id="macroGramInputs" style="display:none;">
-          <div class="srow">
-            <div class="sf"><label class="lbl">Protein (g)</label><input type="number" class="sinp" id="smacrop" placeholder="160"></div>
-            <div class="sf"><label class="lbl">Carbs (g)</label><input type="number" class="sinp" id="smacroc" placeholder="200"></div>
-            <div class="sf"><label class="lbl">Fett (g)</label><input type="number" class="sinp" id="smacrof" placeholder="70"></div>
+        <div style="padding-top:12px;border-top:1px solid var(--br);margin-bottom:12px;">
+          <label class="lbl" style="margin-bottom:6px;">🏋️ Makro-Ziele</label>
+          <div style="display:flex;gap:6px;margin-bottom:8px;">
+            <button type="button" id="macroModePercent" onclick="setMacroMode('percent')" style="flex:1;padding:6px;border-radius:8px;border:1.5px solid var(--g2);background:var(--g2);color:white;font-size:12px;font-weight:700;">% vom Ziel</button>
+            <button type="button" id="macroModeGram" onclick="setMacroMode('gram')" style="flex:1;padding:6px;border-radius:8px;border:1.5px solid var(--br);background:white;color:var(--mu);font-size:12px;font-weight:700;">Eigene Gramm</button>
+          </div>
+          <div id="macroGramInputs" style="display:none;">
+            <div class="srow">
+              <div class="sf"><label class="lbl">Protein (g)</label><input type="number" class="sinp" id="smacrop" placeholder="160"></div>
+              <div class="sf"><label class="lbl">Carbs (g)</label><input type="number" class="sinp" id="smacroc" placeholder="200"></div>
+              <div class="sf"><label class="lbl">Fett (g)</label><input type="number" class="sinp" id="smacrof" placeholder="70"></div>
+            </div>
           </div>
         </div>
-      </div>
-      <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--br);">
         <div class="sf"><label class="lbl">💧 Wasserziel (Gläser)</label><input type="number" class="sinp" id="swatergoal" min="1" max="20" placeholder="8"></div>
+        <button type="button" class="svb" onclick="saveSettings()">Speichern ✓</button>
       </div>
-      <button type="button" class="svb" onclick="saveSettings()">Speichern</button>
-      <button type="button" class="seb" style="margin-top:8px;" onclick="syncToGoogleDrive()">☁️ Google Drive Sync</button>
-      <button type="button" class="seb" onclick="openPromptSettings()" style="margin-top:8px;">⚙️ KI-Prompts bearbeiten</button>
-      <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--br);">
-        <label class="lbl" style="margin-bottom:6px;">⏰ Erinnerungen</label>
-        <div id="reminderList"></div>
-        <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px;">
-          <div style="display:flex;gap:6px;">
-            <input type="time" class="sinp" id="reminderTime" style="flex:0 0 110px;">
-            <input type="text" class="sinp" id="reminderLabel" placeholder="z.B. Mittagessen" style="flex:1;">
-          </div>
-          <button type="button" class="svb" style="margin-top:0;" onclick="addReminder()">⏰ Erinnerung hinzufügen</button>
-        </div>
-      </div>
-      <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--br);">
+
+      <!-- TAB: ERNÄHRUNG -->
+      <div id="spanel-ernaehrung" style="display:none;">
         <label class="lbl" style="margin-bottom:6px;">🥗 Ernährungspräferenzen</label>
         <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px;" id="dietPresetBtns">
           <button type="button" class="diet-btn" onclick="toggleDietPreset('Vegetarisch')">🥦 Vegetarisch</button>
@@ -1039,7 +1071,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
           <button type="button" class="diet-btn" onclick="toggleDietPreset('High Protein')">💪 High Protein</button>
         </div>
         <div id="savedDietFreeList" style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:6px;"></div>
-        <div style="display:flex;gap:6px;">
+        <div style="display:flex;gap:6px;margin-bottom:8px;">
           <input type="text" class="sinp" id="sdietfree" placeholder="Eigene Präferenz (z.B. Histaminintoleranz)..." style="flex:1;margin-bottom:0;">
           <button type="button" class="svb" style="flex:0 0 auto;padding:8px 12px;margin-top:0;white-space:nowrap;" onclick="addDietFree()">+ Speichern</button>
         </div>
@@ -1055,18 +1087,45 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
             <span id="dietWarnThumb" style="position:absolute;height:18px;width:18px;left:3px;bottom:3px;background:white;border-radius:50%;transition:.3s;"></span>
           </label>
         </div>
+        <button type="button" class="svb" style="margin-top:12px;" onclick="saveSettings()">Speichern ✓</button>
       </div>
-      <div style="margin-top:16px;padding-top:14px;border-top:1px solid var(--br);">
-        <label class="lbl" style="margin-bottom:8px;">Datensicherung</label>
-        <button type="button" class="seb" onclick="exportData()">📤 Exportieren</button>
-        <button type="button" class="seb" onclick="document.getElementById('impInp').click()">📥 Importieren</button>
-        <input type="file" id="impInp" accept=".json" style="display:none" onchange="importData(event)">
-        <div style="font-size:12px;color:var(--mu);margin-top:8px;text-align:center;" id="cacheInfo"></div>
+
+      <!-- TAB: ERINNERUNGEN -->
+      <div id="spanel-erinnerungen" style="display:none;">
+        <label class="lbl" style="margin-bottom:6px;">⏰ Erinnerungen</label>
+        <div id="reminderList"></div>
+        <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px;">
+          <div style="display:flex;gap:6px;">
+            <input type="time" class="sinp" id="reminderTime" style="flex:0 0 110px;">
+            <input type="text" class="sinp" id="reminderLabel" placeholder="z.B. Mittagessen" style="flex:1;">
+          </div>
+          <button type="button" class="svb" style="margin-top:0;" onclick="addReminder()">⏰ Erinnerung hinzufügen</button>
+        </div>
       </div>
-      <div style="margin-top:16px;padding-top:14px;border-top:1px solid var(--br);">
-        <label class="lbl" style="margin-bottom:8px;">Eigene Lebensmittel &amp; Rezepte</label>
-        <div id="settFoodList"></div>
+
+      <!-- TAB: DATEN -->
+      <div id="spanel-daten" style="display:none;">
+        <div class="sf" style="margin-bottom:12px;"><label class="lbl">🔑 Anthropic API Key</label>
+          <div style="position:relative;"><input type="password" class="sinp" id="sk"><button type="button" onclick="toggleEye('sk')" style="position:absolute;right:10px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:17px;color:var(--mu);">👁</button></div>
+        </div>
+        <button type="button" class="svb" onclick="saveSettings()" style="margin-bottom:12px;">Speichern ✓</button>
+        <div style="padding-top:12px;border-top:1px solid var(--br);margin-bottom:12px;">
+          <label class="lbl" style="margin-bottom:8px;">💾 Datensicherung</label>
+          <button type="button" class="seb" onclick="exportData()">📤 Exportieren</button>
+          <button type="button" class="seb" onclick="document.getElementById('impInp').click()">📥 Importieren</button>
+          <input type="file" id="impInp" accept=".json" style="display:none" onchange="importData(event)">
+          <button type="button" class="seb" style="margin-top:4px;" onclick="syncToGoogleDrive()">☁️ Google Drive Sync</button>
+        </div>
+        <div style="padding-top:12px;border-top:1px solid var(--br);margin-bottom:12px;">
+          <button type="button" class="seb" onclick="openPromptSettings()">⚙️ KI-Prompts anzeigen</button>
+          <div style="font-size:12px;color:var(--mu);margin-top:8px;text-align:center;" id="cacheInfo"></div>
+        </div>
+        <div style="padding-top:12px;border-top:1px solid var(--br);">
+          <label class="lbl" style="margin-bottom:8px;">🥘 Eigene Lebensmittel &amp; Rezepte</label>
+          <div id="settFoodList"></div>
+        </div>
       </div>
+
     </div>
   </div>
 </div>
@@ -1171,24 +1230,31 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.109';
+var APP_VERSION='0.110';
 var CHANGELOG=[
+  {v:'0.110',items:[
+    {icon:'↕',text:'Mahlzeiten verschieben: Einträge per Knopf zwischen Mahlzeiten wechseln',where:'Eintrag antippen → „↕ Mahlzeit wechseln"'},
+    {icon:'📤',text:'Rezept als Code teilen und einlösen (inkl. Kochanleitung)',where:'Bibliothek → Rezept → 📤 oder Rezept bearbeiten → „Rezept teilen"'},
+    {icon:'📝',text:'Kochanleitung pro Rezept – Freitext, wird beim URL-Import automatisch erkannt',where:'Einstellungen → Rezept bearbeiten → Kochanleitung'},
+    {icon:'➕',text:'Rezept aus allen Quellen erweitern: Chat, Foto, Barcode, Suche, Link',where:'Eintrag antippen → „+ Zutat hinzufügen"'},
+    {icon:'📷',text:'Screenshot-Import verbessert: Tracking-Apps, Einkaufszettel, Übersichten',where:'+ → Foto → Bild auswählen'},
+    {icon:'⚙️',text:'Einstellungen in übersichtliche Tabs aufgeteilt',where:'⚙️ oben rechts'},
+  ]},
+  {v:'0.109',items:[
+    {icon:'🆕',text:'Automatischer Update-Hinweis beim App-Start',where:'Erscheint nach Update automatisch'},
+    {icon:'📄',text:'Benutzerhandbuch aktualisiert',where:'❓ Hilfe'},
+  ]},
   {v:'0.108',items:[
     {icon:'🔗',text:'Rezept-Import per Link direkt beim Eintragen',where:'+ drücken → Tab „🔗 Link"'},
-    {icon:'📋',text:'Erkannte Zutaten sofort anpassen und direkt eintragen oder als Rezept speichern',where:'+ → 🔗 Link → Rezept laden'},
-  ]},
-  {v:'0.107',items:[
-    {icon:'🔗',text:'Rezept per URL importieren – auch mit kopiertem Werbetext',where:'Bibliothek → „🔗 Link"-Button'},
-    {icon:'✅',text:'URL wird automatisch aus dem eingefügten Text erkannt',where:'Bibliothek → 🔗 Link → Textfeld'},
   ]},
 ];
 
 // Default prompts - editable in settings
-var DEFAULT_FOTO_PROMPT='Analysiere dieses Essensfoto auf Deutsch.\nGib ein JSON-Objekt zurueck:\n{"rezept":"Gesamtgerichtname auf Deutsch","zutaten":[{"name":"Zutat auf Deutsch","emoji":"Emoji","g":GRAMM}]}\n\nRegeln:\n- rezept: logischer Gesamtname des Gerichts\n- zutaten: erkenne was SICHTBAR auf dem Teller/Bild liegt - benne es so wie ein Mensch es bestellen oder kaufen wuerde\n- Nenne das fertige Lebensmittel, nicht seine Zutaten oder Bestandteile\n- 1 Einheit schatzen (Nutzer gibt Menge selbst an)\n- Logisch notwendige Beilagen erganzen (z.B. Butter bei belegtem Brot)\n- Getraenke: typische Bestandteile mit realistischen Mengen\n- Keine Rohzutaten nennen aus denen etwas hergestellt wurde\n- Realistische Gramm pro Einheit\n- Alle Namen auf Deutsch\n- Wenn nichts erkennbar: {"rezept":"","zutaten":[]}';
+var DEFAULT_FOTO_PROMPT='Analysiere dieses Bild auf Deutsch. Es kann ein Essensfoto ODER ein Screenshot einer Tracking-App (z.B. MyFitnessPal, Cronometer, Yazio, Samsung Health) sein.\n\nGib ein JSON-Objekt zurueck:\n{"rezept":"Gesamtgerichtname auf Deutsch","zutaten":[{"name":"Zutat auf Deutsch","emoji":"Emoji","g":GRAMM}]}\n\nFall 1 – Essensfoto:\n- zutaten: erkenne was SICHTBAR auf dem Teller/Bild liegt\n- Nenne das fertige Lebensmittel, nicht seine Rohzutaten\n- 1 Einheit schatzen (Nutzer gibt Menge selbst an)\n- Logisch notwendige Beilagen erganzen\n\nFall 2 – Screenshot einer Tracking-App oder Ernaehrungsuebersicht:\n- Lies ALLE eingetragenen Lebensmittel/Gerichte mit den angezeigten Gramm-/Portionsangaben aus\n- Falls kcal/Naehrwerte sichtbar: nutze diese fuer realistischere Schatzung\n- rezept: Name der Mahlzeit oder "Import aus App"\n\nFall 3 – Einkaufszettel / Zutatenliste:\n- Liste alle Zutaten mit typischen Mengen auf\n\nAllgemein:\n- Realistische Gramm pro Einheit\n- Alle Namen auf Deutsch\n- Wenn nichts erkennbar: {"rezept":"","zutaten":[]}';
 
 var DEFAULT_CHAT_PROMPT='Nutzer hat gegessen: {MSG}\nZerlege in einzelne Zutaten.\nRegeln:\n- Werden einzelne Lebensmittel genannt (z.B. "Brot mit Kaese, Senf, Schinken"): NUR die genannten Zutaten listen, nichts erganzen\n- Wird ein Gericht oder Rezept genannt (z.B. "Hamburger", "Aperol Spritz"): typische Bestandteile als fertige Produkte aufschluesseln\n- Immer fertige Produkte, keine Rohzutaten (Butterkeks nicht Butter)\n- Immer nur 1 Einheit schatzen - Nutzer gibt Menge selbst an\n- Realistische Gramm-Schatzung fuer 1 Einheit\n- Namen auf Deutsch\n- Format: [{"name":"Deutscher Name","emoji":"Emoji","g":80}]';
 
-var PROMPT_VERSION='3';
+var PROMPT_VERSION='4';
 function getFotoPrompt(){
   // Reset if prompt version changed
   if(localStorage.getItem('nt_prompt_ver')!==PROMPT_VERSION){
@@ -1477,8 +1543,8 @@ function recipeImportStart(){
                    .slice(0,3000);
       callClaude('claude-haiku-4-5',[{type:'text',text:
         'Extrahiere das Rezept aus diesem Text und gib NUR gültiges JSON zurück:\n'
-        +'{"name":"Rezeptname","zutaten":[{"name":"Zutat","menge":"100g"}]}\n'
-        +'Text: '+text}],500,
+        +'{"name":"Rezeptname","zutaten":[{"name":"Zutat","menge":"100g"}],"anleitung":"Zubereitungsschritte als einzelner Text (optional, leer lassen wenn nicht vorhanden)"}\n'
+        +'Text: '+text}],800,
         function(resp){
           try{
             var a=resp.indexOf('{'),z=resp.lastIndexOf('}');
@@ -1490,8 +1556,9 @@ function recipeImportStart(){
             });
             lookupNutrients(rawItems,function(ings){
               var rec={id:Date.now().toString(),name:d.name,emoji:'🔗',ingredients:ings,importedFrom:url};
+              if(d.anleitung&&d.anleitung.trim())rec.instructions=d.anleitung.trim();
               recipes.unshift(rec);saveX();
-              showToast('✓ "'+d.name+'" importiert ('+ings.length+' Zutaten)');
+              showToast('✓ "'+d.name+'" importiert ('+ings.length+' Zutaten'+(rec.instructions?' + Anleitung':'')+')');
             });
           }catch(e){showToast('Rezept konnte nicht erkannt werden');}
         },
@@ -2375,6 +2442,17 @@ function pickerBarcodeAdd(){
   var food=window._pickerBarcodeFood;if(!food)return;
   var amt=parseFloat(document.getElementById('pickerBcAmt').value)||100;
   var r=amt/100;
+  if(window._editEntryMode){
+    window._editEntryMode=false;
+    var e=getDay().meals[window._editEntryMeal][window._editEntryIdx];
+    if(e&&e.ingredients){
+      e.ingredients.push({name:food.name,emoji:food.emoji,amount:amt,per100:food.per100});
+      saveS();closePicker();
+      openEditEntry(window._editEntryMeal,window._editEntryIdx);
+      showToast((food.emoji||'🍽')+' '+food.name+' hinzugefügt');
+      return;
+    }
+  }
   getDay().meals[pickerMeal].push(Object.assign({name:food.name,emoji:food.emoji,amount:amt,per100:food.per100},scaleNutrients(food.per100,r)));
   var _bidx=getDay().meals[pickerMeal].length-1;
   saveS();renderAll();closePicker();
@@ -2548,7 +2626,7 @@ function pickerUpdateChatTotal(){
   document.getElementById('pickerChatTotal').textContent='1 Portion: '+totalStr(t)+(p!==1?'  ·  '+p+'× = '+totalStr(scaleNutrients(t,p)):'');
 }
 
-function pickerChatAdd(saveAsRecipe){_pickerAdd('💬','pickerChatRecipeName','pickerChatPortions','Chat-Eintrag',saveAsRecipe,false);}
+function pickerChatAdd(saveAsRecipe){_pickerAdd('💬','pickerChatRecipeName','pickerChatPortions','Chat-Eintrag',saveAsRecipe,true);}
 
 // ─── PICKER: LINK/URL TAB ───
 function pickerLinkDetect(){
@@ -2583,8 +2661,8 @@ function pickerLinkImport(){
                    .slice(0,3000);
       callClaude('claude-haiku-4-5',[{type:'text',text:
         'Extrahiere das Rezept aus diesem Text und gib NUR gültiges JSON zurück:\n'
-        +'{"name":"Rezeptname","zutaten":[{"name":"Zutat","menge":"100g"}]}\n'
-        +'Text: '+text}],500,
+        +'{"name":"Rezeptname","zutaten":[{"name":"Zutat","menge":"100g"}],"anleitung":"Zubereitungsschritte (optional)"}\n'
+        +'Text: '+text}],800,
         function(resp){
           try{
             var a=resp.indexOf('{'),z=resp.lastIndexOf('}');
@@ -2594,6 +2672,7 @@ function pickerLinkImport(){
               var g=parseFloat((z.menge||'').replace(/[^\d.]/g,''))||100;
               return{name:z.name,g:g,emoji:emo(z.name)};
             });
+            window._pickerLinkInstructions=d.anleitung||'';
             lookupNutrients(rawItems,function(ings){
               pickerIngredients=ings;
               document.getElementById('pickerLinkRecipeName').value=d.name;
@@ -2626,7 +2705,15 @@ function pickerUpdateLinkTotal(){
   var p=parseFloat(document.getElementById('pickerLinkPortions').value)||1;
   document.getElementById('pickerLinkTotal').textContent='1 Portion: '+totalStr(t)+(p!==1?'  ·  '+p+'× = '+totalStr(scaleNutrients(t,p)):'');
 }
-function pickerLinkAdd(saveAsRecipe){_pickerAdd('🔗','pickerLinkRecipeName','pickerLinkPortions','Rezept',saveAsRecipe,false);}
+function pickerLinkAdd(saveAsRecipe){
+  _pickerAdd('🔗','pickerLinkRecipeName','pickerLinkPortions','Rezept',saveAsRecipe,true);
+  // Kochanleitung auf das zuletzt gespeicherte Rezept übertragen
+  if(saveAsRecipe&&window._pickerLinkInstructions&&recipes.length){
+    recipes[0].instructions=window._pickerLinkInstructions;
+    saveX();
+  }
+  window._pickerLinkInstructions='';
+}
 
 // ─── PICKER: EIGENES TAB ───
 function pickerSaveOwn(){
@@ -2728,11 +2815,18 @@ function renderEditBody(e){
       +'<div class="ing-list" id="editIngList">'+ingHtml+'</div>'
       +'<button type="button" class="seb" style="margin-bottom:8px;" onclick="editAddIng()">+ Zutat hinzufügen</button>'
       +(e.recipeId?'':'<button type="button" class="seb" style="margin-bottom:8px;border-color:var(--g2);color:var(--g2);" onclick="editSaveAsRecipe()">📋 Als Rezept speichern</button>')
+      +(function(){var rec=e.recipeId&&recipes.find(function(r){return r.id===e.recipeId;});var ins=(rec&&rec.instructions)||e.instructions||'';return ins?'<div style="margin:10px 0;padding:12px;background:var(--gl);border-radius:12px;border:1px solid var(--g3);"><div style="font-size:12px;font-weight:700;color:var(--g1);margin-bottom:6px;">📝 Kochanleitung</div><div style="font-size:13px;white-space:pre-wrap;color:var(--tx);">'+ins+'</div></div>':'';}())
       +renderAmpelInfo(e)
       +renderNutrientDetail({kcal:t.kcal,protein:t.protein,carbs:t.carbs,fat:t.fat,sugar:t.sugar||0,fiber:t.fiber||0,salt:t.salt||0},p)
       +(e.mealPhoto?'<div style="margin:8px 0;"><img src="'+e.mealPhoto+'" style="width:100%;border-radius:10px;max-height:160px;object-fit:cover;"></div>':'')
       +'<button type="button" class="cb2" onclick="saveEditEntry()">Speichern ✓</button>'
       +'<button type="button" class="seb" style="margin-bottom:8px;border-color:var(--mu);color:var(--mu);" onclick="saveMealAsTemplate(\''+editMeal+'\')" >📋 Als Vorlage speichern</button>'
+      +'<button type="button" class="seb" style="margin-bottom:8px;" onclick="openMoveEntry()">↕ Mahlzeit wechseln</button>'
+      +'<div id="moveEntryPanel" style="display:none;background:var(--gl);border-radius:12px;padding:12px;margin-bottom:8px;">'
+      +'<div style="font-size:12px;font-weight:700;color:var(--mu);margin-bottom:8px;text-transform:uppercase;">Verschieben nach:</div>'
+      +'<div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;">'
+      +MEALS.filter(function(m){return m!==editMeal;}).map(function(m){return'<button type="button" class="svb" style="margin:0;padding:8px;" onclick="moveEntry(\''+m+'\')">'+MEAL_NAMES[m]+'</button>';}).join('')
+      +'</div></div>'
       +'<button type="button" class="del-btn" onclick="deleteEntry()">🗑️ Eintrag löschen</button>';
   } else {
     var _r2=(e.amount||100)/100;
@@ -2746,6 +2840,12 @@ function renderEditBody(e){
       +'<input type="file" id="editMealPhoto" accept="image/*" capture="environment" style="display:none" onchange="handleEditMealPhoto(event)">'
       +'<button type="button" class="seb" style="margin-bottom:8px;" onclick="document.getElementById(\'editMealPhoto\').click()">📷 '+(e.mealPhoto?'Foto ändern':'Foto hinzufügen')+'</button>'
       +'<button type="button" class="cb2" onclick="saveEditEntry()">Speichern ✓</button>'
+      +'<button type="button" class="seb" style="margin-bottom:8px;" onclick="openMoveEntry()">↕ Mahlzeit wechseln</button>'
+      +'<div id="moveEntryPanel" style="display:none;background:var(--gl);border-radius:12px;padding:12px;margin-bottom:8px;">'
+      +'<div style="font-size:12px;font-weight:700;color:var(--mu);margin-bottom:8px;text-transform:uppercase;">Verschieben nach:</div>'
+      +'<div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;">'
+      +MEALS.filter(function(m){return m!==editMeal;}).map(function(m){return'<button type="button" class="svb" style="margin:0;padding:8px;" onclick="moveEntry(\''+m+'\')">'+MEAL_NAMES[m]+'</button>';}).join('')
+      +'</div></div>'
       +'<button type="button" class="del-btn" onclick="deleteEntry()">🗑️ Eintrag löschen</button>';
   }
 }
@@ -2771,8 +2871,7 @@ function editIngDel(i){
 function editAddIng(){
   var meal=editMeal,idx=editIdx;
   closeOv('editOv');
-  // Open picker - when item selected, add to this entry's ingredients
-  openPicker(meal,'search');
+  openPicker(meal);
   window._editEntryMode=true;
   window._editEntryMeal=meal;
   window._editEntryIdx=idx;
@@ -2813,6 +2912,19 @@ function deleteEntry(){
   saveS();renderAll();closeOv('editOv');
 }
 
+function openMoveEntry(){
+  var p=document.getElementById('moveEntryPanel');
+  if(p)p.style.display=p.style.display==='none'?'block':'none';
+}
+
+function moveEntry(targetMeal){
+  var day=getDay();
+  var entry=day.meals[editMeal].splice(editIdx,1)[0];
+  day.meals[targetMeal].push(entry);
+  saveS();renderAll();closeOv('editOv');
+  showToast('↕ Nach '+MEAL_NAMES[targetMeal]+' verschoben');
+}
+
 // Override pickerConfirmAdd when in entry-edit mode
 var _origPickerConfirmAdd=null;
 // We handle this via the _editEntryMode flag in pickerConfirmAdd
@@ -2827,6 +2939,8 @@ function openRecipeEditor(recipeId){
   document.getElementById('recEditTitle').textContent=(rec.emoji||'📋')+' '+rec.name;
   document.getElementById('recEditName').value=rec.name;
   document.getElementById('recEditEmoji').value=rec.emoji||'';
+  var insEl=document.getElementById('recEditInstructions');
+  if(insEl)insEl.value=rec.instructions||'';
   recEditRenderIng(rec.ingredients||[]);
   recEditSearch();
   closeOv('settOv');
@@ -2896,6 +3010,8 @@ function recEditSave(){
   var newEmoji=document.getElementById('recEditEmoji').value.trim();
   if(newName)rec.name=newName;
   if(newEmoji)rec.emoji=newEmoji;
+  var insEl=document.getElementById('recEditInstructions');
+  if(insEl)rec.instructions=insEl.value.trim();
   saveX();
   closeOv('recEditOv');
   setTimeout(function(){openSettings();},200);
@@ -2907,9 +3023,65 @@ function recEditDelete(){
   saveX();renderSettFoodList();closeOv('recEditOv');showToast('Rezept gelöscht');
 }
 
+// ─── REZEPT-CODE EXPORT / IMPORT ───
+function _encodeRecipeCode(rec){
+  var d={n:rec.name,e:rec.emoji||'📋',i:(rec.ingredients||[]).map(function(ing){return{n:ing.name,e:ing.emoji,a:ing.amount,p:{k:Math.round(ing.per100.kcal),pr:Math.round(ing.per100.protein*10)/10,c:Math.round(ing.per100.carbs*10)/10,f:Math.round(ing.per100.fat*10)/10}};})};
+  if(rec.instructions)d.ins=rec.instructions;
+  try{return btoa(unescape(encodeURIComponent(JSON.stringify(d))));}catch(ex){return null;}
+}
+
+function _decodeRecipeCode(code){
+  try{
+    var d=JSON.parse(decodeURIComponent(escape(atob(code.trim().replace(/\s+/g,'')))));
+    var ings=(d.i||[]).map(function(x){return{name:x.n,emoji:x.e,amount:x.a||100,per100:{kcal:x.p.k,protein:x.p.pr,carbs:x.p.c,fat:x.p.f,sugar:0,fiber:0,salt:0}};});
+    return{id:Date.now().toString(),name:d.n||'Importiertes Rezept',emoji:d.e||'📋',ingredients:ings,instructions:d.ins||''};
+  }catch(ex){return null;}
+}
+
+function openRecipeCodeShare(id){
+  var wrap=document.getElementById('recipeCodeExportWrap');
+  var textEl=document.getElementById('recipeCodeText');
+  var importEl=document.getElementById('recipeImportCodeInput');
+  importEl.value='';
+  if(id){
+    var rec=recipes.find(function(r){return r.id===id;});
+    if(rec){var code=_encodeRecipeCode(rec);if(code){textEl.value=code;wrap.style.display='block';}}
+    else{wrap.style.display='none';}
+  } else {
+    wrap.style.display='none';
+  }
+  openOv('recipeCodeOv');
+}
+
+function copyRecipeCode(){
+  var t=document.getElementById('recipeCodeText');
+  if(!t)return;
+  if(navigator.clipboard){navigator.clipboard.writeText(t.value).then(function(){showToast('Code kopiert ✓');});}
+  else{t.select();document.execCommand('copy');showToast('Code kopiert ✓');}
+}
+
+function importRecipeCode(){
+  var code=document.getElementById('recipeImportCodeInput').value.trim();
+  if(!code){showToast('Code eingeben');return;}
+  var rec=_decodeRecipeCode(code);
+  if(!rec){showToast('Ungültiger Code');return;}
+  recipes.unshift(rec);saveX();
+  closeOv('recipeCodeOv');
+  showToast('✅ "'+rec.name+'" importiert');
+}
+
 // ════════════════════════════════════════
 // SECTION: SETTINGS
 // ════════════════════════════════════════
+function settSetTab(tab){
+  ['profil','ziele','ernaehrung','erinnerungen','daten'].forEach(function(t){
+    var btn=document.getElementById('stab-'+t);
+    var panel=document.getElementById('spanel-'+t);
+    if(btn)btn.classList.toggle('act',t===tab);
+    if(panel)panel.style.display=t===tab?'block':'none';
+  });
+}
+
 function openSettings(){
   document.getElementById('sk').value=S.apiKey;
   document.getElementById('sn').value=S.name;
@@ -2935,17 +3107,12 @@ function openSettings(){
   updatePregnantUI();
   updateWeightLossInfo();
   renderReminders();
-  // Wasserziel + Dark Mode
   var wg=document.getElementById('swatergoal');if(wg)wg.value=S.waterGoal||8;
-  // Wasserziel laden
-  var wg=document.getElementById('swatergoal');if(wg)wg.value=S.waterGoal||8;
-  // Makro-Modus
   setMacroMode(S.macroGoalMode||'percent');
   var mg=S.macroGoalG||{};
   var mp=document.getElementById('smacrop');if(mp)mp.value=mg.protein||'';
   var mc=document.getElementById('smacroc');if(mc)mc.value=mg.carbs||'';
   var mf=document.getElementById('smacrof');if(mf)mf.value=mg.fat||'';
-  // Ernährungspräferenzen laden
   S.dietPrefs=S.dietPrefs||[];
   var dfi=document.getElementById('sdietfree');
   if(dfi)dfi.value=S.dietFree||'';
@@ -2957,6 +3124,7 @@ function openSettings(){
   renderSavedDietFreeList();
   document.getElementById('cacheInfo').textContent=customFoods.length+' eigene Lebensmittel · '+recipes.length+' Rezepte · '+Object.keys(foodCache).length+' gespeichert';
   renderSettFoodList();
+  settSetTab('profil');
   openOv('settOv');
 }
 
@@ -4398,6 +4566,7 @@ function renderLibrary(){
           +'</div>'
           +'<button type="button" onclick="openRecipeEditor(this.dataset.rid)" data-rid="'+r.id+'" style="background:none;border:none;font-size:18px;color:var(--g2);padding:4px;">✏️</button>'
           +'<button type="button" onclick="duplicateRecipe(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Duplizieren">⎘</button>'
+          +'<button type="button" onclick="openRecipeCodeShare(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Teilen">📤</button>'
           +'<button type="button" onclick="openShoppingList(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Einkaufsliste">🛒</button>'
           +'<button type="button" onclick="libAddRecipe(this.dataset.rid)" data-rid="'+r.id+'" style="background:var(--g2);border:none;border-radius:8px;color:white;font-size:18px;padding:4px 8px;">+</button>'
           +'</div>';

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.109';
+var VERSION = '0.110';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['anthropic.com','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 


### PR DESCRIPTION
## Summary

- **↕ Einträge verschieben**: Im Bearbeiten-Dialog kann jeder Eintrag per Knopf zwischen Frühstück, Mittagessen, Abendessen und Snacks verschoben werden
- **📤 Rezept-Code teilen**: Rezepte als kompakten alphanumerischen Code exportieren und teilen – per Knopf in der Bibliothek (📤) oder im Rezept-Editor. Code enthält auch die Kochanleitung. Einlösen über dasselbe Overlay oder die Bibliothek
- **📝 Kochanleitung**: Jedes Rezept kann eine Freitext-Kochanleitung bekommen. Beim URL-Import (🔗 Link) wird die Anleitung automatisch von der Seite extrahiert. Im Tagebuch-Edit wird sie unter den Zutaten angezeigt
- **➕ Alle Erfassungsmethoden zum Erweitern**: Beim „+ Zutat hinzufügen" öffnet sich der volle Picker (Chat, Foto, Barcode, Suche, Link) – nicht mehr nur die Suche
- **📷 Screenshot-Import verbessert**: Der Foto-Prompt erkennt jetzt auch Screenshots aus Tracking-Apps (MyFitnessPal, Yazio, Cronometer etc.), Einkaufszettel und Nährwert-Übersichten
- **⚙️ Einstellungen in Tabs**: 5 übersichtliche Tabs – Profil, Ziele, Ernährung, Erinnerungen, Daten (API Key, Export/Import, Rezepte)

## Test plan

- [x] Eintrag antippen → „↕ Mahlzeit wechseln" → in andere Mahlzeit verschieben
- [x] Bibliothek → Rezept → 📤 → Code kopieren → Code einlösen → Rezept erscheint
- [ ] Einstellungen → Rezept bearbeiten → Kochanleitung eingeben → speichern → Tagebuch-Eintrag zeigt Anleitung
- [x] URL-Import (Bibliothek oder + → Link) → Kochanleitung wird automatisch befüllt
- [x] Eintrag antippen → „+ Zutat hinzufügen" → alle Tabs im Picker verfügbar
- [ ] Foto-Tab → Screenshot einer anderen App hochladen → Lebensmittel werden erkannt
- [x] Einstellungen öffnen → 5 Tabs navigieren, alle Felder vorhanden und funktionsfähig

https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_