### PR TITLE
fix: OneDrive Auto-Sync bei App-Start (v0.118)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1613,6 +1613,14 @@ function renderAutoSaves(){
       +'</div>';
   }).join('')+'<div style="font-size:11px;color:var(--mu);text-align:center;margin-top:8px;">'+saves.length+' / '+AUTOSAVE_MAX+' Autospeicher</div>';
 }
+function _odAutoSync(){
+  if(!_odLoadTokens())return;
+  if(!isOnline)return;
+  if(localStorage.getItem('nt_od_sync_date')===today())return;
+  oneDriveSyncUp().then(function(){
+    localStorage.setItem('nt_od_sync_date',today());
+  }).catch(function(){});
+}
 function _checkOdBanner(){
   if(_odLoadTokens())return;
   var last=localStorage.getItem('nt_od_banner_date');
@@ -1648,7 +1656,8 @@ function showMain(){
   setTimeout(compressOldDays,5000);
   checkProxyPwGate();
   setTimeout(_autosaveCreate,1000);
-  setTimeout(_checkOdBanner,1500);
+  setTimeout(_odAutoSync,3000);
+  setTimeout(_checkOdBanner,3500);
 }
 function checkBackupReminder(){
   try{
@@ -4737,6 +4746,7 @@ function oneDriveSyncUp(){
     }).then(function(r){
       if(!r.ok)throw new Error(r.status);
       localStorage.setItem('nt_last_sync',new Date().toISOString());
+      localStorage.setItem('nt_od_sync_date',today());
       showToast('☁️ OneDrive gespeichert ✓ ('+kb+' KB)');
       renderOneDriveStatus();
     });


### PR DESCRIPTION
## Fix
`_odAutoSync()` fehlte — OneDrive-Upload beim App-Start war nie implementiert.

- `_odAutoSync()` in `showMain()` nach 3s Delay
- Prüft: OneDrive verbunden + online + heute noch nicht gesynct (`nt_od_sync_date`)
- `oneDriveSyncUp()` setzt `nt_od_sync_date` bei Erfolg → keine Doppel-Uploads

https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_