### PR TITLE
feat: 📥 Import-Button in der Hauptansicht (v0.141)

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.140</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn">📤</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.141</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button><button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.140</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.141</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1357,7 +1357,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.140';
+var APP_VERSION='0.141';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1386,6 +1386,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.141',items:[
+    {icon:'📥',text:'Import-Button direkt in der Hauptansicht: oben rechts neben „📤 Sichern" jetzt „📥 Importieren". Link oder Code einfügen — die App erkennt automatisch ob es ein Rezept (→ Bibliothek), eine Mahlzeit (→ Eintrag in gewählte Tageszeit) oder ein Lebensmittel (→ eigene Lebensmittel) ist und legt eine Vorschau zur Bestätigung vor',where:'Hauptansicht oben rechts: 📥'},
+  ]},
   {v:'0.140',items:[
     {icon:'🔗',text:'Eigener Kurzlink-Service auf dem Cloudflare Worker statt is.gd: aus dem ~570-Zeichen-Link wird "https://nutritrack-ai-proxy.h-jolmes.workers.dev/s/Ab12X3y" (~58 Zeichen). Funktioniert dauerhaft (kein Drittanbieter, eigene KV-Storage), 1 Jahr Lebenszeit pro Link, ID alphanumerisch ohne 0/O/1/I/l. Fallback weiterhin: is.gd → langer Link',where:'Jeder 📤 Share-Button'},
   ]},

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.140';
+var VERSION = '0.141';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary

Bisher war Import nur über Bibliothek (Einstellungen → Bibliothek → 📥) erreichbar — laut User-Feedback zu versteckt für den täglichen Flow.

**Neu:** Top-Header der Hauptansicht zeigt 📥 zwischen „📤 Sichern" und ⚙️. Tap öffnet den bestehenden Import-Paste-Dialog. Auto-Detect-Logik routet automatisch:

- `t='r'` → „Rezept importieren?" → in Bibliothek
- `t='m'` → „Mahlzeit importieren?" + Mahlzeit-Ziel-Selector → in den Tag
- `t='f'` → „Lebensmittel importieren?" → in eigene Lebensmittel

Pure Code-Reuse: keine neue Logik, nur ein zusätzlicher Entry-Point auf den bereits bestehenden `openImportPaste()` + `_previewImport()`-Pfad.

Per-Meal-Buttons bewusst weggelassen — die Auto-Detect-Logik macht sie redundant, und 5 Buttons pro Mahlzeit-Header wären zu eng.

## Test plan

- [ ] Hauptansicht: 📥 zwischen 📤 und ⚙️ sichtbar
- [ ] 📥 antippen → Paste-Dialog öffnet sich
- [ ] Rezept-Link einfügen → Vorschau „Rezept importieren?" → Speichern → in Bibliothek
- [ ] Mahlzeit-Link einfügen → Vorschau mit Mahlzeit-Ziel-Selector → Speichern → Einträge im Tag
- [ ] Lebensmittel-Link einfügen → Vorschau → Speichern → in eigenen Lebensmitteln
- [ ] Cross-platform: identisch auf iOS Safari + Chrome Android

---
_Generated by [Claude Code](https://claude.ai/code/session_013mBYT8p8tgaqpeH8w3n7qL)_