### PR TITLE
feat: Android PWA-Direct-Open + iOS Safari-Handoff (v0.142 + v0.143)

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.142</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button><button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.143</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button><button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.142</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.143</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1001,6 +1001,34 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
   </div>
 </div>
 
+<!-- ══ iOS-SAFARI: WEITER IN APP IMPORTIEREN (Storage isoliert) ══ -->
+<div class="ov" id="iosSwitchOv" onclick="bgClose(event,'iosSwitchOv')">
+  <div class="mod">
+    <div class="mhan"></div>
+    <div class="mhd">
+      <button type="button" class="mcl" onclick="closeOv('iosSwitchOv')">✕</button>
+      <div class="mti">📲 In NutriTrack-App öffnen</div>
+      <div class="msu">Apple isoliert Safari-Daten von App-Daten</div>
+    </div>
+    <div class="mbd">
+      <div style="background:#fff8e1;border:1.5px solid #f9c74f;border-radius:12px;padding:12px;margin-bottom:14px;font-size:13px;color:#7d5a00;line-height:1.5;">
+        Du benutzt gerade <strong>Safari</strong>. Damit das Rezept in deiner installierten NutriTrack-App landet, brauchst du nur drei Schritte:
+      </div>
+      <ol style="margin:0 0 14px 0;padding-left:22px;font-size:14px;line-height:1.7;color:var(--tx);">
+        <li>Schließe diese Seite (Tab schließen)</li>
+        <li>Öffne <strong>NutriTrack</strong> auf deinem Home-Bildschirm</li>
+        <li>Tippe oben rechts auf <strong>📥</strong> – der Link wurde bereits kopiert und fügt sich automatisch ein</li>
+      </ol>
+      <button type="button" class="cb2" onclick="iosCopyShareUrl()" style="margin-bottom:8px;">📋 Link erneut kopieren</button>
+      <button type="button" class="seb" onclick="iosImportInBrowser()" style="margin-bottom:0;">Trotzdem hier in Safari importieren</button>
+      <div style="font-size:11px;color:var(--mu);margin-top:10px;text-align:center;line-height:1.4;">
+        Hinweis: Wenn du NutriTrack noch nicht installiert hast, tippe Safaris Teilen-Symbol → „Zum Home-Bildschirm".<br>
+        Auf Android öffnet sich der Link automatisch in der App (kein Extra-Schritt nötig).
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- ══ IMPORT BESTÄTIGEN (Vorschau + Speichern) ══ -->
 <div class="ov" id="importConfirmOv" onclick="bgClose(event,'importConfirmOv')">
   <div class="mod">
