### PR TITLE
fix: EAN-13-Prüfziffer + 2× Bestätigung gegen Halluzinationen (v0.131)

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.130</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.131</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -496,7 +496,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.130</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.131</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1328,7 +1328,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.130';
+var APP_VERSION='0.131';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1357,6 +1357,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.131',items:[
+    {icon:'🛡️',text:'Barcode iOS: EAN-13-Prüfziffer + 2× identische Bestätigung gegen halluzinierte Codes von Claude Vision – falsche Codes landen nicht mehr im Lookup',where:'Barcode-Tab'},
+  ]},
   {v:'0.130',items:[
     {icon:'📷',text:'Barcode: erkannter Code wird jetzt oben in der „Produkt nicht in der Datenbank"-Box angezeigt – damit sichtbar ist, dass der Scan funktioniert hat (auch wenn OpenFoodFacts das Produkt nicht kennt)',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -359,6 +359,9 @@ function _pickerStartServerDecodeLoop(canvas){
   var url=_pickerServerDecodeUrl();if(!url)return false;
   pickerBcServerActive=true;
   var inFlight=0;var nextAt=Date.now()+500;var reqCount=0;
+  // Mehrfrachen-Bestätigung: erst nach 2 identischen gültigen Codes wird der Lookup gestartet.
+  // Schützt gegen seltene Halluzinationen mit zufällig gültiger Prüfziffer.
+  var lastCode=null;
   function setStatus(s){var el=document.getElementById('bcDbgServer');if(el)el.textContent='Server: '+s;}
   setStatus('warte');
   function tick(){
@@ -379,14 +382,25 @@ function _pickerStartServerDecodeLoop(canvas){
         return r.json();
       }).then(function(d){
         if(!pickerBcActive||!pickerBcServerActive||!d)return;
-        var raw=(d&&d.data&&d.data.raw)?String(d.data.raw):'';
-        var code=(d&&d.data&&d.data.code)?String(d.data.code):'';
-        var label=raw?raw.slice(0,28):'(leer)';
+        var data=d.data||{};
+        var raw=data.raw?String(data.raw):'';
+        var code=data.code?String(data.code):'';
+        var candidate=data.candidate?String(data.candidate):'';
+        var checksumOk=Boolean(data.checksumValid);
         if(code){
-          setStatus('✓ '+code);
-          pickerStopScan();pickerLookupBarcode(code);
+          if(lastCode===code){
+            setStatus('✓✓ '+code);
+            pickerStopScan();pickerLookupBarcode(code);
+          }else{
+            lastCode=code;
+            setStatus('1/2 ✓ '+code+' ('+reqCount+')');
+          }
+        }else if(candidate&&!checksumOk){
+          lastCode=null;
+          setStatus('✗ '+candidate+' ('+reqCount+')');
         }else{
-          setStatus(label+' ('+reqCount+')');
+          lastCode=null;
+          setStatus((raw?raw.slice(0,24):'(leer)')+' ('+reqCount+')');
         }
       }).catch(function(e){setStatus('offline ('+reqCount+')');}).then(function(){
         inFlight--;setTimeout(tick,120);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.130';
+var VERSION = '0.131';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -72,6 +72,42 @@ function extractBarcodeDigits(text) {
   return digits;
 }
 
+// Validates EAN-13 / EAN-8 / UPC-A check digit (last digit).
+// Returns true for codes with a correct check digit, false otherwise.
+// Strong filter against hallucinated digits from the vision model.
+function isValidBarcodeChecksum(code) {
+  if (typeof code !== "string" || !/^\d+$/.test(code)) return false;
+  if (code.length !== 13 && code.length !== 12 && code.length !== 8) {
+    // We cannot validate Code 128 / Code 39 / unusual lengths cheaply – allow them through.
+    return true;
+  }
+  // EAN-13 / UPC-A use the same checksum algorithm; pad UPC-A (12) to 13 with leading 0.
+  const padded = code.length === 12 ? "0" + code : code;
+  if (padded.length === 13) {
+    let sumOdd = 0;
+    let sumEven = 0;
+    for (let i = 0; i < 12; i++) {
+      const d = padded.charCodeAt(i) - 48;
+      if (i % 2 === 0) sumOdd += d;
+      else sumEven += d;
+    }
+    const total = sumOdd + sumEven * 3;
+    const expected = (10 - (total % 10)) % 10;
+    return expected === padded.charCodeAt(12) - 48;
+  }
+  if (code.length === 8) {
+    // EAN-8: positions 1,3,5,7 ×3 + positions 2,4,6 ×1 (0-indexed inverted).
+    let sum = 0;
+    for (let i = 0; i < 7; i++) {
+      const d = code.charCodeAt(i) - 48;
+      sum += i % 2 === 0 ? d * 3 : d;
+    }
+    const expected = (10 - (sum % 10)) % 10;
+    return expected === code.charCodeAt(7) - 48;
+  }
+  return true;
+}
+
 async function handleDecodeBarcode(request, origin, env) {
   if (origin && !allowedOrigins(env).has(origin)) {
     return jsonResponse(403, "origin_not_allowed", "Origin is not allowed", origin, env);
@@ -114,7 +150,7 @@ async function handleDecodeBarcode(request, origin, env) {
           },
           {
             type: "text",
-            text: "Read the barcode in this image. Reply with ONLY the numeric code (the digits printed below the bars), no spaces, no other text. If no barcode is fully visible or readable, reply NONE.",
+            text: "Read the EAN-13 barcode in this image. Below the black bars there is a row of 13 digits printed in plain text. Reply with ONLY those 13 digits, no spaces, no other text. If you cannot clearly read all 13 digits, reply exactly NONE. Do NOT guess any digit. Do NOT invent digits. NONE is the right answer when the barcode is blurry, partially occluded, or not in the image.",
           },
         ],
       },
@@ -147,12 +183,16 @@ async function handleDecodeBarcode(request, origin, env) {
   }
   const block = (answer && answer.content && answer.content[0]) || null;
   const text = block && block.type === "text" ? block.text : "";
-  const code = extractBarcodeDigits(text);
+  const candidate = extractBarcodeDigits(text);
   const rawTrimmed = (text || "").trim().slice(0, 64);
+  const checksumValid = candidate ? isValidBarcodeChecksum(candidate) : false;
+  const code = checksumValid ? candidate : null;
 
   return jsonResponse(200, "ok", "ok", origin, env, {
     code: code,
     raw: rawTrimmed,
+    candidate: candidate,
+    checksumValid: checksumValid,
     found: Boolean(code),
   });
 }


### PR DESCRIPTION
## Problem

Claude Haiku Vision liest auf iOS gelegentlich Ziffern, die wie ein EAN-13 aussehen, aber **tatsächlich erfunden sind**. Im konkreten Fall: `4006067015623` – die Prüfziffer dieses Codes müsste `5` sein (mathematisch beweisbar), nicht `3`. Auf Android decodet der native `BarcodeDetector` denselben Barcode korrekt; auf iPhone landet der halluzinierte Code in OpenFoodFacts und ergibt „Produkt nicht in der Datenbank".

## Lösung

### Worker
- Strikterer Prompt: „13 Ziffern oder `NONE` – nicht raten, nicht erfinden"
- **EAN-13 / EAN-8 / UPC-A Prüfziffern-Validierung** direkt im Worker
- Antwort enthält jetzt:
  - `code` – nur gesetzt bei gültiger Prüfziffer
  - `candidate` – rohe Ziffern, auch wenn Prüfziffer fehlschlägt
  - `checksumValid` – Boolean
  - `raw` – Claudes Originaltext (max 64 Zeichen)

### Browser
- **Mehrfrachen-Bestätigung**: erst nach **2 identischen gültigen Codes** wird `pickerLookupBarcode` gestartet
- Debug-Label zeigt jetzt:
  - `1/2 ✓ 4011200296898` beim ersten gültigen Treffer
  - `✓✓ 4011200296898` beim zweiten (Lookup läuft)
  - `✗ 4006067015623` bei **ungültiger Prüfziffer** (= Halluzination, verworfen)
  - Roh-Antwort wenn Claude etwas anderes sagt

## Erwartetes Verhalten danach

- iOS Live-Scan: ~2–4 Sekunden bis Treffer (zwei gültige Frames hintereinander)
- Halluzinierte Codes mit falscher Prüfziffer werden gar nicht erst zum Lookup geschickt
- Halluzinationen mit zufällig gültiger Prüfziffer werden durch die 2×-Bestätigung gefiltert (Wahrscheinlichkeit für 2× denselben Falsch-Code: <1%)

## Test plan
- [ ] Worker via Action neu deployen
- [ ] Echtes EAN-13 (z.B. Coca-Cola) auf iPhone scannen → `1/2 ✓` → `✓✓` → Produkt-Anzeige
- [ ] Verpackung ohne klaren Barcode auf iPhone scannen → erwartet: keine Halluzinationen, Label zeigt `NONE` oder `✗ ...`

https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9)_