### PR TITLE
feat: Universelles Teilen/Importieren + Kurzlink + Android-PWA-Routing (v0.139)

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.138</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.139</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -464,10 +464,10 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
       <div id="nutriAmpelWrap" style="overflow:hidden;max-height:0;transition:max-height .35s ease;"></div>
       <div id="ki-day-wrap" style="display:none;margin-top:10px;border-top:1px solid rgba(255,255,255,0.2);padding-top:10px;"></div>
     </div>
-    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#fff8e1">🌅</div><div><div class="mnm">Frühstück</div><div class="ms" id="sub-breakfast">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('breakfast')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('breakfast')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openMealShare('breakfast')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('breakfast')">+</button></div></div><div id="entries-breakfast"><div class="me">Noch nichts eingetragen</div></div></div>
-    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#e8f5e9">☀️</div><div><div class="mnm">Mittagessen</div><div class="ms" id="sub-lunch">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('lunch')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('lunch')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openMealShare('lunch')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('lunch')">+</button></div></div><div id="entries-lunch"><div class="me">Noch nichts eingetragen</div></div></div>
-    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#e3f2fd">🌙</div><div><div class="mnm">Abendessen</div><div class="ms" id="sub-dinner">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('dinner')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('dinner')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openMealShare('dinner')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('dinner')">+</button></div></div><div id="entries-dinner"><div class="me">Noch nichts eingetragen</div></div></div>
-    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#fce4ec">🍎</div><div><div class="mnm">Snacks</div><div class="ms" id="sub-snack">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('snack')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('snack')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openMealShare('snack')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('snack')">+</button></div></div><div id="entries-snack"><div class="me">Noch nichts eingetragen</div></div></div>
+    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#fff8e1">🌅</div><div><div class="mnm">Frühstück</div><div class="ms" id="sub-breakfast">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('breakfast')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('breakfast')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="shareMeal('breakfast')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('breakfast')">+</button></div></div><div id="entries-breakfast"><div class="me">Noch nichts eingetragen</div></div></div>
+    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#e8f5e9">☀️</div><div><div class="mnm">Mittagessen</div><div class="ms" id="sub-lunch">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('lunch')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('lunch')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="shareMeal('lunch')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('lunch')">+</button></div></div><div id="entries-lunch"><div class="me">Noch nichts eingetragen</div></div></div>
+    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#e3f2fd">🌙</div><div><div class="mnm">Abendessen</div><div class="ms" id="sub-dinner">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('dinner')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('dinner')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="shareMeal('dinner')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('dinner')">+</button></div></div><div id="entries-dinner"><div class="me">Noch nichts eingetragen</div></div></div>
+    <div class="mc"><div class="mh"><div class="mhl"><div class="mi" style="background:#fce4ec">🍎</div><div><div class="mnm">Snacks</div><div class="ms" id="sub-snack">0 kcal</div></div></div><div style="display:flex;gap:4px;"><button type="button" class="ma" style="font-size:12px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="openTemplateOv('snack')" title="Vorlage laden">📋</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="copyMealFromYesterday('snack')" title="Von gestern">⎘</button><button type="button" class="ma" style="font-size:14px;width:28px;background:none;border:1.5px solid var(--br);color:var(--mu);" onclick="shareMeal('snack')" title="Mahlzeit teilen">📤</button><button type="button" class="ma" onclick="openPicker('snack')">+</button></div></div><div id="entries-snack"><div class="me">Noch nichts eingetragen</div></div></div>
     <div class="wc" id="exerciseCard">
       <div class="wh">
         <div class="wt">🏃 Sport & Aktivität</div>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.138</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.139</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -781,7 +781,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
           style="width:100%;border:1.5px solid var(--br);border-radius:12px;padding:10px;font-size:13px;font-family:inherit;resize:vertical;outline:none;margin-bottom:8px;min-height:80px;"></textarea>
       </div>
       <button type="button" class="cb2" onclick="recEditSave()">💾 Rezept speichern</button>
-      <button type="button" class="seb" style="margin-bottom:8px;" onclick="openRecipeCodeShare(recEditId)">📤 Rezept teilen</button>
+      <button type="button" class="seb" style="margin-bottom:8px;" onclick="shareRecipe(recEditId)">📤 Rezept teilen</button>
       <button type="button" class="del-btn" onclick="recEditDelete()">🗑️ Rezept löschen</button>
     </div>
   </div>
@@ -954,90 +954,80 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
   </div>
 </div>
 
-<!-- ══ MAHLZEIT TEILEN ══ -->
-<div class="ov" id="mealCodeOv" onclick="bgClose(event,'mealCodeOv')">
+<!-- ══ TEILEN (universal: Rezept / Mahlzeit / Lebensmittel) ══ -->
+<div class="ov" id="shareItemOv" onclick="bgClose(event,'shareItemOv')">
   <div class="mod">
     <div class="mhan"></div>
     <div class="mhd">
-      <button type="button" class="mcl" onclick="closeOv('mealCodeOv')">✕</button>
-      <div class="mti" id="mealCodeTitle">Mahlzeit teilen</div>
-      <div class="msu">Code kopieren oder einlösen</div>
+      <button type="button" class="mcl" onclick="closeOv('shareItemOv')">✕</button>
+      <div class="mti" id="shareItemTitle">📤 Teilen</div>
+      <div class="msu" id="shareItemSubtitle">Per Link teilen oder kopieren</div>
     </div>
     <div class="mbd">
-      <div id="mealCodeExportWrap">
-        <label class="lbl">Mahlzeit-Code</label>
-        <textarea id="mealCodeText" readonly rows="4"
-          style="width:100%;border:1.5px solid var(--g2);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;background:var(--gl);color:var(--tx);margin-bottom:8px;word-break:break-all;"></textarea>
-        <button type="button" class="cb2" onclick="copyMealCode()" style="margin-bottom:16px;">📋 Code kopieren</button>
-        <div style="border-top:1px solid var(--br);margin-bottom:12px;"></div>
+      <div style="background:var(--gl);border-radius:12px;padding:12px;margin-bottom:10px;">
+        <div id="shareItemName" style="font-weight:800;font-size:15px;color:var(--tx);"></div>
+        <div id="shareItemSummary" style="font-size:12px;color:var(--mu);margin-top:2px;"></div>
       </div>
