### PR TITLE
ci: Node.js 22 in Worker-Workflows setzen (Wrangler v4 Fix)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Skip when Cloudflare GitHub secrets are missing
         if: env.CLOUDFLARE_API_TOKEN == '' || env.CLOUDFLARE_ACCOUNT_ID == ''
         run: |

--- a/.github/workflows/setup-share-kv.yml
+++ b/.github/workflows/setup-share-kv.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Verify Cloudflare secrets
         run: |
           if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then


### PR DESCRIPTION
## Summary

Setzt Node.js 22 als Voraussetzung in beiden Worker-Workflows. Der erste Run von `setup-share-kv.yml` ist daran gescheitert:

```
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

Wrangler v4 verlangt Node ≥22, der GitHub-Runner-Default ist Node 20. Ohne expliziten `actions/setup-node`-Schritt schlägt `npx wrangler@latest` fehl. `deploy-worker.yml` ist gleich mit gepatcht, damit der nächste regulaere Worker-Deploy nicht in dieselbe Falle läuft.

## Test plan

- [ ] PR mergen
- [ ] Actions → **Setup Share KV (one-shot)** → **Run workflow** auf `main`
- [ ] Job läuft diesmal durch, KV-Namespace wird angelegt, Worker deployt
- [ ] `/health` zeigt `shareConfigured: true`

https://claude.ai/code/session_01DzR3kQmpBWAqMMVkpe4mFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzR3kQmpBWAqMMVkpe4mFT)_