### PR TITLE
feat: iOS Barcode-Scanner via Cloudflare-Worker + Claude Vision (v0.128)

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.127</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.128</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -496,7 +496,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.127</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.128</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1328,7 +1328,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.127';
+var APP_VERSION='0.128';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1357,6 +1357,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.128',items:[
+    {icon:'📷',text:'iOS Barcode-Scanner: Live-Frames laufen parallel an den Cloudflare-Worker und werden dort via Claude Haiku Vision dekodiert – Live-Sucher unverändert, aber endlich Treffer auf iPhone',where:'Barcode-Tab'},
+  ]},
   {v:'0.127',items:[
     {icon:'📷',text:'Barcode-Scanner: zxing-wasm (C++/WebAssembly) ersetzt langsamen JS-Decoder – iOS Safari erkennt jetzt EAN-13 zuverlässig',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -11,6 +11,7 @@ var pickerIngredients=[];     // photo/chat detected ingredients
 var pickerBcFound=null;       // barcode found pending confirm
 var pickerBcReader=null;      // ZXing reader instance
 var pickerBcActive=false;
+var pickerBcServerActive=false; // Server-Decode-Loop läuft parallel zum lokalen Decoder
 var pickerTorchOn=false;
 
 // ════════════════════════════════════════
@@ -307,7 +308,8 @@ function _pickerFrameLoop(videoEl,canvas,ctx,detect,label){
   var dbgEl=document.getElementById('pickerBarcodeResult');
   if(dbgEl){
     dbgEl.innerHTML='<div id="bcDbgWrap" style="font-size:11px;color:var(--mu);text-align:center;padding:4px 0;">'+
-      '<span id="bcDbgLabel">'+label+'</span> · Frame <span id="bcDbgN">0</span> · <span id="bcDbgSz">–</span></div>';
+      '<span id="bcDbgLabel">'+label+'</span> · Frame <span id="bcDbgN">0</span> · <span id="bcDbgSz">–</span> · '+
+      '<span id="bcDbgServer">Server: aus</span></div>';
     document.getElementById('bcDbgWrap').appendChild(dbgCv);
   }
   var TARGET_W=800;
@@ -342,6 +344,50 @@ function _pickerFrameLoop(videoEl,canvas,ctx,detect,label){
     }
   }
   schedule();
+}
+
+// Server-Decode-Loop: streamt parallel zum lokalen Decoder ~1.4 fps gecropte
+// JPEG-Frames an den Cloudflare-Worker (POST /decode-barcode), der per Claude
+// Haiku Vision die Ziffern liest. Lokaler Decoder läuft weiter – wer zuerst
+// trifft, gewinnt. Auf iOS ist der Worker-Pfad meist der einzige, der trifft.
+function _pickerServerDecodeUrl(){
+  if(typeof PROJECT_AI_PROXY_URL!=='string'||!PROJECT_AI_PROXY_URL)return null;
+  return PROJECT_AI_PROXY_URL.replace(/\/v1\/messages\/?$/,'/decode-barcode');
+}
+function _pickerStartServerDecodeLoop(canvas){
+  if(typeof canUseAi!=='function'||!canUseAi())return false;
+  var url=_pickerServerDecodeUrl();if(!url)return false;
+  pickerBcServerActive=true;
+  var inFlight=0;var nextAt=Date.now()+500;
+  function setStatus(s){var el=document.getElementById('bcDbgServer');if(el)el.textContent='Server: '+s;}
+  setStatus('warte');
+  function tick(){
+    if(!pickerBcActive||!pickerBcServerActive)return;
+    var now=Date.now();
+    if(inFlight>=1||now<nextAt||!canvas.width||canvas.width<16){setTimeout(tick,120);return;}
+    nextAt=now+700;inFlight++;
+    setStatus('scan…');
+    canvas.toBlob(function(blob){
+      if(!pickerBcActive||!pickerBcServerActive||!blob){inFlight--;setTimeout(tick,120);return;}
+      fetch(url,{
+        method:'POST',
+        headers:{'Content-Type':'image/jpeg','x-app-proxy-secret':getProxySecret()},
+        body:blob
+      }).then(function(r){
+        if(!pickerBcActive||!pickerBcServerActive)return null;
+        if(r.status===204){setStatus('—');return null;}
+        if(!r.ok){setStatus('Fehler '+r.status);return null;}
+        return r.json();
+      }).then(function(d){
+        if(!pickerBcActive||!pickerBcServerActive||!d)return;
+        if(d.ok&&d.data&&d.data.code){setStatus('Treffer ✓');pickerStopScan();pickerLookupBarcode(d.data.code);}
+      }).catch(function(){setStatus('offline');}).then(function(){
+        inFlight--;setTimeout(tick,120);
+      });
+    },'image/jpeg',0.6);
+  }
+  setTimeout(tick,500);
+  return true;
 }
 
 function pickerStartScan(){
@@ -435,6 +481,12 @@ function pickerStartScan(){
       // 1. BarcodeDetector (Chrome/Edge: GPU-nativ, sehr schnell)
       // 2. zxing-wasm (iOS Safari & alle Browser ohne BarcodeDetector – C++/WASM, robust)
       // 3. ZXing-JS (Fallback falls WASM-Modul nicht laden konnte)
+      // PARALLEL: Server-Decode über Cloudflare-Worker (Claude Haiku Vision).
+      // Nur auf Plattformen ohne BarcodeDetector aktivieren – auf Chrome/Android
+      // trifft der lokale Decoder ohnehin in <100ms, da brauchen wir keinen Roundtrip.
+      if(!('BarcodeDetector' in window)){
+        try{_pickerStartServerDecodeLoop(canvas);}catch(e){}
+      }
       if('BarcodeDetector' in window){
         var want=['ean_13','ean_8','upc_a','upc_e','code_128','code_39'];
         BarcodeDetector.getSupportedFormats().then(function(supported){
@@ -481,6 +533,7 @@ function pickerStartScan(){
 
 function pickerStopScan(){
   pickerBcActive=false;
+  pickerBcServerActive=false;
   if(pickerBcReader){
     try{if(pickerBcReader._scanLoop)clearInterval(pickerBcReader._scanLoop);}catch(e){}
     try{if(pickerBcReader._zxing)pickerBcReader._zxing.reset();}catch(e){}

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.127';
+var VERSION = '0.128';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -2,6 +2,14 @@
 
 This Worker proxies NutriTrack AI requests to Anthropic so the real Anthropic API key is never shipped to the browser.
 
+## Endpoints
+
+- `GET  /health` – status JSON, no auth.
+- `POST /v1/messages` – generic Anthropic Messages proxy (used by KI-Foto/Chat features). Body is JSON forwarded to `api.anthropic.com/v1/messages`.
+- `POST /decode-barcode` – live barcode decoder. Body is a raw JPEG (max 200 KB). Worker forwards it to Claude Haiku 4.5 Vision and returns either `204 No Content` (no barcode found) or `{ ok: true, data: { code: "<digits>" } }`. Used by the Barcode-Tab to decode each frame on iPhones where local WASM decoders fail.
+
+All POST endpoints require the `x-app-proxy-secret` header to match `NUTRITRACK_PROXY_TOKEN`.
+
 ## Cloudflare Setup
 
 1. Open the Cloudflare Dashboard.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -8,6 +8,8 @@ const DEFAULT_ALLOWED_ORIGINS = [
   "http://127.0.0.1:8787",
 ];
 const MAX_BODY_BYTES = 1024 * 1024 * 4;
+const MAX_BARCODE_BODY_BYTES = 1024 * 200; // 200 KB pro Frame reicht
+const BARCODE_MODEL = "claude-haiku-4-5";
 
 function allowedOrigins(env) {
   const raw = env.ALLOWED_ORIGINS || DEFAULT_ALLOWED_ORIGINS.join(",");
@@ -51,6 +53,111 @@ function getContentLength(request) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function bytesToBase64(bytes) {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function extractBarcodeDigits(text) {
+  if (typeof text !== "string") return null;
+  const cleaned = text.trim().toUpperCase();
+  if (cleaned === "NONE" || cleaned === "" || cleaned.includes("NONE")) return null;
+  const digits = cleaned.replace(/\D/g, "");
+  // EAN-13, EAN-8, UPC-A (12), UPC-E (8), Code128/39 typ. 8-14
+  if (digits.length < 8 || digits.length > 14) return null;
+  return digits;
+}
+
+async function handleDecodeBarcode(request, origin, env) {
+  if (origin && !allowedOrigins(env).has(origin)) {
+    return jsonResponse(403, "origin_not_allowed", "Origin is not allowed", origin, env);
+  }
+  if (!env.ANTHROPIC_API_KEY || !env.NUTRITRACK_PROXY_TOKEN) {
+    return jsonResponse(500, "worker_not_configured", "Required Worker secrets are missing", origin, env);
+  }
+  const token = request.headers.get("x-app-proxy-secret") || "";
+  if (token !== env.NUTRITRACK_PROXY_TOKEN) {
+    return jsonResponse(401, "unauthorized", "Invalid app proxy secret", origin, env);
+  }
+  if (getContentLength(request) > MAX_BARCODE_BODY_BYTES) {
+    return jsonResponse(413, "request_too_large", "Frame is too large", origin, env);
+  }
+
+  let buffer;
+  try {
+    buffer = new Uint8Array(await request.arrayBuffer());
+  } catch (error) {
+    return jsonResponse(400, "invalid_body", "Frame body could not be read", origin, env);
+  }
+  if (!buffer.length || buffer.length > MAX_BARCODE_BODY_BYTES) {
+    return jsonResponse(400, "invalid_body", "Frame body is empty or too large", origin, env);
+  }
+
+  const contentType = request.headers.get("content-type") || "image/jpeg";
+  const mediaType = contentType.split(";")[0].trim() || "image/jpeg";
+  const base64 = bytesToBase64(buffer);
+
+  const body = {
+    model: BARCODE_MODEL,
+    max_tokens: 32,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: mediaType, data: base64 },
+          },
+          {
+            type: "text",
+            text: "Read the barcode in this image. Reply with ONLY the numeric code (the digits printed below the bars), no spaces, no other text. If no barcode is fully visible or readable, reply NONE.",
+          },
+        ],
+      },
+    ],
+  };
+
+  let upstream;
+  try {
+    upstream = await fetch(ANTHROPIC_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": env.ANTHROPIC_API_KEY,
+        "anthropic-version": env.ANTHROPIC_VERSION || DEFAULT_ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    return jsonResponse(502, "upstream_error", "Failed to reach Anthropic", origin, env);
+  }
+  if (!upstream.ok) {
+    return jsonResponse(upstream.status, "upstream_error", "Anthropic returned an error", origin, env);
+  }
+
+  let answer;
+  try {
+    answer = await upstream.json();
+  } catch (error) {
+    return jsonResponse(502, "upstream_error", "Anthropic returned invalid JSON", origin, env);
+  }
+  const block = (answer && answer.content && answer.content[0]) || null;
+  const text = block && block.type === "text" ? block.text : "";
+  const code = extractBarcodeDigits(text);
+
+  if (!code) {
+    return new Response(null, {
+      status: 204,
+      headers: { ...corsHeaders(origin, env), "Cache-Control": "no-store" },
+    });
+  }
+  return jsonResponse(200, "ok", "ok", origin, env, { code });
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin") || "";
@@ -65,6 +172,10 @@ export default {
         service: "nutritrack-ai-proxy",
         configured: Boolean(env.ANTHROPIC_API_KEY && env.NUTRITRACK_PROXY_TOKEN),
       });
+    }
+
+    if (request.method === "POST" && url.pathname === "/decode-barcode") {
+      return handleDecodeBarcode(request, origin, env);
     }
 
     if (request.method !== "POST" || url.pathname !== "/v1/messages") {


### PR DESCRIPTION
## Summary

Live-Stream-UX bleibt unverändert, aber **Frames werden parallel zum lokalen `zxing-wasm` an den Cloudflare-Worker gestreamt**, der per **Claude Haiku 4.5 Vision** die Ziffern unter dem Strichcode liest. Erste erfolgreiche Antwort gewinnt. Auf Android trifft `BarcodeDetector` lokal in <100 ms und der Server-Pfad bleibt deaktiviert; auf iOS Safari ist der Worker-Pfad meist der einzige, der trifft.

## Worker-Änderungen
- Neue Route `POST /decode-barcode` (max 200 KB JPEG, gleiche Auth wie `/v1/messages`)
- Forwarded an Anthropic Messages API mit Vision-Prompt für EAN/UPC/Code-128
- `204 No Content` bei „NONE", sonst `{ok:true, data:{code:"..."}}`

## Browser-Änderungen
- `_pickerStartServerDecodeLoop` in `picker.js`: alle ~700 ms ein POST, max 1 In-Flight-Request, sauberes Abräumen in `pickerStopScan()`
- Debug-Label zeigt Server-Status (`warte` / `scan…` / `Treffer ✓` / `—` / `Fehler` / `offline`)
- Lokales `zxing-wasm` läuft weiter als kostenfreier Belt & Suspenders

## Versions-Bump
- `0.127` → `0.128` an allen vier Stellen (`index.html` ×3 + `sw.js`) + `CHANGELOG`-Eintrag

## Erwartete Kosten
~0,001 € pro Frame, realistischer Scan trifft beim 2.–4. Frame → ~0,003 € pro Scan. Bei 10 Scans/Tag: **~0,90 € pro Jahr**.

## Test plan
- [ ] PR mergen → GitHub Action `Deploy Cloudflare Worker` läuft grün durch
- [ ] Smoke-Test: `POST /decode-barcode` ohne Auth-Header → `401`
- [ ] Auf iPhone (iOS 26) Barcode-Tab öffnen → echten EAN-13 scannen
- [ ] Debug-Label zeigt `Server: scan…` → innerhalb 1–3 Sek. `Server: Treffer ✓`
- [ ] Auf Android Pixel/Samsung Live-Scan funktioniert weiterhin lokal (kein Server-Roundtrip, Debug-Label `Server: aus`)

https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9)_