-      <label class="lbl">Mahlzeit-Code einlösen</label>
-      <textarea id="mealImportCodeInput" rows="3" placeholder="Code hier einfügen..."
-        style="width:100%;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;margin-bottom:8px;word-break:break-all;"></textarea>
-      <label class="lbl">Eintragen in Mahlzeit:</label>
-      <select id="mealImportTarget" class="sinp" style="margin-bottom:8px;">
-        <option value="breakfast">Frühstück</option>
-        <option value="lunch">Mittagessen</option>
-        <option value="dinner">Abendessen</option>
-        <option value="snack">Snacks</option>
-      </select>
-      <button type="button" class="svb" onclick="importMealCode()" style="margin-top:0;">✅ Einträge importieren</button>
+      <input type="hidden" id="shareItemUrl">
+      <input type="hidden" id="shareItemUrlLong">
+      <input type="hidden" id="shareItemCode">
+      <div id="shareItemShortStatus" style="font-size:11px;color:var(--mu);text-align:center;margin-bottom:8px;min-height:14px;"></div>
+      <button type="button" class="cb2" onclick="shareItemDoShare()" style="margin-bottom:8px;">📤 Link teilen</button>
+      <button type="button" class="seb" onclick="shareItemDoCopy()" style="margin-bottom:12px;">📋 Link kopieren</button>
+      <details style="margin-bottom:4px;">
+        <summary style="font-size:12px;color:var(--mu);cursor:pointer;padding:4px 0;">Erweitert: Code statt Link</summary>
+        <textarea id="shareItemCodeText" readonly rows="3"
+          style="width:100%;box-sizing:border-box;border:1.5px solid var(--g2);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;background:var(--gl);color:var(--tx);margin:8px 0;word-break:break-all;"></textarea>
+        <button type="button" class="seb" onclick="shareItemDoCopyCode()" style="width:100%;">📋 Code kopieren</button>
+      </details>
     </div>
   </div>
 </div>
 
-<!-- ══ REZEPT TEILEN (Link + Code-Fallback) ══ -->
-<div class="ov" id="recipeCodeOv" onclick="bgClose(event,'recipeCodeOv')">
+<!-- ══ IMPORT EINFÜGEN (manuell paste Link/Code) ══ -->
+<div class="ov" id="importPasteOv" onclick="bgClose(event,'importPasteOv')">
   <div class="mod">
     <div class="mhan"></div>
     <div class="mhd">
-      <button type="button" class="mcl" onclick="closeOv('recipeCodeOv')">✕</button>
-      <div class="mti">📤 Rezept teilen</div>
-      <div class="msu">Per Link teilen oder Code/Link einlösen</div>
+      <button type="button" class="mcl" onclick="closeOv('importPasteOv')">✕</button>
+      <div class="mti">📥 Importieren</div>
+      <div class="msu">Link oder Code einfügen – erkennt Rezept, Mahlzeit oder Lebensmittel automatisch</div>
     </div>
     <div class="mbd">
-      <div id="recipeCodeExportWrap" style="display:none;">
-        <div id="recipeSharePreview" style="background:var(--gl);border-radius:12px;padding:12px;margin-bottom:10px;">
-          <div id="recipeShareName" style="font-weight:800;font-size:15px;color:var(--tx);"></div>
-          <div id="recipeShareSummary" style="font-size:12px;color:var(--mu);margin-top:2px;"></div>
-        </div>
-        <input type="hidden" id="recipeShareUrl">
-        <button type="button" class="cb2" onclick="shareRecipeLink()" style="margin-bottom:8px;">📤 Link teilen</button>
-        <button type="button" class="seb" onclick="copyRecipeLink()" style="margin-bottom:12px;">📋 Link kopieren</button>
-        <details style="margin-bottom:12px;">
-          <summary style="font-size:12px;color:var(--mu);cursor:pointer;padding:4px 0;">Erweitert: Code statt Link</summary>
-          <textarea id="recipeCodeText" readonly rows="3"
-            style="width:100%;box-sizing:border-box;border:1.5px solid var(--g2);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;background:var(--gl);color:var(--tx);margin:8px 0;word-break:break-all;"></textarea>
-          <button type="button" class="seb" onclick="copyRecipeCode()" style="width:100%;">📋 Code kopieren</button>
-        </details>
-        <div style="border-top:1px solid var(--br);margin-bottom:12px;"></div>
-      </div>
-      <label class="lbl">Rezept-Link oder -Code einlösen</label>
-      <textarea id="recipeImportCodeInput" rows="3" placeholder="Link oder Code hier einfügen..."
+      <textarea id="importPasteInput" rows="4" placeholder="Link oder Code hier einfügen..."
         style="width:100%;box-sizing:border-box;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:12px;font-family:monospace;resize:none;outline:none;margin-bottom:8px;word-break:break-all;"></textarea>
-      <button type="button" class="svb" onclick="importRecipeCode()" style="margin-top:0;">✅ Rezept importieren</button>
+      <button type="button" class="svb" onclick="importPasted()" style="margin-top:0;">✅ Vorschau anzeigen</button>
     </div>
   </div>
 </div>
 
-<!-- ══ REZEPT-IMPORT BESTÄTIGEN (geteilter Link geöffnet) ══ -->
-<div class="ov" id="recipeImportConfirmOv" onclick="bgClose(event,'recipeImportConfirmOv')">
+<!-- ══ IMPORT BESTÄTIGEN (Vorschau + Speichern) ══ -->
+<div class="ov" id="importConfirmOv" onclick="bgClose(event,'importConfirmOv')">
   <div class="mod">
     <div class="mhan"></div>
     <div class="mhd">
-      <button type="button" class="mcl" onclick="closeOv('recipeImportConfirmOv')">✕</button>
-      <div class="mti">📥 Rezept importieren?</div>
-      <div class="msu">Du hast einen geteilten Rezept-Link geöffnet</div>
+      <button type="button" class="mcl" onclick="closeOv('importConfirmOv')">✕</button>
+      <div class="mti" id="importConfirmTitle">📥 Importieren?</div>
+      <div class="msu" id="importConfirmSubtitle"></div>
     </div>
     <div class="mbd">
       <div style="background:var(--gl);border-radius:12px;padding:14px;margin-bottom:12px;">
-        <div id="recipeImportConfirmTitle" style="font-weight:800;font-size:17px;color:var(--tx);"></div>
-        <div id="recipeImportConfirmSummary" style="font-size:13px;color:var(--mu);margin-top:4px;"></div>
-        <div id="recipeImportConfirmIngs" style="font-size:12px;color:var(--tx);margin-top:8px;line-height:1.5;"></div>
-        <div id="recipeImportConfirmIns" style="display:none;font-size:12px;color:var(--mu);margin-top:10px;padding-top:10px;border-top:1px solid var(--br);white-space:pre-wrap;"></div>
+        <div id="importConfirmName" style="font-weight:800;font-size:16px;color:var(--tx);"></div>
+        <div id="importConfirmSummary" style="font-size:13px;color:var(--mu);margin-top:4px;"></div>
+        <div id="importConfirmDetail" style="font-size:12px;color:var(--tx);margin-top:8px;line-height:1.5;"></div>
+        <div id="importConfirmIns" style="display:none;font-size:12px;color:var(--mu);margin-top:10px;padding-top:10px;border-top:1px solid var(--br);white-space:pre-wrap;"></div>
       </div>
-      <button type="button" class="svb" onclick="confirmRecipeImport()" style="margin-top:0;margin-bottom:8px;">✅ In Bibliothek speichern</button>
-      <button type="button" class="seb" onclick="closeOv('recipeImportConfirmOv')">Abbrechen</button>
+      <div id="importConfirmMealRow" style="display:none;margin-bottom:8px;">
+        <label class="lbl">Eintragen in Mahlzeit:</label>
+        <select id="importConfirmMealTarget" class="sinp">
+          <option value="breakfast">Frühstück</option>
+          <option value="lunch">Mittagessen</option>
+          <option value="dinner">Abendessen</option>
+          <option value="snack">Snacks</option>
+        </select>
+      </div>
+      <button type="button" class="svb" id="importConfirmBtn" onclick="importConfirm()" style="margin-top:0;margin-bottom:8px;">✅ Speichern</button>
+      <button type="button" class="seb" onclick="closeOv('importConfirmOv')">Abbrechen</button>
     </div>
   </div>
 </div>
