### PR TITLE
fix: KV-Binding SHARE_KV in wrangler.toml aktivieren

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -19,9 +19,9 @@ ENABLE_VISION_FALLBACK = "false"
 #   wrangler kv namespace create nutritrack-shares
 # → liefert eine ID. Dann den folgenden Block einkommentieren und id einsetzen:
 #
-# [[kv_namespaces]]
-# binding = "SHARE_KV"
-# id = "REPLACE_WITH_KV_NAMESPACE_ID"
+[[kv_namespaces]]
+binding = "SHARE_KV"
+id = "873c9976307f4af087ff8205ba957b1c"
 #
 # Solange der Block auskommentiert ist, gibt /share 503 zurueck und die PWA
 # faellt automatisch auf is.gd / Originallink zurueck. Siehe README.md.


### PR DESCRIPTION
## Summary

KV-Namespace `nutritrack-shares` wurde via `setup-share-kv.yml` in Cloudflare angelegt, ID hier ins `worker/wrangler.toml` eingetragen. Worker ist bereits deployt und live mit aktivem `SHARE_KV`-Binding — dieser PR hält das Repo nur konsistent zum deployten Stand.

## Verifikation

- [ ] `/health` am Worker zeigt `"shareConfigured": true`
- [ ] Rezept-Share in der PWA liefert ~58-Zeichen-Kurzlink auf die Worker-Domain (nicht is.gd)

Sobald gemerged, kann der einmalige Workflow `.github/workflows/setup-share-kv.yml` gelöscht werden — er wird nicht mehr gebraucht.

https://claude.ai/code/session_01DzR3kQmpBWAqMMVkpe4mFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzR3kQmpBWAqMMVkpe4mFT)_