@@ -1357,7 +1385,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.142';
+var APP_VERSION='0.143';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1386,6 +1414,11 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.143',items:[
+    {icon:'📲',text:'Auf iOS isoliert Apple seit iOS 17.4 den Safari-Speicher von der installierten PWA – Imports landeten in Safari-Daten und waren in der App nicht sichtbar. Neuer Flow: Wenn du einen geteilten Link in Safari öffnest, kopiert NutriTrack die URL automatisch in die Zwischenablage und zeigt eine 3-Schritt-Anleitung. In der App tippst du oben auf 📥 – der Link wird automatisch eingefügt und du bestätigst nur noch die Vorschau',where:'Geteilter Link in Safari öffnen'},
+    {icon:'📋',text:'Beim 📥-Tap in der App wird die Zwischenablage geprüft. Wenn ein NutriTrack-Link drin liegt, wird er automatisch ins Eingabefeld übernommen – ein Tap weniger',where:'Hauptansicht → 📥'},
+    {icon:'🆘',text:'„Trotzdem in Safari importieren"-Option für reine Browser-Nutzer ohne installierte App – Daten bleiben dann in Safari, nicht in der App',where:'iOS-Switch-to-App-Dialog'},
+  ]},
   {v:'0.142',items:[
     {icon:'📲',text:'Geteilte Links öffnen jetzt direkt die installierte PWA (auf Android Chrome) statt einem neuen Browser-Tab. Dafür liegt der Kurzlink ab jetzt auf der PWA-Origin selbst (hjolmes.github.io/nutritrack/?s=Ab12X), nicht mehr auf der Worker-Origin – Chrome erkennt den PWA-Scope und routet via handle_links zur App. Auf iOS bleibt der Safari-Pfad (Apple bietet keine PWA-URL-Routing-API), aber Safari und PWA teilen sich denselben Storage – das Rezept landet trotzdem in der App',where:'Jeder geteilte Link'},
     {icon:'🔗',text:'Kurzlink ist jetzt sogar 11 Zeichen kürzer (~47 statt ~58), weil hjolmes.github.io kürzer ist als nutritrack-ai-proxy.h-jolmes.workers.dev. Alte v0.140-Links bleiben gültig – der Worker leitet sie automatisch auf das neue Format um',where:''},
@@ -2998,9 +3031,71 @@ function importPasted(){
   setTimeout(function(){_previewImport(d);},150);
 }
 
+// ─── PLATFORM DETECTION ───
+function _isIos(){
+  var ua=navigator.userAgent;
+  if(/iPad|iPhone|iPod/.test(ua)&&!window.MSStream)return true;
+  // iPadOS 13+ fakes Macintosh UA aber hat Touch
+  if(/Mac/.test(ua)&&navigator.maxTouchPoints&&navigator.maxTouchPoints>1)return true;
+  return false;
+}
+function _isPwaStandalone(){
+  return (window.matchMedia&&window.matchMedia('(display-mode: standalone)').matches)
+      || window.navigator.standalone===true;
+}
+
+// ─── iOS SAFARI → PWA HANDOFF ───
+// Apple isoliert seit iOS 17.4 den Storage zwischen Safari und installierten
+// Home-Screen-PWAs. Damit Imports nicht in Safari landen sondern in der App,
+// kopieren wir den Link in die Zwischenablage und zeigen klare 3-Schritt-Anleitung.
+var _iosShareUrlPending='';
+
+function _showIosBrowserToAppFlow(fullUrl){
+  _iosShareUrlPending=fullUrl;
+  // Sofort kopieren – damit User beim Schritt 3 keine Extra-Aktion braucht.
+  if(navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(fullUrl).catch(function(){});
+  } else {_fallbackCopy(fullUrl);}
+  openOv('iosSwitchOv');
+}
+function iosCopyShareUrl(){
+  if(!_iosShareUrlPending){showToast('Kein Link gespeichert');return;}
+  _copyToClipboard(_iosShareUrlPending,'Link');
+}
+function iosImportInBrowser(){
+  closeOv('iosSwitchOv');
+  // Re-trigger the normal boot flow but bypass the iOS guard
+  var url=_iosShareUrlPending;
+  _iosShareUrlPending='';
+  if(!url)return;
+  var u;try{u=new URL(url);}catch(e){return;}
+  var sid=_extractShareId(u.search);
+  if(sid){setTimeout(function(){_lookupAndPreview(sid);},150);return;}
+  var ext=_extractShareCode((u.hash||'')+' '+(u.search||''));
+  if(!ext)return;
+  var d=_normalizePayload(_decodePayload(ext.code),ext.legacy);
+  if(!d){showToast('Ungültiger Link');return;}
+  setTimeout(function(){_previewImport(d);},150);
+}
+
+// ─── IMPORT-PASTE: AUTO-FILL AUS ZWISCHENABLAGE ───
 function openImportPaste(){
-  document.getElementById('importPasteInput').value='';
+  var inp=document.getElementById('importPasteInput');
+  inp.value='';
   openOv('importPasteOv');
+  // Zwischenablage prüfen – iOS zeigt evtl. einen "Einfügen erlauben?"-Hinweis
+  if(navigator.clipboard&&navigator.clipboard.readText){
+    navigator.clipboard.readText().then(function(txt){
+      if(!txt)return;
+      var t=String(txt).trim();
+      if(t.length>4096)return; // unrealistisch lang → ignorieren
+      if(/[?&]s=[A-Za-z0-9]{4,16}/.test(t)||/[#?&][xr]=[A-Za-z0-9+/=_%-]{8,}/.test(t)){
+        inp.value=t;
+        inp.style.background='#f0faf4';
+        showToast('Aus Zwischenablage eingefügt ✓');
+      }
+    }).catch(function(){/* user denied / not allowed */});
+  }
 }
 
 // ─── AUTO-IMPORT BEIM BOOT (geteilter Link geöffnet) ───
@@ -3008,17 +3103,24 @@ function _checkSharedItemOnBoot(){
   try{
     var search=location.search||'';
     var hash=location.hash||'';
-    // 1) Worker-stored short link: ?s=<id>
     var sid=_extractShareId(search);
+    var hasInlinePayload=/[#?&][xr]=/.test(hash+' '+search);
+    if(!sid&&!hasInlinePayload)return;
+    // iOS Safari (non-standalone): Storage isoliert von der installierten PWA.
+    // Statt direkt zu importieren zeigen wir die Switch-to-App-Anleitung.
+    if(_isIos()&&!_isPwaStandalone()){
+      var fullUrl=location.href;
+      try{history.replaceState(null,'',location.pathname);}catch(e){}
+      setTimeout(function(){_showIosBrowserToAppFlow(fullUrl);},300);
+      return;
+    }
+    // Normaler Pfad: Android (PWA oder Browser) und iOS-PWA-standalone
     if(sid){
       try{history.replaceState(null,'',location.pathname);}catch(e){}
       setTimeout(function(){_lookupAndPreview(sid);},300);
       return;
     }
-    // 2) Inline payload: #x=<code> / #r=<code>
-    var blob=hash+' '+search;
-    if(!/[#?&][xr]=/.test(blob))return;
-    var ext=_extractShareCode(blob);
+    var ext=_extractShareCode(hash+' '+search);
     if(!ext)return;
     var d=_normalizePayload(_decodePayload(ext.code),ext.legacy);
     try{history.replaceState(null,'',location.pathname);}catch(e){}

--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <!-- MAIN -->
 <div id="mainScreen" class="screen">
   <div class="hdr">
-    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.141</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button><button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
+    <div class="hr"><div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.142</span></div><div style="display:flex;gap:4px;"><button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button><button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button><button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button><button type="button" class="hbtn" onclick="openSettings()">⚙️</button></div></div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
       <div style="flex:1;font-size:12px;color:#e65100;font-weight:600;">☁️ OneDrive nicht verbunden – Sichere deine Daten einmal täglich lokal.</div>
       <button type="button" onclick="shareData()" style="font-size:12px;font-weight:700;color:#e65100;background:none;border:1px solid #e65100;padding:4px 8px;border-radius:8px;cursor:pointer;">💾 Jetzt</button>
@@ -503,7 +503,7 @@ button,input,select,textarea{font-family:'Nunito Sans',sans-serif;cursor:pointer
 <div id="statsScreen" class="screen">
   <div class="hdr">
     <div class="hr">
-      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.141</span></div>
+      <div class="logo">Nutri<em>Track</em> <span style="font-size:11px;font-weight:700;color:var(--mu);letter-spacing:.5px;">Beta v0.142</span></div>
       <div style="display:flex;gap:4px;">
         <button type="button" class="hbtn" onclick="openHelp()" style="font-size:13px;font-weight:800;color:var(--g1);border:2px solid var(--g2);border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;padding:0;">?</button>
         <button type="button" class="hbtn" onclick="shareData()">📤</button>
@@ -1357,7 +1357,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.141';
+var APP_VERSION='0.142';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1386,6 +1386,10 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.142',items:[
+    {icon:'📲',text:'Geteilte Links öffnen jetzt direkt die installierte PWA (auf Android Chrome) statt einem neuen Browser-Tab. Dafür liegt der Kurzlink ab jetzt auf der PWA-Origin selbst (hjolmes.github.io/nutritrack/?s=Ab12X), nicht mehr auf der Worker-Origin – Chrome erkennt den PWA-Scope und routet via handle_links zur App. Auf iOS bleibt der Safari-Pfad (Apple bietet keine PWA-URL-Routing-API), aber Safari und PWA teilen sich denselben Storage – das Rezept landet trotzdem in der App',where:'Jeder geteilte Link'},
+    {icon:'🔗',text:'Kurzlink ist jetzt sogar 11 Zeichen kürzer (~47 statt ~58), weil hjolmes.github.io kürzer ist als nutritrack-ai-proxy.h-jolmes.workers.dev. Alte v0.140-Links bleiben gültig – der Worker leitet sie automatisch auf das neue Format um',where:''},
+  ]},
   {v:'0.141',items:[
     {icon:'📥',text:'Import-Button direkt in der Hauptansicht: oben rechts neben „📤 Sichern" jetzt „📥 Importieren". Link oder Code einfügen — die App erkennt automatisch ob es ein Rezept (→ Bibliothek), eine Mahlzeit (→ Eintrag in gewählte Tageszeit) oder ein Lebensmittel (→ eigene Lebensmittel) ist und legt eine Vorschau zur Bestätigung vor',where:'Hauptansicht oben rechts: 📥'},
   ]},
@@ -2954,9 +2958,38 @@ function importConfirm(){
   if(typeof renderSettFoodList==='function')renderSettFoodList();
 }
 
+// Extracts a Worker-stored share id from input. Returns the id string or null.
+function _extractShareId(input){
+  if(!input)return null;
+  var m=String(input).match(/[?&]s=([A-Za-z0-9]{4,16})/);
+  return m?m[1]:null;
+}
+
+// Looks up a stored share via the Worker and routes to the import-preview flow.
+function _lookupAndPreview(id){
+  if(!id)return;
+  fetch(SHARE_WORKER_URL+'/share/'+encodeURIComponent(id),{method:'GET'})
+    .then(function(r){return r.ok?r.json():null;})
+    .then(function(j){
+      if(!j||!j.data||!j.data.code){showToast('Link abgelaufen oder nicht erreichbar');return;}
+      var d=_normalizePayload(_decodePayload(j.data.code),false);
+      if(!d){showToast('Ungültiger geteilter Inhalt');return;}
+      _previewImport(d);
+    })
+    .catch(function(){showToast('Link konnte nicht geladen werden – online?');});
+}
+
 function importPasted(){
   var raw=document.getElementById('importPasteInput').value;
   if(!raw||!raw.trim()){showToast('Link oder Code eingeben');return;}
+  // Worker-stored short link: "https://hjolmes.github.io/nutritrack/?s=abc"
+  var sid=_extractShareId(raw);
+  if(sid){
+    closeOv('importPasteOv');
+    setTimeout(function(){_lookupAndPreview(sid);},150);
+    return;
+  }
+  // Inline #x= / #r= / raw base64 paste
   var ext=_extractShareCode(raw);
   if(!ext){showToast('Ungültig');return;}
   var d=_normalizePayload(_decodePayload(ext.code),ext.legacy);
@@ -2973,9 +3006,20 @@ function openImportPaste(){
 // ─── AUTO-IMPORT BEIM BOOT (geteilter Link geöffnet) ───
 function _checkSharedItemOnBoot(){
   try{
-    var blob=(location.hash||'')+' '+(location.search||'');
+    var search=location.search||'';
+    var hash=location.hash||'';
+    // 1) Worker-stored short link: ?s=<id>
+    var sid=_extractShareId(search);
+    if(sid){
+      try{history.replaceState(null,'',location.pathname);}catch(e){}
+      setTimeout(function(){_lookupAndPreview(sid);},300);
+      return;
+    }
+    // 2) Inline payload: #x=<code> / #r=<code>
+    var blob=hash+' '+search;
+    if(!/[#?&][xr]=/.test(blob))return;
     var ext=_extractShareCode(blob);
-    if(!ext||!/[#?&][xr]=/.test(blob))return;
+    if(!ext)return;
     var d=_normalizePayload(_decodePayload(ext.code),ext.legacy);
     try{history.replaceState(null,'',location.pathname);}catch(e){}
     if(!d)return;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.142';
+var VERSION = '0.143';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.141';
+var VERSION = '0.142';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -299,11 +299,31 @@ async function handleShareCreate(request, origin, env) {
     return jsonResponse(500, "id_collision", "Could not generate unique ID", origin, env);
   }
   await env.SHARE_KV.put(id, code, { expirationTtl: SHARE_TTL_SECONDS });
-  const workerUrl = new URL(request.url);
+  // Short URL on PWA origin so Android Chrome's handle_links can route
+  // installed-PWA links directly to the app instead of the browser tab.
   return jsonResponse(200, "ok", "ok", origin, env, {
     id,
-    short: workerUrl.origin + "/s/" + id,
+    short: SHARE_TARGET_BASE + "?s=" + id,
   });
+}
+
+async function handleShareLookup(request, origin, env) {
+  if (origin && !allowedOrigins(env).has(origin)) {
+    return jsonResponse(403, "origin_not_allowed", "Origin is not allowed", origin, env);
+  }
+  if (!env.SHARE_KV) {
+    return jsonResponse(503, "kv_not_configured", "Share storage is not configured", origin, env);
+  }
+  const url = new URL(request.url);
+  const id = url.pathname.replace(/^\/share\//, "").trim();
+  if (!id || !/^[A-Za-z0-9]{4,16}$/.test(id)) {
+    return jsonResponse(400, "invalid_id", "Invalid share id", origin, env);
+  }
+  const code = await env.SHARE_KV.get(id);
+  if (!code) {
+    return jsonResponse(404, "not_found", "Share link expired or not found", origin, env);
+  }
+  return jsonResponse(200, "ok", "ok", origin, env, { id, code });
 }
 
 function escapeHtml(s) {
@@ -311,20 +331,18 @@ function escapeHtml(s) {
 }
 
 async function handleShareRedirect(request, env) {
+  // Legacy endpoint for v0.140 short URLs that pointed at the worker origin.
+  // We now route to the PWA-origin short form so Android Chrome can deep-link
+  // into an installed PWA via handle_links.
   const url = new URL(request.url);
   const id = url.pathname.replace(/^\/s\//, "").trim();
   if (!id || !/^[A-Za-z0-9]{4,16}$/.test(id)) {
     return new Response("Invalid share link", { status: 400, headers: { "Content-Type": "text/plain; charset=utf-8" } });
   }
-  if (!env.SHARE_KV) {
-    return new Response("Share storage not configured", { status: 503, headers: { "Content-Type": "text/plain; charset=utf-8" } });
-  }
-  const code = await env.SHARE_KV.get(id);
-  if (!code) {
-    return new Response("Share link expired or not found", { status: 404, headers: { "Content-Type": "text/plain; charset=utf-8" } });
-  }
-  // Fragment redirect via HTML — Location-header fragments are unreliable across browsers
-  const target = SHARE_TARGET_BASE + "#x=" + encodeURIComponent(code);
+  // Don't even hit KV — the PWA will look up the code itself and report a clean
+  // error if the id is gone. This keeps the redirect cheap and works even when
+  // SHARE_KV is unbound (e.g., during initial setup).
+  const target = SHARE_TARGET_BASE + "?s=" + encodeURIComponent(id);
   const html = `<!DOCTYPE html><html lang="de"><head><meta charset="utf-8"><title>NutriTrack</title><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=${escapeHtml(target)}"><script>location.replace(${JSON.stringify(target)});</script><style>body{font-family:-apple-system,system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;color:#2d7d52;background:#f5fbf7;}a{color:#2d7d52;}</style></head><body><div style="text-align:center;padding:24px;"><div style="font-size:42px;">📥</div><div style="margin-top:8px;font-weight:700;">Weiterleitung zu NutriTrack…</div><div style="margin-top:8px;font-size:13px;"><a href="${escapeHtml(target)}">Falls die Weiterleitung nicht funktioniert: tippe hier</a></div></div></body></html>`;
   return new Response(html, {
     status: 200,
@@ -351,7 +369,7 @@ export default {
         decoderConfigured: Boolean(env.DECODER_URL),
         visionFallbackEnabled: env.ENABLE_VISION_FALLBACK === "true",
         shareConfigured: Boolean(env.SHARE_KV),
-        codeVersion: "v0.140-share-shortener",
+        codeVersion: "v0.142-pwa-origin-share",
       });
     }
 
@@ -361,6 +379,9 @@ export default {
 
     if (request.method === "POST" && url.pathname === "/share") {
       return handleShareCreate(request, origin, env);
+    }
+    if (request.method === "GET" && url.pathname.startsWith("/share/")) {
+      return handleShareLookup(request, origin, env);
     }
     if (request.method === "GET" && url.pathname.startsWith("/s/")) {
       return handleShareRedirect(request, env);


### PR DESCRIPTION
## Zwei zusammenhängende Fixes für den geteilten Link-Flow

### v0.142: Kurzlink auf PWA-Origin → Android öffnet PWA direkt

Aktueller Kurzlink lag auf `workers.dev` (außerhalb der PWA-Scope) → Chrome's `handle_links` griff nicht → Browser-Tab statt App.

**Fix:** Kurzlink wandert auf `hjolmes.github.io/nutritrack/?s=Ab12Xy3` (47 Zeichen statt 58). Worker bleibt Storage-Backend mit neuem `GET /share/<id>` JSON-Endpoint. Alte v0.140-Links (`/s/<id>`) leiten automatisch um.

**Resultat auf Android Chrome ≥97 mit installierter PWA:** Link öffnet PWA direkt.

### v0.143: iOS-Safari → PWA Handoff via Zwischenablage

Apple isoliert seit iOS 17.4 den Storage zwischen Safari und installierter Home-Screen-PWA — Imports landeten in Safari-Daten, in der App unsichtbar.

**Fix:** Wenn iOS Safari (non-standalone) + Share-URL erkannt:
1. Volle URL automatisch in Zwischenablage kopieren
2. Spezial-Modal mit 3-Schritt-Anleitung: „Safari schließen → NutriTrack vom Home-Bildschirm → 📥 antippen"
3. Auf der PWA-Seite: `openImportPaste()` liest die Zwischenablage und füllt das Eingabefeld automatisch
4. Escape-Hatch „Trotzdem in Safari importieren" für reine Browser-Nutzer ohne installierte App

**iOS-Flow:** WhatsApp → Anleitung lesen → NutriTrack-Icon → 📥 → Bestätigen (3 Taps statt vorher: verloren).

## Cross-platform-Verhalten

| Plattform | Verhalten |
|---|---|
| **Android Chrome ≥97 mit PWA** | ✅ Link öffnet PWA direkt → Auto-Import |
| **Android Chrome ohne PWA** | Browser-Tab → PWA als Webseite → Auto-Import |
| **iOS Safari standalone PWA** | ✅ Direkt-Import in PWA |
| **iOS Safari Browser** | Anleitungs-Modal + Auto-Copy → User wechselt zur App → Auto-Paste |
| **Desktop Browser** | Normales Auto-Import-Verhalten |

## Test plan

- [ ] **Android PWA installiert**: Link aus WhatsApp → öffnet App direkt → Vorschau-Dialog
- [ ] **iOS PWA installiert**: Link aus WhatsApp → öffnet Safari → 3-Schritt-Anleitung erscheint, URL in Zwischenablage
- [ ] **iOS PWA**: App-Icon antippen → 📥 → Eingabefeld ist mit Link aus Zwischenablage vorausgefüllt → Vorschau anzeigen → Speichern
- [ ] **iOS Safari ohne PWA**: „Trotzdem in Safari importieren" → normaler Vorschau-Dialog → Speichern (in Safari-Storage)
- [ ] **iPadOS Safari** (Mac-UA-Fake): wird als iOS erkannt (via `maxTouchPoints`)
- [ ] **Alter v0.140-Link** (`/s/<id>`): leitet auf `?s=<id>` um → öffnet auch in PWA auf Android
- [ ] **Inline `#x=`/`#r=` URLs**: funktionieren unverändert