### PR TITLE
fix: iOS Barcode-Scanner – requestVideoFrameCallback + getSupportedFormats (v0.124)

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.124</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.125</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -485,7 +485,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.124</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.125</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1317,7 +1317,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.124';
+var APP_VERSION='0.125';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1346,6 +1346,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.125',items:[
+    {icon:'🔍',text:'Debug-Vorschau: kleines Bild zeigt was der Decoder sieht + Frame-Zähler + aktiver Pfad',where:'Barcode-Tab'},
+  ]},
   {v:'0.124',items:[
     {icon:'📷',text:'iOS Barcode-Scanner: requestVideoFrameCallback + BarcodeDetector.getSupportedFormats() – zuverlässige Erkennung auf iPhone',where:'Barcode-Tab'},
   ]},

--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.123</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.124</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -485,7 +485,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.123</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.124</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1317,7 +1317,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.123';
+var APP_VERSION='0.124';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1346,6 +1346,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.124',items:[
+    {icon:'📷',text:'iOS Barcode-Scanner: requestVideoFrameCallback + BarcodeDetector.getSupportedFormats() – zuverlässige Erkennung auf iPhone',where:'Barcode-Tab'},
+  ]},
   {v:'0.123',items:[
     {icon:'📷',text:'iOS Barcode-Scanner: Canvas ans DOM gehängt – behebt leere Frames bei ZXing auf iPhone',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -293,13 +293,28 @@ function pickerToggleTorch(){
 // pixel-accessible frames from a camera stream on iOS Safari (GPU compositing
 // makes ctx.drawImage(video) return black pixels outside of rVFC callbacks).
 // Canvas must be in the DOM (position:fixed offscreen) for iOS pixel readback.
-function _pickerFrameLoop(videoEl,canvas,ctx,detect){
+function _pickerFrameLoop(videoEl,canvas,ctx,detect,label){
+  var frameCount=0;
+  var dbgCv=document.createElement('canvas');
+  dbgCv.width=120;dbgCv.height=80;
+  dbgCv.style.cssText='width:120px;height:80px;border:1px solid var(--br);border-radius:6px;display:block;margin:6px auto 0;';
+  var dbgCtx=dbgCv.getContext('2d');
+  var dbgEl=document.getElementById('pickerBarcodeResult');
+  if(dbgEl){
+    dbgEl.innerHTML='<div id="bcDbgWrap" style="font-size:11px;color:var(--mu);text-align:center;padding:4px 0;">'+
+      '<span id="bcDbgLabel">'+label+'</span> · Frame <span id="bcDbgN">0</span></div>';
+    document.getElementById('bcDbgWrap').appendChild(dbgCv);
+  }
   function process(){
     if(!pickerBcActive)return;
     if(!videoEl.videoWidth){schedule();return;}
     if(canvas.width!==videoEl.videoWidth)canvas.width=videoEl.videoWidth;
     if(canvas.height!==videoEl.videoHeight)canvas.height=videoEl.videoHeight;
     ctx.drawImage(videoEl,0,0,canvas.width,canvas.height);
+    // Debug preview: scaled-down copy of what the decoder sees
+    frameCount++;
+    var fn=document.getElementById('bcDbgN');if(fn)fn.textContent=frameCount;
+    dbgCtx.drawImage(canvas,0,0,120,80);
     detect(canvas,schedule);
   }
   function schedule(){
@@ -366,12 +381,10 @@ function pickerStartScan(){
         _pickerFrameLoop(videoEl,canvas,ctx,function(c,next){
           try{var r=reader.decodeFromCanvas(c);if(r&&r.getText()){pickerStopScan();pickerLookupBarcode(r.getText());return;}}catch(e){}
           next();
-        });
+        },'ZXing');
       }
 
       if('BarcodeDetector' in window){
-        // getSupportedFormats guards against unsupported formats (e.g. upc_a
-        // is not supported on Safari and would throw in the constructor)
         var want=['ean_13','ean_8','upc_a','upc_e','code_128','code_39'];
         BarcodeDetector.getSupportedFormats().then(function(supported){
           var formats=want.filter(function(f){return supported.indexOf(f)>=0;});
@@ -383,9 +396,8 @@ function pickerStartScan(){
               if(barcodes&&barcodes.length>0){pickerStopScan();pickerLookupBarcode(barcodes[0].rawValue);}
               else{next();}
             }).catch(next);
-          });
+          },'BarcodeDetector ('+formats.length+' Formate)');
         }).catch(function(){
-          // getSupportedFormats not available – try without upc_a to be safe
           try{
             var detector=new BarcodeDetector({formats:['ean_13','ean_8','upc_e','code_128','code_39']});
             _pickerFrameLoop(videoEl,canvas,ctx,function(c,next){
@@ -394,7 +406,7 @@ function pickerStartScan(){
                 if(barcodes&&barcodes.length>0){pickerStopScan();pickerLookupBarcode(barcodes[0].rawValue);}
                 else{next();}
               }).catch(next);
-            });
+            },'BarcodeDetector (Fallback)');
           }catch(e){startZXing();}
         });
       }else{

--- a/picker.js
+++ b/picker.js
@@ -288,25 +288,29 @@ function pickerToggleTorch(){
 }
 
 
-function _pickerZxingScanLoop(videoEl,canvas,ctx,reader){
-  if(!pickerBcActive)return;
-  if(videoEl.readyState<2||!videoEl.videoWidth){
-    setTimeout(function(){_pickerZxingScanLoop(videoEl,canvas,ctx,reader);},100);return;
+// Unified scan loop for BarcodeDetector and ZXing.
+// Uses requestVideoFrameCallback on iOS 15.4+ – the only reliable way to get
+// pixel-accessible frames from a camera stream on iOS Safari (GPU compositing
+// makes ctx.drawImage(video) return black pixels outside of rVFC callbacks).
+// Canvas must be in the DOM (position:fixed offscreen) for iOS pixel readback.
+function _pickerFrameLoop(videoEl,canvas,ctx,detect){
+  function process(){
+    if(!pickerBcActive)return;
+    if(!videoEl.videoWidth){schedule();return;}
+    if(canvas.width!==videoEl.videoWidth)canvas.width=videoEl.videoWidth;
+    if(canvas.height!==videoEl.videoHeight)canvas.height=videoEl.videoHeight;
+    ctx.drawImage(videoEl,0,0,canvas.width,canvas.height);
+    detect(canvas,schedule);
   }
-  if(canvas.width!==videoEl.videoWidth||canvas.height!==videoEl.videoHeight){
-    canvas.width=videoEl.videoWidth;canvas.height=videoEl.videoHeight;
-  }
-  // iOS Safari: ctx.drawImage(video) only works when the canvas is in the DOM
-  if(!canvas.parentNode)document.body.appendChild(canvas);
-  ctx.drawImage(videoEl,0,0,canvas.width,canvas.height);
-  try{
-    var r=reader.decodeFromCanvas(canvas);
-    if(r&&r.getText()){
-      if(canvas.parentNode)canvas.parentNode.removeChild(canvas);
-      pickerStopScan();pickerLookupBarcode(r.getText());return;
+  function schedule(){
+    if(!pickerBcActive)return;
+    if(typeof videoEl.requestVideoFrameCallback==='function'){
+      videoEl.requestVideoFrameCallback(process);
+    }else{
+      setTimeout(process,200);
     }
-  }catch(e){}
-  setTimeout(function(){_pickerZxingScanLoop(videoEl,canvas,ctx,reader);},150);
+  }
+  schedule();
 }
 
 function pickerStartScan(){
@@ -338,34 +342,63 @@ function pickerStartScan(){
       }catch(e){}
     }
     pickerBcReader={_stream:stream};
-    // Wait for video to be ready before scanning
     function startScanWhenReady(){
       if(!pickerBcActive)return;
       document.getElementById('pickerBarcodeResult').innerHTML='';
-      if('BarcodeDetector' in window){
-        var detector=new BarcodeDetector({formats:['ean_13','ean_8','upc_a','upc_e','code_128','code_39']});
-        pickerBcReader._scanLoop=setInterval(function(){
-          if(!pickerBcActive)return;
-          if(videoEl.readyState<2)return;
-          detector.detect(videoEl).then(function(barcodes){
-            if(!pickerBcActive)return;
-            if(barcodes&&barcodes.length>0){clearInterval(pickerBcReader._scanLoop);pickerStopScan();pickerLookupBarcode(barcodes[0].rawValue);}
-          }).catch(function(){});
-        },200);
-      } else if(typeof ZXing!=='undefined'){
+      // Shared canvas: in DOM (offscreen) for iOS pixel readback
+      var canvas=document.createElement('canvas');
+      canvas.style.cssText='position:fixed;left:-9999px;top:-9999px;width:1px;height:1px;pointer-events:none;opacity:0;';
+      document.body.appendChild(canvas);
+      var ctx=canvas.getContext('2d',{willReadFrequently:true});
+      pickerBcReader._canvas=canvas;
+
+      function startZXing(){
+        if(typeof ZXing==='undefined'){
+          document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--re);padding:8px;">❌ ZXing nicht geladen. Seite neu laden.</div>';
+          document.getElementById('pickerBcPhotoBtn').style.display='block';
+          return;
+        }
         var hints=new Map();
         hints.set(ZXing.DecodeHintType.POSSIBLE_FORMATS,[ZXing.BarcodeFormat.EAN_13,ZXing.BarcodeFormat.EAN_8,ZXing.BarcodeFormat.UPC_A,ZXing.BarcodeFormat.UPC_E,ZXing.BarcodeFormat.CODE_128,ZXing.BarcodeFormat.CODE_39]);
         hints.set(ZXing.DecodeHintType.TRY_HARDER,true);
         var reader=new ZXing.BrowserMultiFormatReader(hints,300);
-        var canvas=document.createElement('canvas');
-        canvas.style.cssText='position:fixed;left:-9999px;top:0;pointer-events:none;';
-        var ctx=canvas.getContext('2d',{willReadFrequently:true});
         pickerBcReader._zxing=reader;
-        pickerBcReader._zxingCanvas=canvas;
-        _pickerZxingScanLoop(videoEl,canvas,ctx,reader);
-      } else {
-        document.getElementById('pickerBarcodeResult').innerHTML='<div style="font-size:13px;color:var(--re);padding:8px;">❌ ZXing nicht geladen. Seite neu laden.</div>';
-        document.getElementById('pickerBcPhotoBtn').style.display='block';
+        _pickerFrameLoop(videoEl,canvas,ctx,function(c,next){
+          try{var r=reader.decodeFromCanvas(c);if(r&&r.getText()){pickerStopScan();pickerLookupBarcode(r.getText());return;}}catch(e){}
+          next();
+        });
+      }
+
+      if('BarcodeDetector' in window){
+        // getSupportedFormats guards against unsupported formats (e.g. upc_a
+        // is not supported on Safari and would throw in the constructor)
+        var want=['ean_13','ean_8','upc_a','upc_e','code_128','code_39'];
+        BarcodeDetector.getSupportedFormats().then(function(supported){
+          var formats=want.filter(function(f){return supported.indexOf(f)>=0;});
+          if(!formats.length)formats=['ean_13','ean_8'];
+          var detector=new BarcodeDetector({formats:formats});
+          _pickerFrameLoop(videoEl,canvas,ctx,function(c,next){
+            detector.detect(c).then(function(barcodes){
+              if(!pickerBcActive)return;
+              if(barcodes&&barcodes.length>0){pickerStopScan();pickerLookupBarcode(barcodes[0].rawValue);}
+              else{next();}
+            }).catch(next);
+          });
+        }).catch(function(){
+          // getSupportedFormats not available – try without upc_a to be safe
+          try{
+            var detector=new BarcodeDetector({formats:['ean_13','ean_8','upc_e','code_128','code_39']});
+            _pickerFrameLoop(videoEl,canvas,ctx,function(c,next){
+              detector.detect(c).then(function(barcodes){
+                if(!pickerBcActive)return;
+                if(barcodes&&barcodes.length>0){pickerStopScan();pickerLookupBarcode(barcodes[0].rawValue);}
+                else{next();}
+              }).catch(next);
+            });
+          }catch(e){startZXing();}
+        });
+      }else{
+        startZXing();
       }
     }
     if(videoEl.readyState>=2){startScanWhenReady();}
@@ -387,7 +420,8 @@ function pickerStopScan(){
   pickerBcActive=false;
   if(pickerBcReader){
     try{if(pickerBcReader._scanLoop)clearInterval(pickerBcReader._scanLoop);}catch(e){}
-    try{if(pickerBcReader._zxing){pickerBcReader._zxing.reset();if(pickerBcReader._zxingCanvas&&pickerBcReader._zxingCanvas.parentNode)pickerBcReader._zxingCanvas.parentNode.removeChild(pickerBcReader._zxingCanvas);}}catch(e){}
+    try{if(pickerBcReader._zxing)pickerBcReader._zxing.reset();}catch(e){}
+    try{if(pickerBcReader._canvas&&pickerBcReader._canvas.parentNode)pickerBcReader._canvas.parentNode.removeChild(pickerBcReader._canvas);}catch(e){}
     try{if(pickerBcReader._stream)pickerBcReader._stream.getTracks().forEach(function(t){t.stop();});}catch(e){}
     pickerBcReader=null;
   }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.123';
+var VERSION = '0.124';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.124';
+var VERSION = '0.125';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com'];
 


### PR DESCRIPTION
## Zwei Root-Causes behoben

### 1. `upc_a` Crash auf iOS 17+ (BarcodeDetector-Pfad)

`upc_a` ist in Safari **nicht** unterstützt. Der Aufruf `new BarcodeDetector({formats: [..., 'upc_a', ...]})` wirft einen Fehler auf iOS, der nirgendwo abgefangen wurde → Scan startet lautlos nie.

**Fix:** `BarcodeDetector.getSupportedFormats()` filtert die Format-Liste *vor* dem Konstruktor. Fallback wenn `getSupportedFormats` selbst nicht verfügbar ist.

### 2. Schwarze Canvas-Frames auf iOS (alle Versionen)

`ctx.drawImage(videoEl)` liefert nur schwarze Pixel auf iOS Safari, weil der Kamera-Stream über GPU-Compositing läuft. Die einzige garantierte Möglichkeit, zugängliche Pixel zu bekommen, ist **`requestVideoFrameCallback`** – der Browser ruft den Callback auf, wenn ein Frame tatsächlich aus dem GPU-Compositor liesbar ist.

**Fix:** Neuer einheitlicher `_pickerFrameLoop` nutzt `requestVideoFrameCallback` wenn verfügbar (iOS 15.4+, Chrome), sonst `setTimeout(200ms)`.

### Weitere Verbesserungen

- Beide Pfade (BarcodeDetector + ZXing) nutzen denselben Loop
- BarcodeDetector erkennt jetzt über Canvas (nicht Video-Element direkt) – konsistenter auf allen Plattformen
- Canvas bleibt in DOM für sicheren Pixel-Readback

## Test plan

- [ ] iPhone Safari 17+: Barcode-Tab → EAN-13 halten → wird erkannt
- [ ] iPhone Safari 15/16: ZXing-Pfad → EAN-13 halten → wird erkannt
- [ ] Android Chrome: BarcodeDetector-Pfad weiterhin funktionsfähig
- [ ] Nach Scan/Tab-Wechsel: kein orphaner Canvas in `document.body`

https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh64jzd2Ejpwj8ApGBfUWD)_