### PR TITLE
fix: höhere Kamera-Auflösung auf iOS erzwingen (v0.132)

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.131</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.132</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -496,7 +496,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.131</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.132</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1328,7 +1328,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.131';
+var APP_VERSION='0.132';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1357,6 +1357,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.132',items:[
+    {icon:'📐',text:'Barcode iOS: höhere Kamera-Auflösung erzwungen (ideal 1920×1080) – iOS Safari liefert sonst manchmal nur 480×640, was für Decode zu wenig ist. Debug-Label zeigt jetzt Stream-Auflösung',where:'Barcode-Tab'},
+  ]},
   {v:'0.131',items:[
     {icon:'🛡️',text:'Barcode iOS: EAN-13-Prüfziffer + 2× identische Bestätigung gegen halluzinierte Codes von Claude Vision – falsche Codes landen nicht mehr im Lookup',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -331,7 +331,9 @@ function _pickerFrameLoop(videoEl,canvas,ctx,detect,label){
     ctx.drawImage(videoEl,cropX,cropY,cropW,cropH,0,0,outW,outH);
     frameCount++;
     var fn=document.getElementById('bcDbgN');if(fn)fn.textContent=frameCount;
-    var sz=document.getElementById('bcDbgSz');if(sz)sz.textContent=outW+'×'+outH;
+    // Zeigt: Stream-Auflösung → Decoder-Auflösung. Wichtig für Diagnose ob
+    // iOS uns hochauflösenden Stream gibt.
+    var sz=document.getElementById('bcDbgSz');if(sz)sz.textContent=vw+'×'+vh+' → '+outW+'×'+outH;
     dbgCtx.drawImage(canvas,0,0,120,80);
     detect(canvas,schedule);
   }
@@ -421,7 +423,24 @@ function pickerStartScan(){
   var videoEl=document.getElementById('pickerBarcodeVideo');
   videoEl.setAttribute('playsinline','');
   videoEl.muted=true;
-  navigator.mediaDevices.getUserMedia({video:{facingMode:'environment'}}).then(function(stream){
+  // iOS Safari liefert mit dem reinen facingMode-Constraint manchmal nur 480×640
+  // (Postkarten-Auflösung), was für Barcode-Decode zu wenig Pixel ergibt. Mit
+  // ideal-Werten fragen wir 1920×1080 an; wenn die Kamera weniger kann, wählt
+  // der Browser automatisch die nächst-höhere verfügbare Auflösung.
+  function _getCameraStream(){
+    return navigator.mediaDevices.getUserMedia({
+      video:{
+        facingMode:{ideal:'environment'},
+        width:{ideal:1920},
+        height:{ideal:1080},
+        frameRate:{ideal:30}
+      }
+    }).catch(function(err){
+      // Fallback: simple Constraints falls iOS mit ideal-Werten zickt
+      return navigator.mediaDevices.getUserMedia({video:{facingMode:'environment'}});
+    });
+  }
+  _getCameraStream().then(function(stream){
     if(!pickerBcActive){stream.getTracks().forEach(function(t){t.stop();});return;}
     videoEl.srcObject=stream;
     var playP=videoEl.play();if(playP)playP.catch(function(){});

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.131';
+var VERSION = '0.132';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 


### PR DESCRIPTION
## Diagnose

Der Debug-Label aus v0.131-Test zeigte **408×288** als Decoder-Auflösung. Das bedeutet iOS Safari hat einen **480×640-Hochformat-Stream** geliefert (kein Auto-1080p). Bei der Pixeldichte haben weder zxing-wasm noch Claude Vision genug Material pro Strichcode-Modul: **888 lokale Frames + 27 Server-Requests = 0 Treffer**, obwohl das Vorschau-Bild klar lesbar war.

## Fix

- `getUserMedia` mit `ideal:1920×1080` + `frameRate:30` fordert hochauflösenden Rückkamera-Stream
- Fallback auf einfache `facingMode`-Constraints, falls iOS mit ideal-Werten zickt
- Debug-Label zeigt jetzt zusätzlich die **Stream-Auflösung**, z.B. `1920×1080 → 800×486` – so siehst du sofort, ob die Kamera den hochauflösenden Stream liefert

## Test plan
- [ ] iPhone Live-Scan starten → Debug-Label sollte jetzt z.B. `1920×1080 → 800×486` zeigen statt `480×640 → 408×288`
- [ ] Wenn ja: lokales zxing-wasm sollte zuverlässig treffen
- [ ] Wenn weiter klein: iOS Safari ignoriert `ideal` (selten) – dann müssten wir mit verschiedenen Resolutions experimentieren

https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9)_