@@ -1222,7 +1212,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
           <button type="button" id="libTabRec" onclick="libSetTab('recipes')" style="flex:1;padding:9px;border-radius:10px;border:1.5px solid var(--g2);background:var(--g2);color:white;font-weight:700;font-size:13px;">📋 Rezepte</button>
           <button type="button" id="libTabFoods" onclick="libSetTab('foods')" style="flex:1;padding:9px;border-radius:10px;border:1.5px solid var(--br);background:white;color:var(--mu);font-weight:700;font-size:13px;">🥗 Lebensmittel</button>
           <button type="button" onclick="openRecipeImport()" style="padding:9px 14px;border-radius:10px;border:1.5px solid var(--g2);background:white;color:var(--g2);font-weight:700;font-size:13px;" title="Rezept per URL importieren">🔗</button>
-          <button type="button" onclick="openRecipeCodeShare(null)" style="padding:9px 14px;border-radius:10px;border:1.5px solid var(--g2);background:white;color:var(--g2);font-weight:700;font-size:13px;" title="Rezept-Link oder -Code einlösen">📥</button>
+          <button type="button" onclick="openImportPaste()" style="padding:9px 14px;border-radius:10px;border:1.5px solid var(--g2);background:white;color:var(--g2);font-weight:700;font-size:13px;" title="Link oder Code einlösen">📥</button>
         </div>
         <div id="libraryList" style="display:flex;flex-direction:column;gap:8px;"></div>
       </div>
@@ -1367,7 +1357,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.138';
+var APP_VERSION='0.139';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1396,6 +1386,12 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.139',items:[
+    {icon:'🔗',text:'Teilen via Kurzlink: Lange Base64-URLs werden über is.gd zu „is.gd/abc123" verkürzt – passt in jede WhatsApp-Vorschau, kein Zeilenumbruch mehr. Fallback auf Original-Link wenn der Shortener offline ist',where:'Jeder 📤 Share-Button'},
+    {icon:'📲',text:'Auf Android (Chrome ≥97) öffnen geteilte Links jetzt direkt die installierte PWA statt den Browser-Tab. Auf iOS bleibt der Safari-Pfad (Apple bietet keine PWA-URL-Routing-API), aber das Rezept landet trotzdem in der App – Safari und PWA teilen sich denselben Speicher',where:'Manifest: handle_links + launch_handler'},
+    {icon:'🌐',text:'Eine Funktion für alles: Mahlzeiten, Lebensmittel und Rezepte teilen jetzt über einen einzigen Code-Pfad. Eigene Lebensmittel können erstmals geteilt und importiert werden – per Link wie Rezepte',where:'Bibliothek + Eintragsmenü + Mahlzeit-Header'},
+    {icon:'📥',text:'Import-Dialog erkennt automatisch was kommt: Rezept, Lebensmittel oder ganze Mahlzeit – mit passender Vorschau (Zutaten, Nährwerte, Anzahl Einträge). Bei Mahlzeiten wählst du das Ziel (Frühstück/Mittag/Abend/Snack)',where:'Geteilten Link öffnen → Bestätigungs-Dialog'},
+  ]},
   {v:'0.138',items:[
     {icon:'🔗',text:'Rezepte teilen jetzt per Link statt Code: 📤 öffnet das System-Share-Sheet (WhatsApp, Mail, Signal, …). Empfänger tippt den Link an → Rezept-Vorschau mit Zutaten und Kalorien → ein Tap zum Importieren. Funktioniert auf iOS und Android. Code-Eingabefeld bleibt als Fallback erhalten und akzeptiert sowohl Link als auch alten Code',where:'Bibliothek → Rezept → 📤 oder Rezept bearbeiten → „Rezept teilen"'},
   ]},
