### PR TITLE
feat: v0.111 – iOS Live-Barcode-Scanner (BarcodeDetector, ab iOS 18.6.2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.110</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.111</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div class="dn">
       <button type="button" class="da" onclick="changeDay(-1)">‹</button>
       <div class="dl" id="dateLabel"></div>
@@ -458,7 +458,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.110</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.111</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1230,8 +1230,11 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.110';
+var APP_VERSION='0.111';
 var CHANGELOG=[
+  {v:'0.111',items:[
+    {icon:'📱',text:'Live-Barcode-Scanner auf iPhone/iPad (iOS 18.6.2+)',where:'+ → Barcode → Scanner starten'},
+  ]},
   {v:'0.110',items:[
     {icon:'↕',text:'Mahlzeiten verschieben: Einträge per Knopf zwischen Mahlzeiten wechseln',where:'Eintrag antippen → „↕ Mahlzeit wechseln"'},
     {icon:'📤',text:'Rezept als Code teilen und einlösen (inkl. Kochanleitung)',where:'Bibliothek → Rezept → 📤 oder Rezept bearbeiten → „Rezept teilen"'},
@@ -2203,12 +2206,65 @@ function pickerToggleTorch(){
   }
 }
 
+// iOS Live-Scanner (iOS 17+ / ab iOS 18.6.2 Mindestversion)
+// Nutzt BarcodeDetector API + getUserMedia, angepasst an iOS-Restriktionen.
+// Bestehender Android-Scanner bleibt unverändert.
+function pickerStartScanIOS(){
+  var wrap=document.getElementById('pickerBarcodeWrap');
+  wrap.classList.remove('hidden');
+  document.getElementById('pickerBcStartBtn').style.display='none';
+  document.getElementById('pickerBcStopBtn').style.display='block';
+  document.getElementById('pickerBcPhotoBtn').style.display='block'; // Foto als Fallback weiterhin anbieten
+  document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--g1);padding:8px;text-align:center;"><span class="spin" style="display:inline-block;width:14px;height:14px;border:2px solid var(--g2);border-top-color:transparent;border-radius:50%;vertical-align:middle;margin-right:6px;"></span>Kamera startet…</div>';
+  pickerBcActive=true;
+  var videoEl=document.getElementById('pickerBarcodeVideo');
+  // iOS: {exact} bevorzugt, Fallback ohne exact falls Gerät es ablehnt
+  var tryStream=navigator.mediaDevices.getUserMedia({video:{facingMode:{exact:'environment'}}})
+    .catch(function(){return navigator.mediaDevices.getUserMedia({video:{facingMode:'environment'}});});
+  tryStream.then(function(stream){
+    if(!pickerBcActive){stream.getTracks().forEach(function(t){t.stop();});return;}
+    videoEl.srcObject=stream;
+    videoEl.setAttribute('playsinline',''); // Pflicht auf iOS – verhindert Vollbild
+    videoEl.muted=true;
+    videoEl.play().catch(function(){});
+    document.getElementById('pickerBarcodeResult').innerHTML='';
+    var detector=new BarcodeDetector({formats:['ean_13','ean_8','upc_a','upc_e','code_128','code_39']});
+    pickerBcReader={_stream:stream};
+    pickerBcReader._scanLoop=setInterval(function(){
+      if(!pickerBcActive)return;
+      if(videoEl.readyState<2)return;
+      detector.detect(videoEl).then(function(barcodes){
+        if(!pickerBcActive)return;
+        if(barcodes&&barcodes.length>0){
+          clearInterval(pickerBcReader._scanLoop);
+          pickerStopScan();
+          pickerLookupBarcode(barcodes[0].rawValue);
+        }
+      }).catch(function(){});
+    },250);
+  }).catch(function(err){
+    var msg=err.name==='NotAllowedError'
+      ?'Kamerazugriff verweigert – bitte in iPhone-Einstellungen → Safari → Kamera erlauben.'
+      :'Kamera nicht verfügbar: '+err.message;
+    document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--re);padding:10px;text-align:center;">❌ '+msg+'</div>';
+    document.getElementById('pickerBcPhotoBtn').style.display='block';
+    document.getElementById('pickerBcStopBtn').style.display='none';
+    document.getElementById('pickerBcStartBtn').style.display='block';
+    pickerBcActive=false;
+  });
+}
+
 function pickerStartScan(){
   var isIOS=/iPad|iPhone|iPod/.test(navigator.userAgent)&&!window.MSStream;
   if(isIOS){
-    document.getElementById('pickerBcStartBtn').style.display='none';
-    document.getElementById('pickerBcPhotoBtn').style.display='block';
-    document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--mu);padding:8px;text-align:center;">📷 Foto vom Barcode aufnehmen</div>';
+    if('BarcodeDetector' in window){
+      pickerStartScanIOS();
+    } else {
+      // Bestehender Foto-Fallback für iOS < 17
+      document.getElementById('pickerBcStartBtn').style.display='none';
+      document.getElementById('pickerBcPhotoBtn').style.display='block';
+      document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--mu);padding:8px;text-align:center;">📷 Foto vom Barcode aufnehmen</div>';
+    }
     return;
   }
   var wrap=document.getElementById('pickerBarcodeWrap');

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.110';
+var VERSION = '0.111';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['anthropic.com','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 


### PR DESCRIPTION
## Summary

Neue Funktion `pickerStartScanIOS()` für den Live-Barcode-Scanner auf iPhone/iPad.

**Wie es funktioniert:**
- iOS 17+ hat die native `BarcodeDetector` API im Safari (ab iOS 18.6.2 garantiert)
- `pickerStartScan()` prüft jetzt: iOS + `BarcodeDetector` vorhanden → `pickerStartScanIOS()`
- iOS ohne `BarcodeDetector` (< iOS 17) → unveränderter Foto-Fallback
- Android-Pfad komplett unverändert

**iOS-spezifische Anpassungen in der neuen Funktion:**
- `playsinline` Attribut (Pflicht auf iOS, verhindert Vollbild-Übernahme)
- `{exact: 'environment'}` mit Fallback auf `{environment}` (manche Geräte lehnen exact ab)
- Kein Zoom/Torch (iOS Safari unterstützt das nicht via `applyConstraints`)
- Foto-Button bleibt parallel sichtbar als manueller Fallback
- Klarer Fehlerhinweis bei verweigerten Kamerarechten (Einstellungen → Safari)

## Test plan

- [ ] iPhone mit iOS 18.6.2+ → + → Barcode → Scanner starten → Live-Kamera öffnet sich
- [ ] Barcode halten → wird erkannt und Produkt gesucht
- [ ] Kamerazugriff verweigern → Fehlermeldung mit Hinweis auf Einstellungen erscheint
- [ ] Android unverändert: Live-Scanner läuft wie bisher
- [ ] Älteres iOS (< 17, falls testbar) → Foto-Modus erscheint wie bisher

https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_