### PR TITLE
fix: WASM-Polling 15s + alle Decoder pro Frame im JS-Fallback (v0.134)

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.133</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.134</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.133</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.134</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1335,7 +1335,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.133';
+var APP_VERSION='0.134';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1364,6 +1364,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.134',items:[
+    {icon:'⏳',text:'Barcode: WASM-Module-Polling von 2s auf 15s erhöht – auf iOS Safari mit langsamer Verbindung kann esm.sh länger brauchen. Wenn JS-Fallback aktiv ist, werden trotzdem alle Decoder pro Frame geprüft. Debug-Label zeigt jetzt live, welche Engines aktiv sind',where:'Barcode-Tab'},
+  ]},
   {v:'0.133',items:[
     {icon:'📷',text:'Barcode: zbar-wasm als zweiter lokaler Decoder (gleiche Library wie OpenFoodFacts-App), pro Frame parallel zu zxing-wasm – fängt Codes mit niedrigem Kontrast oder dünnen Strichen, wo ZXing aufgibt. Plus iOS Auto-Focus aktiviert + engerer Crop (70×35)',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -531,17 +531,43 @@ function pickerStartScan(){
         hints.set(ZXing.DecodeHintType.TRY_HARDER,true);
         var reader=new ZXing.BrowserMultiFormatReader(hints,300);
         pickerBcReader._zxing=reader;
+        // Pro Frame ALLE Decoder probieren in Reihenfolge:
+        // 1. zxing-wasm wenn nachträglich geladen (kann nach Start verfügbar werden)
+        // 2. zbar-wasm wenn geladen
+        // 3. ZXing-JS (immer da)
         _pickerFrameLoop(videoEl,canvas,ctx,function(c,next){
-          try{var r=reader.decodeFromCanvas(c);if(r&&r.getText()){pickerStopScan();pickerLookupBarcode(r.getText());return;}}catch(e){}
-          _zbarTry(c).then(function(zbarCode){
+          // Update label dynamically based on which engines are loaded
+          var lbl=document.getElementById('bcDbgLabel');
+          if(lbl){
+            var parts=['ZXing-JS'];
+            if(window.ZXingWasm&&window.ZXingWasm.readBarcodes)parts.unshift('ZXing-WASM');
+            if(window.ZBarWasm&&window.ZBarWasm.scanImageData)parts.push('ZBar-WASM');
+            lbl.textContent=parts.join('+');
+          }
+          var p=Promise.resolve(null);
+          if(window.ZXingWasm&&window.ZXingWasm.readBarcodes){
+            p=window.ZXingWasm.readBarcodes(c,{
+              formats:['EAN-13','EAN-8','UPC-A','UPC-E','Code128','Code39'],
+              tryHarder:true,tryRotate:true,tryInvert:true,maxNumberOfSymbols:1
+            }).then(function(rs){return rs&&rs.length&&rs[0].text?rs[0].text:null;}).catch(function(){return null;});
+          }
+          p.then(function(code){
             if(!pickerBcActive)return;
-            if(zbarCode){pickerStopScan();pickerLookupBarcode(zbarCode);return;}
-            next();
+            if(code){pickerStopScan();pickerLookupBarcode(code);return;}
+            // Try ZXing-JS
+            try{var r=reader.decodeFromCanvas(c);if(r&&r.getText()){pickerStopScan();pickerLookupBarcode(r.getText());return;}}catch(e){}
+            // Try ZBar last
+            _zbarTry(c).then(function(zbarCode){
+              if(!pickerBcActive)return;
+              if(zbarCode){pickerStopScan();pickerLookupBarcode(zbarCode);return;}
+              next();
+            });
           });
         },'ZXing-JS+ZBar');
       }
 
-      // Wartet bis zu 2s auf das WASM-Modul, dann startet WASM oder JS-Fallback.
+      // Polling auf 15s erhöht – auf iOS Safari mit mobiler Verbindung kann
+      // esm.sh 5–10s brauchen, vorher haben wir vorzeitig auf JS-Fallback gewechselt.
       function startWasmOrFallback(){
         if(!pickerBcActive)return;
         if(window.ZXingWasm&&window.ZXingWasm.readBarcodes){startZXingWasm();return;}
@@ -550,7 +576,7 @@ function pickerStartScan(){
           if(!pickerBcActive){clearInterval(poll);return;}
           waited+=100;
           if(window.ZXingWasm&&window.ZXingWasm.readBarcodes){clearInterval(poll);startZXingWasm();}
-          else if(waited>=2000){clearInterval(poll);startZXingJs();}
+          else if(waited>=15000){clearInterval(poll);startZXingJs();}
         },100);
       }
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.133';
+var VERSION = '0.134';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 


### PR DESCRIPTION
## Diagnose

v0.133-Test zeigte: Debug-Label sagt **`ZXing-JS`** statt `ZXing+ZBar-WASM`. Das bedeutet die WASM-Module von esm.sh waren beim Scan-Start noch nicht geladen, das Polling brach nach 2 s ab und iOS fiel auf den alten/schwachen `ZXing-JS` zurück. **Daher hat zbar-wasm gestern nichts geholfen – es war nie aktiv.**

## Fix

- Polling-Timeout `2 s → 15 s` (mobile Verbindungen brauchen oft >5 s)
- Im JS-Fallback-Modus werden trotzdem **pro Frame alle Decoder geprüft** in Reihenfolge:
  1. `zxing-wasm` (falls nachträglich geladen)
  2. `ZXing-JS` (immer da)
  3. `zbar-wasm` (falls geladen)
- Wenn WASM erst nach 15 s nachlädt, wird es ab diesem Frame automatisch genutzt
- Debug-Label zeigt jetzt **live**, welche Engines aktiv sind: `ZXing-WASM+ZXing-JS+ZBar-WASM` etc.

## Test plan
- [ ] iPhone neu laden, App offline schließen, neu öffnen
- [ ] Scan starten – nach kurzer Wartezeit sollte Label `ZXing-WASM+...` zeigen (nicht nur `ZXing-JS`)
- [ ] Wenn Label trotz 15 s nur `ZXing-JS` zeigt: esm.sh ist auf iPhone nicht erreichbar → dann müssten wir self-hosten

https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9)_