### PR TITLE
feat: Manuelle Eingabe (Live-Text-Notnagel) + S/W-Kontrast-Filter (v0.135)

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.134</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.135</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.134</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.135</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -665,6 +665,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
         <button type="button" id="pickerBcStartBtn" class="abt" onclick="pickerStartScan()">▶ Scanner starten</button>
         <button type="button" id="pickerBcStopBtn" class="abt" style="display:none;background:linear-gradient(135deg,#555,#777);" onclick="pickerStopScan()">■ Scanner stoppen</button>
         <label id="pickerBcPhotoBtn" for="pickerBcPhoto" class="abt" style="display:none;margin-top:8px;cursor:pointer;">📷 Foto aufnehmen</label>
+        <button type="button" id="pickerBcManualBtn" onclick="pickerOpenManualBarcode()" style="margin-top:8px;width:100%;background:rgba(0,0,0,.04);border:1.5px solid var(--br);border-radius:10px;padding:10px;font-size:14px;font-weight:600;color:var(--mu);">📝 Code manuell eingeben</button>
       </div>
 
       <!-- Tab: Chat -->
@@ -1335,7 +1336,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.134';
+var APP_VERSION='0.135';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1364,6 +1365,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.135',items:[
+    {icon:'📝',text:'Barcode: „Code manuell eingeben"-Knopf als Notnagel wenn die Decoder versagen. Auf iPhone kannst du im Eingabefeld via long-press Apples Live Text nutzen – das liest EAN-Ziffern brilliant. Plus Schwarz-Weiß-Filter mit erhöhtem Kontrast vor jedem Decode (hilft bei reflektiven Verpackungen wie Joghurtbechern)',where:'Barcode-Tab'},
+  ]},
   {v:'0.134',items:[
     {icon:'⏳',text:'Barcode: WASM-Module-Polling von 2s auf 15s erhöht – auf iOS Safari mit langsamer Verbindung kann esm.sh länger brauchen. Wenn JS-Fallback aktiv ist, werden trotzdem alle Decoder pro Frame geprüft. Debug-Label zeigt jetzt live, welche Engines aktiv sind',where:'Barcode-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -313,10 +313,9 @@ function _pickerFrameLoop(videoEl,canvas,ctx,detect,label){
     document.getElementById('bcDbgWrap').appendChild(dbgCv);
   }
   var TARGET_W=800;
-  // Engerer Crop = mehr Pixel pro Strichcode-Modul für den Decoder. 70%×35%
-  // entspricht dem grünen Sucher-Rahmen. Vorher 85%×45% – zu viel Hintergrund.
-  var CROP_W_RATIO=0.70;
-  var CROP_H_RATIO=0.35;
+  // 80%×42%: kompromiss zwischen genug Pixeln und engem Fokus auf Barcode.
+  var CROP_W_RATIO=0.80;
+  var CROP_H_RATIO=0.42;
   function process(){
     if(!pickerBcActive)return;
     if(!videoEl.videoWidth){schedule();return;}
@@ -330,7 +329,12 @@ function _pickerFrameLoop(videoEl,canvas,ctx,detect,label){
     var outH=Math.max(1,Math.round(cropH*scale));
     if(canvas.width!==outW)canvas.width=outW;
     if(canvas.height!==outH)canvas.height=outH;
+    // Schwarz-Weiß + erhöhter Kontrast hilft bei reflektiven Verpackungen
+    // (Joghurtbecher, Folien) und niedrigem Strichkontrast. iOS Safari 14.5+
+    // unterstützt ctx.filter; Browsern ohne Support ignorieren still die filter.
+    try{ctx.filter='grayscale(100%) contrast(180%) brightness(105%)';}catch(e){}
     ctx.drawImage(videoEl,cropX,cropY,cropW,cropH,0,0,outW,outH);
+    try{ctx.filter='none';}catch(e){}
     frameCount++;
     var fn=document.getElementById('bcDbgN');if(fn)fn.textContent=frameCount;
     // Zeigt: Stream-Auflösung → Decoder-Auflösung. Wichtig für Diagnose ob
@@ -733,6 +737,29 @@ function pickerBcNo(){
   document.getElementById('pickerBcConfirm').classList.add('hidden');
   pickerBcFound=null;
   pickerAnalyze();
+}
+
+// Notnagel: Code manuell eintippen wenn alle Decoder versagen.
+// Auf iOS: long-press im Eingabefeld → "Text scannen" nutzt Apples Live Text OCR,
+// die EAN-Klartextziffern unter dem Strichcode extrem zuverlässig liest.
+function pickerOpenManualBarcode(){
+  pickerStopScan();
+  var el=document.getElementById('pickerBarcodeResult');
+  if(!el)return;
+  el.innerHTML='<div style="background:var(--gl);border:1.5px solid var(--br);border-radius:12px;padding:12px;">'
+    +'<div style="font-size:12px;color:var(--mu);margin-bottom:6px;">Tippe die 13 Ziffern unter dem Strichcode ein.</div>'
+    +'<div style="font-size:11px;color:var(--mu);margin-bottom:10px;line-height:1.4;">📱 <strong>iPhone-Tipp:</strong> Halte das Eingabefeld lang gedrückt → „Text scannen" → mit Kamera die Ziffern lesen lassen (Apples Live Text).</div>'
+    +'<input type="text" id="bcDirectInput" inputmode="numeric" pattern="[0-9]*" autocomplete="off" placeholder="z.B. 4011200296898" style="width:100%;box-sizing:border-box;border:2px solid var(--br);border-radius:9px;padding:10px;font-size:16px;font-family:ui-monospace,Menlo,monospace;letter-spacing:1px;outline:none;margin-bottom:10px;" maxlength="14">'
+    +'<button type="button" onclick="pickerSubmitManualBarcode()" style="width:100%;background:linear-gradient(135deg,var(--g1),var(--g2));color:white;border:none;border-radius:10px;padding:11px;font-weight:800;font-size:14px;">Suchen ✓</button>'
+    +'</div>';
+  setTimeout(function(){var i=document.getElementById('bcDirectInput');if(i)i.focus();},50);
+}
+function pickerSubmitManualBarcode(){
+  var i=document.getElementById('bcDirectInput');
+  if(!i)return;
+  var code=(i.value||'').replace(/\D/g,'');
+  if(code.length<8){showToast('Mindestens 8 Ziffern eingeben');return;}
+  pickerLookupBarcode(code);
 }
 
 function pickerLookupBarcode(code){

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.134';
+var VERSION = '0.135';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 


### PR DESCRIPTION
## Diagnose

v0.134-Test: ZXing+ZBar-WASM beide aktiv (Label bestätigt!), trotzdem 1375 Frames + 40 Server-Requests ohne Treffer. Der Rügenwalder-Strichcode auf glänzender Joghurtbecher-Folie ist objektiv lesbar, aber **am Limit der Browser-Decoder** (Reflexionen, leichte Bewegungsunschärfe).

## Drei Verbesserungen

### 1. Canvas-Filter: Schwarz-Weiß + Kontrast vor jedem Decode
```js
ctx.filter = 'grayscale(100%) contrast(180%) brightness(105%)';
```
- iOS Safari 14.5+ supported (try/catch für ältere)
- Hilft bei reflektiven Oberflächen, Folien, niedrigem Strichkontrast
- Bonus: bessere JPEG-Kompression beim Server-Upload

### 2. Crop wieder leicht größer: 80%×42%
- Mehr Pixel pro Strichcode-Modul

### 3. 📝 „Code manuell eingeben" – der zuverlässige Notnagel
- Neuer Knopf unter dem Sucher
- Eingabefeld mit numerischer Tastatur
- **iPhone-Tipp prominent angezeigt:** long-press im Feld → „Text scannen" → Apples **Live Text** OCR liest die 13 EAN-Klartextziffern. Das nutzt iOS' eigenes Vision-Framework und ist auf iPhones extrem zuverlässig
- Damit hat der User **immer einen Weg**, wenn alle Decoder versagen

## Test plan
- [ ] iPhone neu laden → v0.135 im Header
- [ ] Rügenwalder nochmal scannen – mit S/W-Filter könnte's klappen
- [ ] Falls nicht: Knopf „📝 Code manuell eingeben" tippen → im Feld lange drücken → „Text scannen" wählen → Kamera auf die Ziffern unter dem Strichcode richten → Apple Live Text trägt die 13 Ziffern ein → Suchen
- [ ] OpenFoodFacts findet Brandt/Rügenwalder → Erfolg

https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9

---
_Generated by [Claude Code](https://claude.ai/code/session_014mWXDs5pwH2UhpFff2K6B9)_