### PR TITLE
feat: Eigener Kurzlink-Service auf Cloudflare Worker (v0.140)

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.139</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.140</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.139</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.140</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1357,7 +1357,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.139';
+var APP_VERSION='0.140';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1386,6 +1386,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.140',items:[
+    {icon:'🔗',text:'Eigener Kurzlink-Service auf dem Cloudflare Worker statt is.gd: aus dem ~570-Zeichen-Link wird "https://nutritrack-ai-proxy.h-jolmes.workers.dev/s/Ab12X3y" (~58 Zeichen). Funktioniert dauerhaft (kein Drittanbieter, eigene KV-Storage), 1 Jahr Lebenszeit pro Link, ID alphanumerisch ohne 0/O/1/I/l. Fallback weiterhin: is.gd → langer Link',where:'Jeder 📤 Share-Button'},
+  ]},
   {v:'0.139',items:[
     {icon:'🔗',text:'Teilen via Kurzlink: Lange Base64-URLs werden über is.gd zu „is.gd/abc123" verkürzt – passt in jede WhatsApp-Vorschau, kein Zeilenumbruch mehr. Fallback auf Original-Link wenn der Shortener offline ist',where:'Jeder 📤 Share-Button'},
     {icon:'📲',text:'Auf Android (Chrome ≥97) öffnen geteilte Links jetzt direkt die installierte PWA statt den Browser-Tab. Auf iOS bleibt der Safari-Pfad (Apple bietet keine PWA-URL-Routing-API), aber das Rezept landet trotzdem in der App – Safari und PWA teilen sich denselben Speicher',where:'Manifest: handle_links + launch_handler'},
@@ -2700,21 +2703,39 @@ function _normalizePayload(d,legacy){
   return d;
 }
 
-// ─── SHORTENER (is.gd, CORS-offen) ───
-function _shortenUrl(longUrl,onDone){
+// ─── SHORTENER ───
+// Primary: eigener Cloudflare Worker (KV-backed, dauerhaft, CORS unter Kontrolle).
+// Fallback: is.gd (CORS-offen, falls Worker temporär 503 oder KV nicht konfiguriert).
+// Final: Originallink.
+var SHARE_WORKER_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
+
+function _shortenUrl(payloadCode,longUrl,onDone){
   var done=false;var fin=function(u){if(done)return;done=true;onDone(u);};
-  // 4s timeout — falls is.gd lahmt, lieber Originallink anbieten
-  setTimeout(function(){fin(longUrl);},4000);
+  setTimeout(function(){fin(longUrl);},6000);
   if(!isOnline){fin(longUrl);return;}
+  // 1) Eigener Worker
+  var ctrl=null;
   try{
-    fetch('https://is.gd/create.php?format=simple&url='+encodeURIComponent(longUrl))
-      .then(function(r){return r.ok?r.text():null;})
-      .then(function(t){
-        var s=(t||'').trim();
-        if(s&&/^https?:\/\/(is\.gd|v\.gd)\//.test(s))fin(s);
-        else fin(longUrl);
+    fetch(SHARE_WORKER_URL+'/share',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({code:payloadCode})
+    }).then(function(r){return r.ok?r.json():null;})
+      .then(function(j){
+        if(j&&j.data&&j.data.short&&/^https?:\/\//.test(j.data.short)){fin(j.data.short);return;}
+        throw new Error('worker-share-failed');
       })
-      .catch(function(){fin(longUrl);});
+      .catch(function(){
+        // 2) is.gd Fallback
+        return fetch('https://is.gd/create.php?format=simple&url='+encodeURIComponent(longUrl))
+          .then(function(r){return r.ok?r.text():null;})
+          .then(function(t){
+            var s=(t||'').trim();
+            if(s&&/^https?:\/\/(is|v)\.gd\//.test(s))fin(s);
+            else fin(longUrl);
+          })
+          .catch(function(){fin(longUrl);});
+      });
   }catch(e){fin(longUrl);}
 }
 
@@ -2753,10 +2774,10 @@ function _shareItem(payload,name,summary){
   document.getElementById('shareItemCodeText').value=built.code;
   var status=document.getElementById('shareItemShortStatus');
   status.textContent='⏳ Kurzlink wird erstellt …';
-  _shortenUrl(built.url,function(short){
+  _shortenUrl(built.code,built.url,function(short){
     document.getElementById('shareItemUrl').value=short;
     if(short!==built.url){
-      status.innerHTML='✓ Kurzlink: <span style="font-family:monospace;">'+short+'</span>';
+      status.innerHTML='✓ Kurzlink: <span style="font-family:monospace;font-size:11px;word-break:break-all;">'+short+'</span>';
     } else {
       status.textContent='Kurzlink offline – langer Link wird verwendet';
     }

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.139';
+var VERSION = '0.140';
 var CACHE = 'nt-' + VERSION;
-var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net'];
+var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 
 self.addEventListener('install', function(e) {
   // Sofort aktivieren ohne auf alte Tabs zu warten

--- a/worker/README.md
+++ b/worker/README.md
@@ -7,6 +7,8 @@ This Worker proxies NutriTrack AI requests to Anthropic so the real Anthropic AP
 - `GET  /health` – status JSON, no auth.
 - `POST /v1/messages` – generic Anthropic Messages proxy (used by KI-Foto/Chat features). Body is JSON forwarded to `api.anthropic.com/v1/messages`.
 - `POST /decode-barcode` – live barcode decoder. Body is a raw JPEG (max 200 KB). Returns `{ ok: true, data: { code, found, source, ... } }`. Used by the Barcode-Tab to decode each frame on iPhones where local WASM decoders fail.
+- `POST /share` – speichert einen Share-Code (Rezept / Mahlzeit / Lebensmittel) in KV und gibt eine 7-Zeichen-Kurz-ID zurück. Body: `{"code":"<base64>"}` (max 8 KB). Antwort: `{ok:true,data:{id,short}}`. TTL: 1 Jahr. CORS auf PWA-Origin beschränkt, kein Token erforderlich.
+- `GET  /s/<id>` – schlägt die Kurz-ID in KV nach und antwortet mit einer Mini-HTML-Seite, die per `location.replace()` zu `https://hjolmes.github.io/nutritrack/#x=<code>` weiterleitet (Fragment-Redirect via Location-Header ist nicht zuverlässig in allen Browsern).
 
   **Decode pipeline (since v0.137):**
   1. **Primary path:** posts the JPEG to the OSS-Decoder microservice at `DECODER_URL` (OpenCV `BarcodeDetector` + pyzbar — see `decoder/`). Hit returns immediately with `source: "opencv"`. Free, ~30–150 ms warm.
@@ -37,6 +39,36 @@ All POST endpoints require the `x-app-proxy-secret` header to match `NUTRITRACK_
 10. In `index.html`, set:
    - `PROJECT_AI_PROXY_URL` to `<Worker URL>/v1/messages`
    - `PROJECT_AI_PROXY_SECRET` to the same value as `NUTRITRACK_PROXY_TOKEN`
+
+## KV-Storage für Share-Link-Shortener (seit v0.140)
+
+Damit `POST /share` und `GET /s/<id>` funktionieren, braucht der Worker einen KV-Namespace mit Binding-Name `SHARE_KV`.
+
+**Einmaliger Setup via Wrangler:**
+
+```bash
+wrangler kv namespace create nutritrack-shares
+# → Output enthaelt eine ID, z.B.:
+#   { binding = "SHARE_KV", id = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d" }
+```
+
+Dann in `wrangler.toml` die `id` unter `[[kv_namespaces]]` ersetzen (`REPLACE_WITH_KV_NAMESPACE_ID`).
+
+**Alternativ via Cloudflare Dashboard:**
+
+1. `Workers & Pages` → `KV` → `Create namespace` → Name `nutritrack-shares`.
+2. Worker auswählen → `Settings` → `Variables and Secrets` → `KV Namespace Bindings` → `Add binding`:
+   - Variable name: `SHARE_KV`
+   - KV namespace: `nutritrack-shares`
+
+Health-Check `GET /health` zeigt `shareConfigured: true` wenn der Binding aktiv ist. Ist KV nicht konfiguriert, gibt der Worker `503 kv_not_configured` zurück und die PWA fällt automatisch auf is.gd / Originallink zurück.
+
+Free Tier deckt unsere Volumina locker ab:
+- 100k Reads/Tag (Empfaenger tippt Link an)
+- 1k Writes/Tag (Sender erstellt neuen Kurzlink)
+- 1 GB Storage gesamt
+
+TTL pro Eintrag: 1 Jahr (`SHARE_TTL_SECONDS`). Löschung läuft automatisch.
 
 ## GitHub Setup
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -253,6 +253,88 @@ async function handleDecodeBarcode(request, origin, env) {
   });
 }
 
+// ─── SHARE-LINK SHORTENER (KV-backed) ───
+const SHARE_ID_LEN = 7;
+const SHARE_TTL_SECONDS = 60 * 60 * 24 * 365; // 1 year
+const MAX_SHARE_CODE_BYTES = 1024 * 8; // 8 KB; recipes ~600 chars
+const SHARE_TARGET_BASE = "https://hjolmes.github.io/nutritrack/";
+// Base58-ish (no 0/O/1/I/l) – avoids visual confusion in shared URLs
+const SHARE_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
+
+function generateShareId() {
+  const arr = new Uint8Array(SHARE_ID_LEN);
+  crypto.getRandomValues(arr);
+  let id = "";
+  for (let i = 0; i < SHARE_ID_LEN; i++) id += SHARE_ALPHABET[arr[i] % SHARE_ALPHABET.length];
+  return id;
+}
+
+async function handleShareCreate(request, origin, env) {
+  if (origin && !allowedOrigins(env).has(origin)) {
+    return jsonResponse(403, "origin_not_allowed", "Origin is not allowed", origin, env);
+  }
+  if (!env.SHARE_KV) {
+    return jsonResponse(503, "kv_not_configured", "Share storage is not configured", origin, env);
+  }
+  if (getContentLength(request) > MAX_SHARE_CODE_BYTES) {
+    return jsonResponse(413, "request_too_large", "Code is too large", origin, env);
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch (e) {
+    return jsonResponse(400, "invalid_json", "Body must be JSON", origin, env);
+  }
+  const code = typeof body.code === "string" ? body.code.trim() : "";
+  if (!code || code.length < 8 || code.length > 8192 || !/^[A-Za-z0-9+/=_-]+$/.test(code)) {
+    return jsonResponse(400, "invalid_code", "Invalid share code", origin, env);
+  }
+  let id = null;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const candidate = generateShareId();
+    const exists = await env.SHARE_KV.get(candidate);
+    if (!exists) { id = candidate; break; }
+  }
+  if (!id) {
+    return jsonResponse(500, "id_collision", "Could not generate unique ID", origin, env);
+  }
+  await env.SHARE_KV.put(id, code, { expirationTtl: SHARE_TTL_SECONDS });
+  const workerUrl = new URL(request.url);
+  return jsonResponse(200, "ok", "ok", origin, env, {
+    id,
+    short: workerUrl.origin + "/s/" + id,
+  });
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+async function handleShareRedirect(request, env) {
+  const url = new URL(request.url);
+  const id = url.pathname.replace(/^\/s\//, "").trim();
+  if (!id || !/^[A-Za-z0-9]{4,16}$/.test(id)) {
+    return new Response("Invalid share link", { status: 400, headers: { "Content-Type": "text/plain; charset=utf-8" } });
+  }
+  if (!env.SHARE_KV) {
+    return new Response("Share storage not configured", { status: 503, headers: { "Content-Type": "text/plain; charset=utf-8" } });
+  }
+  const code = await env.SHARE_KV.get(id);
+  if (!code) {
+    return new Response("Share link expired or not found", { status: 404, headers: { "Content-Type": "text/plain; charset=utf-8" } });
+  }
+  // Fragment redirect via HTML — Location-header fragments are unreliable across browsers
+  const target = SHARE_TARGET_BASE + "#x=" + encodeURIComponent(code);
+  const html = `<!DOCTYPE html><html lang="de"><head><meta charset="utf-8"><title>NutriTrack</title><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=${escapeHtml(target)}"><script>location.replace(${JSON.stringify(target)});</script><style>body{font-family:-apple-system,system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;color:#2d7d52;background:#f5fbf7;}a{color:#2d7d52;}</style></head><body><div style="text-align:center;padding:24px;"><div style="font-size:42px;">📥</div><div style="margin-top:8px;font-weight:700;">Weiterleitung zu NutriTrack…</div><div style="margin-top:8px;font-size:13px;"><a href="${escapeHtml(target)}">Falls die Weiterleitung nicht funktioniert: tippe hier</a></div></div></body></html>`;
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin") || "";
@@ -268,12 +350,20 @@ export default {
         configured: Boolean(env.ANTHROPIC_API_KEY && env.NUTRITRACK_PROXY_TOKEN),
         decoderConfigured: Boolean(env.DECODER_URL),
         visionFallbackEnabled: env.ENABLE_VISION_FALLBACK === "true",
-        codeVersion: "v0.137-decoder-first",
+        shareConfigured: Boolean(env.SHARE_KV),
+        codeVersion: "v0.140-share-shortener",
       });
     }
 
     if (request.method === "POST" && url.pathname === "/decode-barcode") {
       return handleDecodeBarcode(request, origin, env);
+    }
+
+    if (request.method === "POST" && url.pathname === "/share") {
+      return handleShareCreate(request, origin, env);
+    }
+    if (request.method === "GET" && url.pathname.startsWith("/s/")) {
+      return handleShareRedirect(request, env);
     }
 
     if (request.method !== "POST" || url.pathname !== "/v1/messages") {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -13,3 +13,15 @@ ENABLE_VISION_FALLBACK = "false"
 # wrangler secret put ANTHROPIC_API_KEY      # only required if ENABLE_VISION_FALLBACK=true
 # wrangler secret put NUTRITRACK_PROXY_TOKEN
 # wrangler secret put DECODER_URL            # https://nutritrack-decoder-xxxxx-ew.a.run.app
+
+# KV-Namespace fuer Share-Link-Shortener (Endpoints: POST /share, GET /s/<id>).
+# Setup einmalig:
+#   wrangler kv namespace create nutritrack-shares
+# → liefert eine ID. Dann den folgenden Block einkommentieren und id einsetzen:
+#
+# [[kv_namespaces]]
+# binding = "SHARE_KV"
+# id = "REPLACE_WITH_KV_NAMESPACE_ID"
+#
+# Solange der Block auskommentiert ist, gibt /share 503 zurueck und die PWA
+# faellt automatisch auf is.gd / Originallink zurueck. Siehe README.md.


### PR DESCRIPTION
## Summary

is.gd schlägt in der PWA zuverlässig fehl (vermutlich CORS-Änderung oder Service-Worker-Interferenz). Statt mit einem Drittanbieter-Workaround zu kämpfen baue ich den Shortener jetzt selbst auf der bestehenden **Cloudflare-Worker-Infrastruktur** — voll unter unserer Kontrolle, dauerhaft funktionsfähig.

### Worker
- **Neu: `POST /share`** — Body `{code:"<base64>"}`, gibt `{id, short:"…/s/Ab12X3y"}` zurück. Speichert in Cloudflare Workers KV mit 1-Jahr-TTL. Code-Format + Länge (max 8 KB) validiert. CORS auf PWA-Origin beschränkt, kein Auth-Token nötig (KV-Schreibrate begrenzt natürlich Abuse).
- **Neu: `GET /s/<id>`** — schlägt KV[id] nach und liefert Mini-HTML, das per `location.replace()` zur PWA mit `#x=…` weiterleitet. HTML-Redirect statt 302-Location, weil Fragment-Header nicht in allen Browsern zuverlässig durchgeleitet werden.
- **ID-Generierung**: 7 Zeichen aus Base58-Alphabet ohne 0/O/1/I/l (visuell nicht verwechselbar). 56^7 ≈ 1,7 Billionen Kombinationen, plus 5 Retry-Attempts gegen Kollisionen.
- `/health` zeigt jetzt `shareConfigured` zusätzlich an.

### PWA
- `_shortenUrl()` ruft jetzt zuerst den eigenen Worker, dann is.gd als Fallback, dann Originallink. 6 s-Total-Timeout.
- Status-Zeile im Share-Modal zeigt den vollen Kurzlink (war vorher abgeschnitten bei langen URLs).

### Service Worker
- `is.gd` + `v.gd` in SKIP-Liste aufgenommen, damit sie nicht durch den cache-first-Pfad laufen (`workers.dev` war schon drin).

### Längen-Vergleich
- **Vorher** (langer Link): `https://hjolmes.github.io/nutritrack/#x=eyJ0…` ≈ **570 Zeichen**
- **Nachher** (Kurzlink): `https://nutritrack-ai-proxy.h-jolmes.workers.dev/s/paD9JZA` = **58 Zeichen**
- WhatsApp-Vorschau passt jetzt sauber in eine Zeile.

## ⚠️ Erforderlicher Setup-Schritt

Damit der Worker tatsächlich kürzt, **muss einmalig ein KV-Namespace erstellt werden**:

```bash
wrangler kv namespace create nutritrack-shares
# Output enthält die ID, z.B.:  id = "1a2b3c4d5e6f…"
```

Dann in `worker/wrangler.toml` den Block einkommentieren und ID einsetzen:

```toml
[[kv_namespaces]]
binding = "SHARE_KV"
id = "1a2b3c4d5e6f…"
```

Alternative via Cloudflare Dashboard: KV-Namespace anlegen + Worker-Binding setzen (Variable `SHARE_KV`). Anleitung in `worker/README.md`.

**Solange KV nicht konfiguriert ist**: `/share` antwortet mit `503 kv_not_configured`, PWA fällt automatisch auf is.gd / Originallink zurück (also weiterhin „Kurzlink offline" wie aktuell).

## Test plan

- [ ] KV-Namespace anlegen + wrangler.toml updaten
- [ ] Worker deployen (GHA `deploy-worker.yml` triggert auf push)
- [ ] `GET /health` → `shareConfigured: true` prüfen
- [ ] In PWA Rezept teilen → Status-Zeile zeigt Worker-Kurzlink (~58 Zeichen)
- [ ] Kurzlink in WhatsApp tippen → öffnet PWA → Import-Dialog erscheint
- [ ] KV-Eintrag in Cloudflare-Dashboard sichtbar (mit 1-Jahr-TTL)
- [ ] Cross-platform: identisches Verhalten auf iOS Safari + Chrome Android

---
_Generated by [Claude Code](https://claude.ai/code/session_013mBYT8p8tgaqpeH8w3n7qL)_