### PR TITLE
fix: iOS Barcode-Scan – Canvas im DOM für Pixel-Readback (v0.123)

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.122</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.123</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -485,7 +485,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.122</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.123</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1317,7 +1317,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.122';
+var APP_VERSION='0.123';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1346,6 +1346,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.123',items:[
+    {icon:'📷',text:'iOS Barcode-Scanner: Canvas ans DOM gehängt – behebt leere Frames bei ZXing auf iPhone',where:'Barcode-Tab'},
+  ]},
   {v:'0.122',items:[
     {icon:'📷',text:'iOS Barcode-Scanner: createImageBitmap behebt schwarze Frames – Live-Scan funktioniert jetzt auf iPhone',where:'Barcode-Tab'},
     {icon:'➕',text:'Barcode nicht gefunden → Produkt manuell eintragen (wird dauerhaft gespeichert)',where:'Barcode-Tab'},

--- a/picker.js
+++ b/picker.js
@@ -290,27 +290,23 @@ function pickerToggleTorch(){
 
 function _pickerZxingScanLoop(videoEl,canvas,ctx,reader){
   if(!pickerBcActive)return;
-  requestAnimationFrame(function(){
-    if(!pickerBcActive)return;
-    if(videoEl.readyState<2||!videoEl.videoWidth){
-      setTimeout(function(){_pickerZxingScanLoop(videoEl,canvas,ctx,reader);},100);return;
-    }
+  if(videoEl.readyState<2||!videoEl.videoWidth){
+    setTimeout(function(){_pickerZxingScanLoop(videoEl,canvas,ctx,reader);},100);return;
+  }
+  if(canvas.width!==videoEl.videoWidth||canvas.height!==videoEl.videoHeight){
     canvas.width=videoEl.videoWidth;canvas.height=videoEl.videoHeight;
-    function onFrame(){
-      try{
-        var r=reader.decodeFromCanvas(canvas);
-        if(r&&r.getText()){pickerStopScan();pickerLookupBarcode(r.getText());return;}
-      }catch(e){}
-      setTimeout(function(){_pickerZxingScanLoop(videoEl,canvas,ctx,reader);},150);
+  }
+  // iOS Safari: ctx.drawImage(video) only works when the canvas is in the DOM
+  if(!canvas.parentNode)document.body.appendChild(canvas);
+  ctx.drawImage(videoEl,0,0,canvas.width,canvas.height);
+  try{
+    var r=reader.decodeFromCanvas(canvas);
+    if(r&&r.getText()){
+      if(canvas.parentNode)canvas.parentNode.removeChild(canvas);
+      pickerStopScan();pickerLookupBarcode(r.getText());return;
     }
-    if(typeof createImageBitmap!=='undefined'){
-      createImageBitmap(videoEl).then(function(bm){
-        ctx.drawImage(bm,0,0,canvas.width,canvas.height);bm.close();onFrame();
-      }).catch(function(){ctx.drawImage(videoEl,0,0,canvas.width,canvas.height);onFrame();});
-    } else {
-      ctx.drawImage(videoEl,0,0,canvas.width,canvas.height);onFrame();
-    }
-  });
+  }catch(e){}
+  setTimeout(function(){_pickerZxingScanLoop(videoEl,canvas,ctx,reader);},150);
 }
 
 function pickerStartScan(){
@@ -361,9 +357,11 @@ function pickerStartScan(){
         hints.set(ZXing.DecodeHintType.POSSIBLE_FORMATS,[ZXing.BarcodeFormat.EAN_13,ZXing.BarcodeFormat.EAN_8,ZXing.BarcodeFormat.UPC_A,ZXing.BarcodeFormat.UPC_E,ZXing.BarcodeFormat.CODE_128,ZXing.BarcodeFormat.CODE_39]);
         hints.set(ZXing.DecodeHintType.TRY_HARDER,true);
         var reader=new ZXing.BrowserMultiFormatReader(hints,300);
-        pickerBcReader._zxing=reader;
         var canvas=document.createElement('canvas');
+        canvas.style.cssText='position:fixed;left:-9999px;top:0;pointer-events:none;';
         var ctx=canvas.getContext('2d',{willReadFrequently:true});
+        pickerBcReader._zxing=reader;
+        pickerBcReader._zxingCanvas=canvas;
         _pickerZxingScanLoop(videoEl,canvas,ctx,reader);
       } else {
         document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--re);padding:8px;">❌ ZXing nicht geladen. Seite neu laden.</div>';
@@ -389,7 +387,7 @@ function pickerStopScan(){
   pickerBcActive=false;
   if(pickerBcReader){
     try{if(pickerBcReader._scanLoop)clearInterval(pickerBcReader._scanLoop);}catch(e){}
-    try{if(pickerBcReader._zxing)pickerBcReader._zxing.reset();}catch(e){}
+    try{if(pickerBcReader._zxing){pickerBcReader._zxing.reset();if(pickerBcReader._zxingCanvas&&pickerBcReader._zxingCanvas.parentNode)pickerBcReader._zxingCanvas.parentNode.removeChild(pickerBcReader._zxingCanvas);}}catch(e){}
     try{if(pickerBcReader._stream)pickerBcReader._stream.getTracks().forEach(function(t){t.stop();});}catch(e){}
     pickerBcReader=null;
   }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.122';
+var VERSION = '0.123';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 


### PR DESCRIPTION
## Ursache

iOS Safari verweigert den Pixel-Readback (`ctx.getImageData`) für Canvas-Elemente, die **nicht im DOM** sind, wenn die Quelle ein Camera-Stream ist. `ctx.drawImage(videoEl)` schreibt zwar keine Exception, liefert aber nur schwarze Pixel zurück – ZXing findet dann natürlich keine Barcodes.

`createImageBitmap(videoEl)` hat denselben Effekt (GPU-Compositing-Layer, kein CPU-Readback).

## Fix

```js
// Canvas vor erstem drawImage ans DOM hängen (unsichtbar, offscreen)
if (!canvas.parentNode) document.body.appendChild(canvas);
ctx.drawImage(videoEl, 0, 0, canvas.width, canvas.height);
```

Canvas-Stil: `position:fixed; left:-9999px; top:0; pointer-events:none;`  
Wird nach erfolgreichem Scan und bei `pickerStopScan()` wieder entfernt.

## Test plan

- [ ] iPhone Safari: Barcode-Tab öffnen → Kamerabild sichtbar
- [ ] EAN-13 Barcode vor die Kamera halten → wird erkannt und aufgelöst
- [ ] Tab wechseln / Picker schließen → kein orphaner Canvas in `document.body`
- [ ] Android Chrome: BarcodeDetector-Pfad unverändert funktionsfähig

https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_