@@ -1611,7 +1607,7 @@ window.addEventListener('DOMContentLoaded',function(){
   var _mainShown=(S.setupDone||hadLegacyApiKey||S.name!=='Du');
   if(_mainShown)showMain();
   // Auto-Import wenn die App über einen geteilten Rezept-Link geöffnet wurde
-  if(_mainShown)_checkSharedRecipeOnBoot();
+  if(_mainShown)_checkSharedItemOnBoot();
   // Service Worker
   if('serviceWorker' in navigator){
     navigator.serviceWorker.register('/nutritrack/sw.js').then(function(){
@@ -2546,9 +2542,13 @@ function openEntryMenu(meal,idx){
   var rec=e.recipeId&&recipes.find(function(r){return r.id===e.recipeId;});
   var ins=(rec&&rec.instructions)||e.instructions||'';
   var body=document.getElementById('entryMenuBody');
+  var shareCall=rec
+    ?'shareRecipe(\''+rec.id+'\')'
+    :'shareEntryAsFood(\''+meal+'\','+idx+')';
+  var shareLabel=rec?'📤 Rezept teilen':'📤 Lebensmittel teilen';
   body.innerHTML=
     '<button type="button" class="svb" style="margin-bottom:8px;" onclick="closeOv(\'entryMenuOv\');openEditEntry(\''+meal+'\','+idx+')">✏️ Eintrag bearbeiten</button>'
-    +(rec?'<button type="button" class="seb" style="margin-bottom:8px;" onclick="closeOv(\'entryMenuOv\');openRecipeCodeShare(\''+rec.id+'\')">📤 Rezept teilen</button>':'')
+    +'<button type="button" class="seb" style="margin-bottom:8px;" onclick="closeOv(\'entryMenuOv\');'+shareCall+'">'+shareLabel+'</button>'
     +(ins?'<button type="button" class="seb" style="margin-bottom:8px;" onclick="showEntryInstructions()">📝 Kochanleitung anzeigen</button>':'')
     +'<div id="entryInstructionsPanel" style="display:none;background:var(--gl);border-radius:12px;padding:12px;margin-bottom:8px;white-space:pre-wrap;font-size:13px;color:var(--tx);">'+ins+'</div>';
   openOv('entryMenuOv');
@@ -2556,58 +2556,6 @@ function openEntryMenu(meal,idx){
 function showEntryInstructions(){
   var p=document.getElementById('entryInstructionsPanel');
   if(p)p.style.display=p.style.display==='none'?'block':'none';
-}
-
-// ─── MAHLZEIT ALS CODE TEILEN ───
-function _encodeMealCode(meal){
-  var entries=getDay().meals[meal]||[];
-  if(!entries.length)return null;
-  var d={m:meal,e:entries.map(function(e){
-    if(e.isRecipe){
-      return{t:'r',n:e.name,em:e.emoji,p:e.portions||1,i:(e.ingredients||[]).map(function(ing){return{n:ing.name,em:ing.emoji,a:ing.amount,p:{k:Math.round(ing.per100.kcal),pr:Math.round((ing.per100.protein||0)*10)/10,c:Math.round((ing.per100.carbs||0)*10)/10,f:Math.round((ing.per100.fat||0)*10)/10}};})};
-    }
-    return{t:'f',n:e.name,em:e.emoji,a:e.amount,p:{k:Math.round(e.per100&&e.per100.kcal||e.kcal),pr:Math.round((e.per100&&e.per100.protein||e.protein||0)*10)/10,c:Math.round((e.per100&&e.per100.carbs||e.carbs||0)*10)/10,f:Math.round((e.per100&&e.per100.fat||e.fat||0)*10)/10}};
-  })};
-  try{return btoa(unescape(encodeURIComponent(JSON.stringify(d))));}catch(ex){return null;}
-}
-function _decodeMealCode(code){
-  try{
-    var d=JSON.parse(decodeURIComponent(escape(atob(code.trim().replace(/\s+/g,'')))));
-    return d.e.map(function(x){
-      if(x.t==='r'){
-        var ings=(x.i||[]).map(function(ing){return{name:ing.n,emoji:ing.em,amount:ing.a||100,per100:{kcal:ing.p.k,protein:ing.p.pr,carbs:ing.p.c,fat:ing.p.f,sugar:0,fiber:0,salt:0}};});
-        var t=ingTotal(ings);return Object.assign({name:x.n,emoji:x.em,isRecipe:true,recipeId:null,portions:x.p,ingredients:ings},scaleNutrients(t,x.p));
-      }
-      var per100={kcal:x.p.k,protein:x.p.pr,carbs:x.p.c,fat:x.p.f,sugar:0,fiber:0,salt:0};
-      var r=(x.a||100)/100;
-      return Object.assign({name:x.n,emoji:x.em,amount:x.a||100,per100:per100},scaleNutrients(per100,r));
-    });
-  }catch(ex){return null;}
-}
-function openMealShare(meal){
-  var code=_encodeMealCode(meal);
-  if(!code){showToast('Keine Einträge zum Teilen');return;}
-  document.getElementById('mealCodeTitle').textContent='📤 '+MEAL_NAMES[meal]+' teilen';
-  document.getElementById('mealCodeText').value=code;
-  document.getElementById('mealImportCodeInput').value='';
-  document.getElementById('mealImportTarget').value=meal;
-  openOv('mealCodeOv');
-}
-function copyMealCode(){
-  var t=document.getElementById('mealCodeText');
-  if(!t)return;
-  if(navigator.clipboard){navigator.clipboard.writeText(t.value).then(function(){showToast('Code kopiert ✓');});}
-  else{t.select();document.execCommand('copy');showToast('Code kopiert ✓');}
-}
-function importMealCode(){
-  var code=document.getElementById('mealImportCodeInput').value.trim();
-  var target=document.getElementById('mealImportTarget').value;
-  if(!code){showToast('Code eingeben');return;}
-  var entries=_decodeMealCode(code);
-  if(!entries||!entries.length){showToast('Ungültiger Code');return;}
-  entries.forEach(function(e){getDay().meals[target].push(e);});
-  saveS();renderAll();closeOv('mealCodeOv');
-  showToast('✅ '+entries.length+' Einträge in '+MEAL_NAMES[target]+' importiert');
 }
 
 // Override pickerConfirmAdd when in entry-edit mode
@@ -2712,97 +2660,65 @@ function recEditDelete(){
   saveX();renderSettFoodList();closeOv('recEditOv');showToast('Rezept gelöscht');
 }
 
-// ─── REZEPT-CODE EXPORT / IMPORT ───
-function _encodeRecipeCode(rec){
-  var d={n:rec.name,e:rec.emoji||'📋',i:(rec.ingredients||[]).map(function(ing){return{n:ing.name,e:ing.emoji,a:ing.amount,p:{k:Math.round(ing.per100.kcal),pr:Math.round(ing.per100.protein*10)/10,c:Math.round(ing.per100.carbs*10)/10,f:Math.round(ing.per100.fat*10)/10}};})};
-  if(rec.instructions)d.ins=rec.instructions;
-  try{return btoa(unescape(encodeURIComponent(JSON.stringify(d))));}catch(ex){return null;}
-}
+// ════════════════════════════════════════
+// SECTION: SHARE & IMPORT (universal: Rezept / Mahlzeit / Lebensmittel)
+// ════════════════════════════════════════
+// Payload-Schema (base64-encoded JSON):
+//   {t:'r', n, em, ins, i:[{n, em, a, p:{k,pr,c,f}}, ...]}        // Rezept
+//   {t:'f', n, em, p:{k,pr,c,f}}                                  // Lebensmittel
+//   {t:'m', m, e:[entries]}                                       // Mahlzeit
+// URL-Format: https://.../#x=<urlencoded-base64>
+// Legacy:     https://.../#r=<urlencoded-base64>  (v0.138, nur Rezept)
 
-function _decodeRecipeCode(code){
-  try{
-    var d=JSON.parse(decodeURIComponent(escape(atob(code.trim().replace(/\s+/g,'')))));
-    var ings=(d.i||[]).map(function(x){return{name:x.n,emoji:x.e,amount:x.a||100,per100:{kcal:x.p.k,protein:x.p.pr,carbs:x.p.c,fat:x.p.f,sugar:0,fiber:0,salt:0}};});
-    return{id:Date.now().toString(),name:d.n||'Importiertes Rezept',emoji:d.e||'📋',ingredients:ings,instructions:d.ins||''};
-  }catch(ex){return null;}
+function _encodePayload(obj){
+  try{return btoa(unescape(encodeURIComponent(JSON.stringify(obj))));}catch(e){return null;}
 }
-
-function _recipeShareUrl(rec){
-  var code=_encodeRecipeCode(rec);
-  if(!code)return null;
-  return location.origin+location.pathname+'#r='+encodeURIComponent(code);
+function _decodePayload(code){
+  try{return JSON.parse(decodeURIComponent(escape(atob(String(code).trim().replace(/\s+/g,'')))));}catch(e){return null;}
 }
-
-function _recipeSummary(rec){
-  var ings=rec.ingredients||[];
-  var t=ingTotal(ings);
-  return ings.length+' Zutat'+(ings.length===1?'':'en')+' · '+Math.round(t.kcal)+' kcal';
+function _buildShareUrl(payload){
+  var code=_encodePayload(payload);
+  if(!code)return{url:null,code:null};
+  return{url:location.origin+location.pathname+'#x='+encodeURIComponent(code),code:code};
 }
-
-function _extractRecipeCode(input){
-  if(!input)return '';
+function _extractShareCode(input){
+  if(!input)return null;
   var s=String(input).trim();
-  var m=s.match(/[#?&]r=([^&\s]+)/);
-  if(m){
-    var c=m[1];
-    try{c=decodeURIComponent(c);}catch(e){}
-    return c.replace(/\s+/g,'');
+  var m=s.match(/[#?&]x=([^&\s]+)/);
+  if(m){var c=m[1];try{c=decodeURIComponent(c);}catch(e){}return{legacy:false,code:c.replace(/\s+/g,'')};}
+  m=s.match(/[#?&]r=([^&\s]+)/);
+  if(m){var c=m[1];try{c=decodeURIComponent(c);}catch(e){}return{legacy:true,code:c.replace(/\s+/g,'')};}
+  return{legacy:false,code:s.replace(/\s+/g,'')};
+}
+function _normalizePayload(d,legacy){
+  if(!d)return null;
+  // Legacy v0.138 recipe format: no 't', has 'n' + 'i' + 'e' (emoji)
+  if(!d.t){
+    if(legacy||(d.n&&Array.isArray(d.i))){d.t='r';if(d.e&&!d.em)d.em=d.e;}
+    else return null;
   }
-  return s.replace(/\s+/g,'');
+  return d;
 }
 
-function openRecipeCodeShare(id){
-  var wrap=document.getElementById('recipeCodeExportWrap');
-  var textEl=document.getElementById('recipeCodeText');
-  var importEl=document.getElementById('recipeImportCodeInput');
-  importEl.value='';
-  if(id){
-    var rec=recipes.find(function(r){return r.id===id;});
-    if(rec){
-      var code=_encodeRecipeCode(rec);
-      var url=_recipeShareUrl(rec);
-      if(code&&url){
-        textEl.value=code;
-        document.getElementById('recipeShareUrl').value=url;
-        document.getElementById('recipeShareName').textContent=(rec.emoji||'📋')+' '+rec.name;
-        document.getElementById('recipeShareSummary').textContent=_recipeSummary(rec);
-        wrap.style.display='block';
-      } else {
-        wrap.style.display='none';
-      }
-    } else {
-      wrap.style.display='none';
-    }
-  } else {
-    wrap.style.display='none';
-  }
-  openOv('recipeCodeOv');
+// ─── SHORTENER (is.gd, CORS-offen) ───
+function _shortenUrl(longUrl,onDone){
+  var done=false;var fin=function(u){if(done)return;done=true;onDone(u);};
+  // 4s timeout — falls is.gd lahmt, lieber Originallink anbieten
+  setTimeout(function(){fin(longUrl);},4000);
+  if(!isOnline){fin(longUrl);return;}
+  try{
+    fetch('https://is.gd/create.php?format=simple&url='+encodeURIComponent(longUrl))
+      .then(function(r){return r.ok?r.text():null;})
+      .then(function(t){
+        var s=(t||'').trim();
+        if(s&&/^https?:\/\/(is\.gd|v\.gd)\//.test(s))fin(s);
+        else fin(longUrl);
+      })
+      .catch(function(){fin(longUrl);});
+  }catch(e){fin(longUrl);}
 }
 
-function shareRecipeLink(){
-  var url=document.getElementById('recipeShareUrl').value;
-  var name=document.getElementById('recipeShareName').textContent||'Rezept';
-  if(!url){showToast('Kein Link verfügbar');return;}
-  if(navigator.share){
-    navigator.share({title:name,text:'Rezept aus NutriTrack: '+name,url:url}).catch(function(err){
-      // user cancelled or share failed → silent on AbortError, otherwise fall back to copy
-      if(err&&err.name!=='AbortError')copyRecipeLink();
-    });
-  } else {
-    copyRecipeLink();
-  }
-}
-
-function copyRecipeLink(){
-  var url=document.getElementById('recipeShareUrl').value;
-  if(!url){showToast('Kein Link verfügbar');return;}
-  if(navigator.clipboard&&navigator.clipboard.writeText){
-    navigator.clipboard.writeText(url).then(function(){showToast('Link kopiert ✓');},function(){_fallbackCopy(url);});
-  } else {
-    _fallbackCopy(url);
-  }
-}
-
+// ─── FALLBACK CLIPBOARD ───
 function _fallbackCopy(text){
   try{
     var t=document.createElement('textarea');
@@ -2810,70 +2726,237 @@ function _fallbackCopy(text){
     document.body.appendChild(t);t.select();
     document.execCommand('copy');
     document.body.removeChild(t);
-    showToast('Link kopiert ✓');
+    showToast('Kopiert ✓');
   }catch(e){showToast('Kopieren nicht möglich');}
 }
-
-function copyRecipeCode(){
-  var t=document.getElementById('recipeCodeText');
-  if(!t)return;
+function _copyToClipboard(text,label){
   if(navigator.clipboard&&navigator.clipboard.writeText){
-    navigator.clipboard.writeText(t.value).then(function(){showToast('Code kopiert ✓');},function(){t.select();document.execCommand('copy');showToast('Code kopiert ✓');});
+    navigator.clipboard.writeText(text).then(
+      function(){showToast((label||'Link')+' kopiert ✓');},
+      function(){_fallbackCopy(text);}
+    );
+  } else {_fallbackCopy(text);}
+}
+
+// ─── ZENTRALE SHARE-FUNKTION ───
+function _shareItem(payload,name,summary){
+  if(!payload){showToast('Nichts zum Teilen');return;}
+  var built=_buildShareUrl(payload);
+  if(!built.url){showToast('Teilen fehlgeschlagen');return;}
+  var titleMap={r:'📤 Rezept teilen',f:'📤 Lebensmittel teilen',m:'📤 Mahlzeit teilen'};
+  document.getElementById('shareItemTitle').textContent=titleMap[payload.t]||'📤 Teilen';
+  document.getElementById('shareItemName').textContent=(payload.em||(payload.t==='m'?'🍽':'📋'))+' '+name;
+  document.getElementById('shareItemSummary').textContent=summary;
+  document.getElementById('shareItemUrlLong').value=built.url;
+  document.getElementById('shareItemUrl').value=built.url;
+  document.getElementById('shareItemCode').value=built.code;
+  document.getElementById('shareItemCodeText').value=built.code;
+  var status=document.getElementById('shareItemShortStatus');
+  status.textContent='⏳ Kurzlink wird erstellt …';
+  _shortenUrl(built.url,function(short){
+    document.getElementById('shareItemUrl').value=short;
+    if(short!==built.url){
+      status.innerHTML='✓ Kurzlink: <span style="font-family:monospace;">'+short+'</span>';
+    } else {
+      status.textContent='Kurzlink offline – langer Link wird verwendet';
+    }
+  });
+  openOv('shareItemOv');
+}
+
+function shareItemDoShare(){
+  var url=document.getElementById('shareItemUrl').value;
+  var name=document.getElementById('shareItemName').textContent||'NutriTrack';
+  if(!url){showToast('Kein Link verfügbar');return;}
+  if(navigator.share){
+    navigator.share({title:name,text:name,url:url}).catch(function(err){
+      if(err&&err.name!=='AbortError')_copyToClipboard(url,'Link');
+    });
+  } else {_copyToClipboard(url,'Link');}
+}
+function shareItemDoCopy(){
+  var url=document.getElementById('shareItemUrl').value;
+  if(!url){showToast('Kein Link verfügbar');return;}
+  _copyToClipboard(url,'Link');
+}
+function shareItemDoCopyCode(){
+  var c=document.getElementById('shareItemCode').value;
+  if(!c)return;_copyToClipboard(c,'Code');
+}
+
+// ─── TYP-SPEZIFISCHE SHARE-EINSTIEGE ───
+function shareRecipe(id){
+  var rec=recipes.find(function(r){return r.id===id;});
+  if(!rec){showToast('Rezept nicht gefunden');return;}
+  var ings=rec.ingredients||[];
+  var payload={t:'r',n:rec.name,em:rec.emoji||'📋',i:ings.map(function(ing){return{n:ing.name,em:ing.emoji,a:ing.amount,p:{k:Math.round(ing.per100.kcal),pr:Math.round((ing.per100.protein||0)*10)/10,c:Math.round((ing.per100.carbs||0)*10)/10,f:Math.round((ing.per100.fat||0)*10)/10}};})};
+  if(rec.instructions)payload.ins=rec.instructions;
+  var t=ingTotal(ings);
+  var summary=ings.length+' Zutat'+(ings.length===1?'':'en')+' · '+Math.round(t.kcal)+' kcal';
+  _shareItem(payload,rec.name,summary);
+}
+function shareMeal(meal){
+  var entries=getDay().meals[meal]||[];
+  if(!entries.length){showToast('Keine Einträge zum Teilen');return;}
+  var payload={t:'m',m:meal,e:entries.map(function(e){
+    if(e.isRecipe){
+      return{t:'r',n:e.name,em:e.emoji,p:e.portions||1,i:(e.ingredients||[]).map(function(ing){return{n:ing.name,em:ing.emoji,a:ing.amount,p:{k:Math.round(ing.per100.kcal),pr:Math.round((ing.per100.protein||0)*10)/10,c:Math.round((ing.per100.carbs||0)*10)/10,f:Math.round((ing.per100.fat||0)*10)/10}};})};
+    }
+    return{t:'f',n:e.name,em:e.emoji,a:e.amount,p:{k:Math.round(e.per100&&e.per100.kcal||e.kcal||0),pr:Math.round((e.per100&&e.per100.protein||e.protein||0)*10)/10,c:Math.round((e.per100&&e.per100.carbs||e.carbs||0)*10)/10,f:Math.round((e.per100&&e.per100.fat||e.fat||0)*10)/10}};
+  })};
+  var totalKcal=entries.reduce(function(a,e){return a+(e.kcal||0);},0);
+  var summary=entries.length+' Eintr'+(entries.length===1?'ag':'äge')+' · '+Math.round(totalKcal)+' kcal';
+  _shareItem(payload,MEAL_NAMES[meal],summary);
+}
+function shareLibFood(filteredIdx){
+  var f=(window._libFoods||[])[filteredIdx];
+  if(!f){showToast('Lebensmittel nicht gefunden');return;}
+  var payload={t:'f',n:f.name,em:f.emoji||'🍽',p:{k:Math.round(f.per100.kcal||0),pr:Math.round((f.per100.protein||0)*10)/10,c:Math.round((f.per100.carbs||0)*10)/10,f:Math.round((f.per100.fat||0)*10)/10}};
+  var summary=Math.round(f.per100.kcal||0)+' kcal · '+Math.round(f.per100.protein||0)+'g P · '+Math.round(f.per100.carbs||0)+'g KH · '+Math.round(f.per100.fat||0)+'g F (pro 100g)';
+  _shareItem(payload,f.name,summary);
+}
+function shareCustomFood(idx){
+  var f=customFoods[idx];
+  if(!f){showToast('Lebensmittel nicht gefunden');return;}
+  var payload={t:'f',n:f.name,em:f.emoji||'🍽',p:{k:Math.round(f.per100.kcal||0),pr:Math.round((f.per100.protein||0)*10)/10,c:Math.round((f.per100.carbs||0)*10)/10,f:Math.round((f.per100.fat||0)*10)/10}};
+  var summary=Math.round(f.per100.kcal||0)+' kcal · '+Math.round(f.per100.protein||0)+'g P · '+Math.round(f.per100.carbs||0)+'g KH · '+Math.round(f.per100.fat||0)+'g F (pro 100g)';
+  _shareItem(payload,f.name,summary);
+}
+function shareEntryAsFood(meal,idx){
+  var e=getDay().meals[meal][idx];
+  if(!e){showToast('Eintrag nicht gefunden');return;}
+  if(e.isRecipe&&e.recipeId){shareRecipe(e.recipeId);return;}
+  var per100=e.per100||{kcal:e.kcal||0,protein:e.protein||0,carbs:e.carbs||0,fat:e.fat||0};
+  var payload={t:'f',n:e.name,em:e.emoji||'🍽',p:{k:Math.round(per100.kcal||0),pr:Math.round((per100.protein||0)*10)/10,c:Math.round((per100.carbs||0)*10)/10,f:Math.round((per100.fat||0)*10)/10}};
+  var summary=Math.round(per100.kcal||0)+' kcal · '+Math.round(per100.protein||0)+'g P · '+Math.round(per100.carbs||0)+'g KH · '+Math.round(per100.fat||0)+'g F (pro 100g)';
+  _shareItem(payload,e.name,summary);
+}
+
+// ─── IMPORT: VORSCHAU + BESTÄTIGUNG ───
+var _pendingImport=null;
+
+function _materializeRecipe(d){
+  var ings=(d.i||[]).map(function(x){return{name:x.n,emoji:x.em||x.e,amount:x.a||100,per100:{kcal:x.p.k||0,protein:x.p.pr||0,carbs:x.p.c||0,fat:x.p.f||0,sugar:0,fiber:0,salt:0}};});
+  return{id:Date.now().toString(),name:d.n||'Importiertes Rezept',emoji:d.em||d.e||'📋',ingredients:ings,instructions:d.ins||''};
+}
+function _materializeFood(d){
+  return{name:d.n||'Importiertes Lebensmittel',emoji:d.em||d.e||'🍽',per100:{kcal:d.p.k||0,protein:d.p.pr||0,carbs:d.p.c||0,fat:d.p.f||0,sugar:0,fiber:0,salt:0}};
+}
+function _materializeMealEntries(d){
+  return(d.e||[]).map(function(x){
+    if(x.t==='r'){
+      var ings=(x.i||[]).map(function(ing){return{name:ing.n,emoji:ing.em,amount:ing.a||100,per100:{kcal:ing.p.k||0,protein:ing.p.pr||0,carbs:ing.p.c||0,fat:ing.p.f||0,sugar:0,fiber:0,salt:0}};});
+      var t=ingTotal(ings);
+      return Object.assign({name:x.n,emoji:x.em,isRecipe:true,recipeId:null,portions:x.p||1,ingredients:ings},scaleNutrients(t,x.p||1));
+    }
+    var per100={kcal:x.p.k||0,protein:x.p.pr||0,carbs:x.p.c||0,fat:x.p.f||0,sugar:0,fiber:0,salt:0};
+    var r=(x.a||100)/100;
+    return Object.assign({name:x.n,emoji:x.em,amount:x.a||100,per100:per100},scaleNutrients(per100,r));
+  });
+}
+
+function _previewImport(d){
+  if(!d){showToast('Ungültiges Format');return;}
+  var titleEl=document.getElementById('importConfirmTitle');
+  var subEl=document.getElementById('importConfirmSubtitle');
+  var nameEl=document.getElementById('importConfirmName');
+  var summaryEl=document.getElementById('importConfirmSummary');
+  var detailEl=document.getElementById('importConfirmDetail');
+  var insEl=document.getElementById('importConfirmIns');
+  var mealRow=document.getElementById('importConfirmMealRow');
+  var btn=document.getElementById('importConfirmBtn');
+  insEl.style.display='none';mealRow.style.display='none';
+
+  if(d.t==='r'){
+    var ings=d.i||[];
+    var totalK=ings.reduce(function(a,g){var r=(g.a||0)/100;return a+(g.p.k||0)*r;},0);
+    titleEl.textContent='📥 Rezept importieren?';
+    subEl.textContent='Du hast einen Rezept-Link geöffnet';
+    nameEl.textContent=(d.em||'📋')+' '+d.n;
+    summaryEl.textContent=ings.length+' Zutat'+(ings.length===1?'':'en')+' · '+Math.round(totalK)+' kcal';
+    detailEl.innerHTML=ings.map(function(i){return(i.em||'🍽')+' '+i.n+' <span style="color:var(--mu);">('+(i.a||0)+'g)</span>';}).join(' · ');
+    if(d.ins){insEl.style.display='block';insEl.textContent=d.ins.length>240?d.ins.substring(0,240)+'…':d.ins;}
+    btn.textContent='✅ In Bibliothek speichern';
+  } else if(d.t==='f'){
+    titleEl.textContent='📥 Lebensmittel importieren?';
+    subEl.textContent='Du hast einen Lebensmittel-Link geöffnet';
+    nameEl.textContent=(d.em||'🍽')+' '+d.n;
+    summaryEl.textContent='Werte pro 100g';
+    detailEl.innerHTML='kcal: <strong>'+(d.p.k||0)+'</strong> · Protein: <strong>'+(d.p.pr||0)+'g</strong> · KH: <strong>'+(d.p.c||0)+'g</strong> · Fett: <strong>'+(d.p.f||0)+'g</strong>';
+    btn.textContent='✅ In Bibliothek speichern';
+  } else if(d.t==='m'){
+    var entries=d.e||[];
+    var totalKcal=entries.reduce(function(a,e){
+      if(e.t==='r'){
+        var ek=(e.i||[]).reduce(function(s,i){return s+(i.p.k||0)*(i.a||0)/100;},0);
+        return a+ek*(e.p||1);
+      }
+      return a+(e.p.k||0)*(e.a||0)/100;
+    },0);
+    titleEl.textContent='📥 Mahlzeit importieren?';
+    subEl.textContent='Du hast einen Mahlzeit-Link geöffnet';
+    nameEl.textContent='🍽 '+(MEAL_NAMES[d.m]||'Mahlzeit');
+    summaryEl.textContent=entries.length+' Eintr'+(entries.length===1?'ag':'äge')+' · '+Math.round(totalKcal)+' kcal';
+    detailEl.innerHTML=entries.map(function(e){return(e.em||'🍽')+' '+e.n;}).join(' · ');
+    mealRow.style.display='block';
+    document.getElementById('importConfirmMealTarget').value=d.m||'breakfast';
+    btn.textContent='✅ Einträge übernehmen';
   } else {
-    t.select();document.execCommand('copy');showToast('Code kopiert ✓');
+    showToast('Unbekannter Typ');return;
   }
+  _pendingImport=d;
+  openOv('importConfirmOv');
 }
 
-function importRecipeCode(){
-  var raw=document.getElementById('recipeImportCodeInput').value;
+function importConfirm(){
+  var d=_pendingImport;if(!d)return;
+  if(d.t==='r'){
+    recipes.unshift(_materializeRecipe(d));saveX();
+    showToast('✅ Rezept "'+d.n+'" gespeichert');
+  } else if(d.t==='f'){
+    customFoods.unshift(_materializeFood(d));saveX();
+    showToast('✅ Lebensmittel "'+d.n+'" gespeichert');
+  } else if(d.t==='m'){
+    var target=document.getElementById('importConfirmMealTarget').value||'breakfast';
+    var entries=_materializeMealEntries(d);
+    entries.forEach(function(e){getDay().meals[target].push(e);});
+    saveS();
+    showToast('✅ '+entries.length+' Einträge in '+MEAL_NAMES[target]+' importiert');
+  }
+  _pendingImport=null;
+  closeOv('importConfirmOv');
+  if(typeof renderAll==='function')renderAll();
+  if(typeof renderLibrary==='function')renderLibrary();
+  if(typeof renderSettFoodList==='function')renderSettFoodList();
+}
+
+function importPasted(){
+  var raw=document.getElementById('importPasteInput').value;
   if(!raw||!raw.trim()){showToast('Link oder Code eingeben');return;}
-  var code=_extractRecipeCode(raw);
-  var rec=_decodeRecipeCode(code);
-  if(!rec){showToast('Ungültiger Link/Code');return;}
-  recipes.unshift(rec);saveX();
-  closeOv('recipeCodeOv');
-  showToast('✅ "'+rec.name+'" importiert');
+  var ext=_extractShareCode(raw);
+  if(!ext){showToast('Ungültig');return;}
+  var d=_normalizePayload(_decodePayload(ext.code),ext.legacy);
+  if(!d){showToast('Ungültiger Link/Code');return;}
+  closeOv('importPasteOv');
+  setTimeout(function(){_previewImport(d);},150);
 }
 
-// ─── REZEPT-IMPORT VIA GETEILTEM LINK (#r= / ?r=) ───
-var _pendingImportRecipe=null;
+function openImportPaste(){
+  document.getElementById('importPasteInput').value='';
+  openOv('importPasteOv');
+}
 
-function _checkSharedRecipeOnBoot(){
+// ─── AUTO-IMPORT BEIM BOOT (geteilter Link geöffnet) ───
+function _checkSharedItemOnBoot(){
   try{
     var blob=(location.hash||'')+' '+(location.search||'');
-    var m=blob.match(/[#?&]r=([^&\s]+)/);
-    if(!m)return;
-    var code=m[1];
-    try{code=decodeURIComponent(code);}catch(e){}
-    var rec=_decodeRecipeCode(code);
-    // Clear URL so a refresh doesn't re-trigger the import
+    var ext=_extractShareCode(blob);
+    if(!ext||!/[#?&][xr]=/.test(blob))return;
+    var d=_normalizePayload(_decodePayload(ext.code),ext.legacy);
     try{history.replaceState(null,'',location.pathname);}catch(e){}
-    if(!rec)return;
-    _pendingImportRecipe=rec;
-    var ings=rec.ingredients||[];
-    document.getElementById('recipeImportConfirmTitle').textContent=(rec.emoji||'📋')+' '+rec.name;
-    document.getElementById('recipeImportConfirmSummary').textContent=_recipeSummary(rec);
-    document.getElementById('recipeImportConfirmIngs').innerHTML=ings.map(function(i){return(i.emoji||'🍽')+' '+i.name+' <span style="color:var(--mu);">('+(i.amount||0)+'g)</span>';}).join(' · ');
-    var insEl=document.getElementById('recipeImportConfirmIns');
-    if(rec.instructions){
-      insEl.style.display='block';
-      var ins=rec.instructions;
-      insEl.textContent=ins.length>240?ins.substring(0,240)+'…':ins;
-    } else {
-      insEl.style.display='none';
-    }
-    setTimeout(function(){openOv('recipeImportConfirmOv');},300);
+    if(!d)return;
+    setTimeout(function(){_previewImport(d);},300);
   }catch(e){}
-}
-
-function confirmRecipeImport(){
-  if(!_pendingImportRecipe)return;
-  var rec=_pendingImportRecipe;
-  recipes.unshift(rec);saveX();
-  _pendingImportRecipe=null;
-  closeOv('recipeImportConfirmOv');
-  showToast('✅ "'+rec.name+'" gespeichert');
-  if(typeof renderAll==='function')renderAll();
 }
 
 // ════════════════════════════════════════
@@ -4550,7 +4633,7 @@ function renderLibrary(){
           +'</div>'
           +'<button type="button" onclick="openRecipeEditor(this.dataset.rid)" data-rid="'+r.id+'" style="background:none;border:none;font-size:18px;color:var(--g2);padding:4px;">✏️</button>'
           +'<button type="button" onclick="duplicateRecipe(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Duplizieren">⎘</button>'
-          +'<button type="button" onclick="openRecipeCodeShare(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Teilen">📤</button>'
+          +'<button type="button" onclick="shareRecipe(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Teilen">📤</button>'
           +'<button type="button" onclick="openShoppingList(\''+r.id+'\')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Einkaufsliste">🛒</button>'
           +'<button type="button" onclick="libAddRecipe(this.dataset.rid)" data-rid="'+r.id+'" style="background:var(--g2);border:none;border-radius:8px;color:white;font-size:18px;padding:4px 8px;">+</button>'
           +'</div>';
@@ -4569,6 +4652,7 @@ function renderLibrary(){
       window._libFoods=filtered;
     filtered.forEach(function(f,i){
       var editBtn=f.isCustom?('<button type="button" onclick="openOwnFoodEdit('+i+')" style="background:none;border:none;font-size:16px;color:var(--g2);padding:4px;">&#9998;</button>'):'';
+      var shareBtn='<button type="button" onclick="shareLibFood('+i+')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Teilen">📤</button>';
       html+='<div style="background:white;border-radius:12px;padding:10px 14px;box-shadow:var(--sh);display:flex;align-items:center;gap:10px;">'
         +'<div style="font-size:22px;">'+(f.emoji||'&#127374;')+'</div>'
         +'<div style="flex:1;min-width:0;">'
@@ -4576,6 +4660,7 @@ function renderLibrary(){
           +'<div style="font-size:11px;color:var(--mu);margin-top:1px;">'+Math.round(f.per100.kcal)+' kcal pro 100g</div>'
         +'</div>'
         +editBtn
+        +shareBtn
         +'<button type="button" onclick="libAddFood('+i+')" style="background:var(--g2);border:none;border-radius:8px;color:white;font-size:18px;width:32px;height:32px;">+</button>'
         +'</div>';
     })

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,10 @@
   "start_url": "/nutritrack/",
   "scope": "/nutritrack/",
   "display": "standalone",
+  "handle_links": "preferred",
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  },
   "orientation": "portrait-primary",
   "background_color": "#2d7d52",
   "theme_color": "#2d7d52",

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.138';
+var VERSION = '0.139';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
 


### PR DESCRIPTION
## Summary

Drei zusammenhängende Verbesserungen am v0.138-Sharing-Flow:

### 1. Kurzlink via is.gd
- Lange Base64-URLs (~570 Zeichen) werden auf `https://is.gd/abc123` verkürzt — passt in jede WhatsApp-Vorschau, kein Zeilenumbruch mehr.
- 4 s-Timeout — fällt bei Offline / Shortener-Ausfall sauber auf den Originallink zurück (kein blockierender UI-Hänger).
- Status-Zeile im Share-Modal zeigt live `⏳ Kurzlink wird erstellt` → `✓ Kurzlink: …` oder `Kurzlink offline`.

### 2. Android-PWA-Routing
- `manifest.json`: `"handle_links": "preferred"` + `"launch_handler": {"client_mode": "navigate-existing"}`.
- Chrome ≥97 öffnet geteilte Links zur eigenen Origin direkt in der installierten PWA-Instanz statt im Browser-Tab.
- iOS ignoriert die Manifest-Einträge stillschweigend — Apple bietet keine PWA-URL-Routing-API. Da Safari und PWA dieselbe `localStorage` teilen, landet das importierte Rezept dort trotzdem in der App.

### 3. Eine Funktion für alles (DRY-Refactor)
- **Einheitliches Payload-Schema** mit `t`-Feld: `r` = Rezept, `f` = Lebensmittel, `m` = Mahlzeit. URL-Format vereinheitlicht: `#x=<base64>`.
- **Drei alte Modale** (`recipeCodeOv`, `recipeImportConfirmOv`, `mealCodeOv`) ersetzt durch **drei generische**: `shareItemOv`, `importPasteOv`, `importConfirmOv`. Eine Implementierung für alle Typen.
- **Erstmals: eigene Lebensmittel teilen + importieren** — Bibliothek (Lebensmittel-Tab → 📤 pro Eintrag) und Eintragsmenü (Hauptansicht → Eintrag antippen → „📤 Lebensmittel teilen").
- **Eintragsmenü** zeigt jetzt für alle Einträge eine Teilen-Option (vorher nur für Rezept-Einträge).
- **Import-Vorschau** erkennt Typ automatisch und zeigt passende Vorschau (Zutaten / Nährwerte / Anzahl Einträge). Bei Mahlzeiten: Mahlzeit-Ziel-Selector (Frühstück/Mittag/Abend/Snack).
- **Rückwärtskompatibel:** alte v0.138-Links mit `#r=…` funktionieren weiter (Legacy-Detect im Extractor).

### Cross-platform
- Alle APIs identisch auf iOS Safari + Chrome Android: `navigator.share`, `clipboard.writeText`, `fetch`, `history.replaceState`, `<details>`. Keine Plattform-Forks im Code.
- Round-trip-Test: Rezept (URL ~350 Zeichen), Lebensmittel (~140), Mahlzeit mit gemischten Einträgen (~350) — alle 3 Typen + Legacy `#r=` + Roh-Code-Paste dekodieren korrekt.

## Test plan

- [ ] **Android Chrome PWA**: Rezept teilen → is.gd-Kurzlink an WhatsApp → antippen → öffnet PWA direkt → Import-Dialog erscheint
- [ ] **iOS Safari PWA**: Rezept teilen → is.gd-Kurzlink an WhatsApp → antippen → öffnet Safari → Import-Dialog erscheint → Speichern → Rezept ist auch in der PWA da (Storage-Sharing)
- [ ] **Lebensmittel teilen**: Bibliothek → Lebensmittel-Tab → 📤 → Empfänger importiert → in Bibliothek sichtbar
- [ ] **Mahlzeit teilen**: Frühstück 📤 → Empfänger wählt Ziel-Mahlzeit → Einträge übernommen
- [ ] **Eintragsmenü**: Eintrag antippen → 📤 → Funktioniert für Rezept- und Lebensmittel-Einträge
- [ ] **Code-Fallback**: Im Share-Modal „Erweitert: Code statt Link" → Code kopieren → in andere App einfügen → dort über 📥 importieren
- [ ] **Legacy-Kompat**: alten v0.138-Link mit `#r=` einlösen → funktioniert weiter
- [ ] **Offline-Fallback**: Internet aus → Share öffnen → nach 4 s wechselt zu „Kurzlink offline" und zeigt Originallink

---
_Generated by [Claude Code](https://claude.ai/code/session_013mBYT8p8tgaqpeH8w3n7qL)_