### PR TITLE
feat: Barcode-Diagnose – Roh-Antwort von Claude im Debug-Label (v0.129)

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.128</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.129</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -496,7 +496,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.128</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.129</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1328,7 +1328,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.128';
+var APP_VERSION='0.129';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1357,6 +1357,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.129',items:[
+    {icon:'🔍',text:'Barcode-Diagnose: Debug-Label zeigt Claudes Roh-Antwort + Request-Zähler – damit sichtbar wird, was die KI tatsächlich erkennt (oder nicht)',where:'Barcode-Tab → Debug-Label unter dem Sucher'},
+  ]},
   {v:'0.128',items:[
     {icon:'📷',text:'iOS Barcode-Scanner: Live-Frames laufen parallel an den Cloudflare-Worker und werden dort via Claude Haiku Vision dekodiert – Live-Sucher unverändert, aber endlich Treffer auf iPhone',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -358,15 +358,15 @@ function _pickerStartServerDecodeLoop(canvas){
   if(typeof canUseAi!=='function'||!canUseAi())return false;
   var url=_pickerServerDecodeUrl();if(!url)return false;
   pickerBcServerActive=true;
-  var inFlight=0;var nextAt=Date.now()+500;
+  var inFlight=0;var nextAt=Date.now()+500;var reqCount=0;
   function setStatus(s){var el=document.getElementById('bcDbgServer');if(el)el.textContent='Server: '+s;}
   setStatus('warte');
   function tick(){
     if(!pickerBcActive||!pickerBcServerActive)return;
     var now=Date.now();
     if(inFlight>=1||now<nextAt||!canvas.width||canvas.width<16){setTimeout(tick,120);return;}
-    nextAt=now+700;inFlight++;
-    setStatus('scan…');
+    nextAt=now+700;inFlight++;reqCount++;
+    setStatus('scan… ('+reqCount+')');
     canvas.toBlob(function(blob){
       if(!pickerBcActive||!pickerBcServerActive||!blob){inFlight--;setTimeout(tick,120);return;}
       fetch(url,{
@@ -375,13 +375,20 @@ function _pickerStartServerDecodeLoop(canvas){
         body:blob
       }).then(function(r){
         if(!pickerBcActive||!pickerBcServerActive)return null;
-        if(r.status===204){setStatus('—');return null;}
-        if(!r.ok){setStatus('Fehler '+r.status);return null;}
+        if(!r.ok){setStatus('Fehler '+r.status+' ('+reqCount+')');return null;}
         return r.json();
       }).then(function(d){
         if(!pickerBcActive||!pickerBcServerActive||!d)return;
-        if(d.ok&&d.data&&d.data.code){setStatus('Treffer ✓');pickerStopScan();pickerLookupBarcode(d.data.code);}
-      }).catch(function(){setStatus('offline');}).then(function(){
+        var raw=(d&&d.data&&d.data.raw)?String(d.data.raw):'';
+        var code=(d&&d.data&&d.data.code)?String(d.data.code):'';
+        var label=raw?raw.slice(0,28):'(leer)';
+        if(code){
+          setStatus('✓ '+code);
+          pickerStopScan();pickerLookupBarcode(code);
+        }else{
+          setStatus(label+' ('+reqCount+')');
+        }
+      }).catch(function(e){setStatus('offline ('+reqCount+')');}).then(function(){
         inFlight--;setTimeout(tick,120);
       });
     },'image/jpeg',0.6);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.128';
+var VERSION = '0.129';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -148,14 +148,13 @@ async function handleDecodeBarcode(request, origin, env) {
   const block = (answer && answer.content && answer.content[0]) || null;
   const text = block && block.type === "text" ? block.text : "";
   const code = extractBarcodeDigits(text);
+  const rawTrimmed = (text || "").trim().slice(0, 64);
 
-  if (!code) {
-    return new Response(null, {
-      status: 204,
-      headers: { ...corsHeaders(origin, env), "Cache-Control": "no-store" },
-    });
-  }
-  return jsonResponse(200, "ok", "ok", origin, env, { code });
+  return jsonResponse(200, "ok", "ok", origin, env, {
+    code: code,
+    raw: rawTrimmed,
+    found: Boolean(code),
+  });
 }
 
 export default {


### PR DESCRIPTION
## Summary

Diagnose-Erweiterung: das Debug-Label zeigt jetzt **Claudes Roh-Antwort** und einen Request-Zähler. Damit wird sichtbar, was Haiku Vision tatsächlich liest – ob `NONE`, eine Zahl, oder eine Erklärung wie „I cannot read this barcode".

## Worker
- `POST /decode-barcode` antwortet immer mit JSON statt 204
- Body: `{ ok:true, data:{ code, raw, found } }`
- `raw` enthält die ersten 64 Zeichen von Claudes Antwort

## Browser
- `bcDbgServer`-Label zeigt:
  - `scan… (3)` während In-Flight (Counter)
  - `NONE (3)` / `4011200296898 (4)` etc. wenn Claude antwortet
  - `✓ 4011200296898` bei Treffer
  - `Fehler 401 (3)` / `offline (3)` bei Problemen

## Versions-Bump
`0.128` → `0.129` an allen vier Stellen.

## Test plan
- [ ] Worker via Action neu deployen (auto-trigger durch worker/-Änderung)
- [ ] Auf iPhone Live-Scan starten und Debug-Label live beobachten
- [ ] Notieren was Claude bei einem echten EAN-13 schreibt → wir wissen ob's am Bild oder am Prompt liegt

https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9)_