### PR TITLE
feat: Feedback-Button mit GitHub-Issue-Anbindung (v0.145)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,20 +2,30 @@
 
 > **Anweisung für neue Sessions:** Lies diese Datei zuerst. Sie ersetzt jede manuelle Kontext-Übergabe. Beim Abschluss einer Iteration (Merge auf `main`) wird sie aktualisiert.
 
-**Letzte Aktualisierung:** 2026-05-02 (nach v0.144)
+**Letzte Aktualisierung:** 2026-05-02 (nach v0.145)
 
 ---
 
 ## Aktueller Versionsstand
 
-- **Live:** v0.144 auf `main` (Bloom-Redesign + 5-Tab-Nav + Mahlzeit-Detail)
+- **Live:** v0.145 auf `main` (Feedback-Button mit GitHub-Issue-Anbindung)
 - **PWA:** https://hjolmes.github.io/nutritrack/
-- **Worker:** https://nutritrack-ai-proxy.h-jolmes.workers.dev (codeVersion `v0.142-pwa-origin-share`, vom Redesign nicht berührt)
+- **Worker:** https://nutritrack-ai-proxy.h-jolmes.workers.dev (codeVersion `v0.145-feedback`, neuer `POST /feedback` Endpoint)
 - **Decoder:** https://nutritrack-decoder-294137824893.europe-west1.run.app
 
-## Architektur (Stand v0.144)
+## Architektur (Stand v0.145)
 
-### UI-Struktur (neu in v0.144)
+### Feedback-Button (neu in v0.145)
+
+- **UI:** 🐛-Button im Top-Header **jedes** Screens (`mainScreen`, `historyScreen`, `statsScreen`, `moreScreen`) plus eigener Eintrag im „Mehr"-Hub. Beim Klick wird der aktuelle Tab/Screen vor dem Modal-Open eingefroren, damit die Quelle korrekt erfasst wird.
+- **Modal `feedbackOv`:** Toggle Bug/Wunsch, freie Beschreibung (max 2000 Zeichen), optional Auto-Screenshot via lazy-loaded `html2canvas@1.4.1` (Modal schließt sich kurz, damit es nicht im Bild landet, max 1200px Breite, JPEG 0.8). Detail-Section zeigt vor dem Senden, was mitgeschickt wird (Tab, Screen, App-Version, PWA-Standalone, Online, Zeitpunkt, User-Agent).
+- **JS-Hooks:** `openFeedback()`, `attachFeedbackScreenshot()`, `submitFeedback()`, `_setFeedbackType()`, `_clearFeedbackScreenshot()`, `_captureFeedbackContext()`. Section-Marker im Code: `// SECTION: FEEDBACK`.
+- **Worker-Anbindung:** `POST https://nutritrack-ai-proxy.h-jolmes.workers.dev/feedback`. Body `{type:'bug'|'enhancement', description, context, screenshotB64?}`. Origin-Check, kein Proxy-Token (wie `/share`).
+- **GitHub-Flow im Worker:** Falls Screenshot vorhanden, wird er via Contents-API auf den (lazy erstellten) Branch `feedback-screenshots` nach `feedback/screenshots/<ts>-<rand>.jpg` committed. Danach wird ein Issue im konfigurierten Repo (`GITHUB_REPO`, default `hjolmes/nutritrack`) mit Title-Prefix `[Bug]`/`[Idee]`, Labels `bug|enhancement` + `from-app`, Markdown-Body inkl. Kontext-Tabelle und eingebettetem Screenshot-Link erstellt.
+- **Worker-Secrets (manuell):** `GITHUB_TOKEN` (fine-grained PAT, Scope `hjolmes/nutritrack`, Permissions `Issues: read & write` + `Contents: read & write`), optional `GITHUB_REPO` (sonst Default).
+- **Service Worker:** `unpkg.com` ist bereits in der SKIP-Liste (war für ZXing schon nötig) — html2canvas-CDN wird also nicht gecached und dadurch beim ersten Klick lazy nachgeladen.
+
+### UI-Struktur (Stand v0.144)
 
 - **Theme:** Cream-Background `#faf6f1`, Coral-Akzent `#e96e3c`, Fraunces-Serif (display) + Inter (body). Implementiert als Override-Block ganz unten im `<style>`-Bereich von `index.html` (`/* BLOOM REDESIGN v0.144 */`) — bestehende Klassen werden re-skinned, alle JS-Hooks bleiben erhalten.
 - **Screens:**
@@ -91,6 +101,7 @@ URL: `https://nutritrack-ai-proxy.h-jolmes.workers.dev`
 | `POST /share` | Body `{code:"<base64>"}` → `{ok:true, data:{id, short}}` |
 | `GET /share/<id>` | Lookup → `{ok:true, data:{id, code}}` |
 | `GET /s/<id>` | Legacy (v0.140) → HTML-Redirect zu `?s=<id>` |
+| `POST /feedback` | Body `{type, description, context, screenshotB64?}` → erstellt GitHub-Issue, optional Screenshot-Commit auf Branch `feedback-screenshots` |
 
 ### Worker-Bindings/Secrets
 
@@ -98,6 +109,8 @@ URL: `https://nutritrack-ai-proxy.h-jolmes.workers.dev`
 - `NUTRITRACK_PROXY_TOKEN` (secret)
 - `DECODER_URL` (secret)
 - `SHARE_KV` (KV-Namespace, ID `873c9976307f4af087ff8205ba957b1c`)
+- `GITHUB_TOKEN` (secret, fine-grained PAT für `/feedback` — nur `hjolmes/nutritrack`, Permissions `Issues: read & write` + `Contents: read & write`)
+- `GITHUB_REPO` (optional env var, Default `hjolmes/nutritrack`)
 
 ### Cloud Run Decoder
 
@@ -126,6 +139,10 @@ Suchpfade für die wichtigsten Sektionen:
 - `handleShareLookup()` — GET /share/<id>
 - `handleShareRedirect()` — GET /s/<id> (Legacy)
 - `generateShareId()` — Base58-7-char IDs (kein 0/O/1/I/l)
+- `// ─── FEEDBACK ENDPOINT (creates GitHub Issue, optional screenshot upload) ───`
+- `handleFeedback()` — POST /feedback
+- `ensureFeedbackBranch()` — lazy create `feedback-screenshots` branch
+- `uploadFeedbackScreenshot()` — Contents-API PUT JPEG, returns `download_url`
 
 ### `manifest.json`
 
@@ -134,8 +151,8 @@ Suchpfade für die wichtigsten Sektionen:
 
 ### `sw.js`
 
-- `VERSION = '0.143'`
-- SKIP-Liste: `workers.dev`, `is.gd`, `v.gd`, etc. (kein SW-Caching für Shortener)
+- `VERSION = '0.145'`
+- SKIP-Liste: `workers.dev`, `is.gd`, `v.gd`, `unpkg.com`, etc. (kein SW-Caching für Shortener / CDN-Libs wie html2canvas)
 
 ## Versioning-Workflow (PFLICHT bei jedem deployablen Bump)
 
@@ -170,6 +187,7 @@ Niemals committen: API Keys, OAuth Tokens, exportierte Backups, persönliche Ern
 - ⏳ iOS Safari-Handoff (v0.143): 3-Schritt-Flow noch nicht in der Praxis durchgespielt
 - ⏳ iOS PWA standalone Direct-Import: noch nicht getestet
 - ⏳ v0.144 Bloom-Redesign: nicht in echter PWA durchgespielt — Heute-Header personalisiert, 2×2-Grid und Mahlzeit-Detail bisher nur über statisches HTTP-Serving + JS-Syntax-Check verifiziert
+- ⏳ v0.145 Feedback-Button: End-to-End-Test ausstehend — benötigt erst Worker-Deploy mit gesetztem `GITHUB_TOKEN`-Secret + Issues-Schreibrechten auf `hjolmes/nutritrack`. Erst danach lässt sich der Flow (Modal → Beschreibung + Auto-Screenshot → Issue erscheint in GitHub mit Screenshot-Bild) verifizieren
 
 ## Versions-Historie
 
@@ -182,6 +200,7 @@ Niemals committen: API Keys, OAuth Tokens, exportierte Backups, persönliche Ern
 | v0.142 | #43 | Kurzlink wandert auf PWA-Origin → Android öffnet PWA direkt |
 | v0.143 | #43 | iOS-Safari-Handoff via Zwischenablage + Auto-Paste |
 | v0.144 | #45 | Bloom-Redesign (Cream/Coral/Fraunces) + 5-Tab-Bottom-Nav + Mahlzeit-Detail-Subseite + Verlauf/Mehr-Hub |
+| v0.145 | TBD | 🐛 Feedback-Button im Header jedes Screens + Mehr-Hub: Bug/Wunsch direkt aus der App als GitHub-Issue auf `hjolmes/nutritrack`, optional mit Auto-Screenshot (html2canvas, lazy-loaded). Worker-Endpoint `POST /feedback` mit lazy-erstelltem `feedback-screenshots` Branch für Screenshot-Commits |
 
 ## Mögliche Folge-Iterationen (nicht eingeplant)
 

--- a/index.html
+++ b/index.html
@@ -656,6 +656,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
         <button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button>
         <button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button>
+        <button type="button" class="hbtn" onclick="openFeedback()" title="Bug melden oder Wunsch">🐛</button>
         <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
     </div>
@@ -802,6 +803,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
         <button type="button" class="hbtn" onclick="shareData()" title="Daten sichern">📤</button>
         <button type="button" class="hbtn" onclick="openImportPaste()" title="Importieren">📥</button>
+        <button type="button" class="hbtn" onclick="openFeedback()" title="Bug melden oder Wunsch">🐛</button>
         <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
     </div>
@@ -872,6 +874,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
         <div class="greet-sub">Letzte 30 Tage</div>
       </div>
       <div style="display:flex;gap:6px;">
+        <button type="button" class="hbtn" onclick="openFeedback()" title="Bug melden oder Wunsch">🐛</button>
         <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
     </div>
@@ -935,6 +938,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
       </div>
       <div style="display:flex;gap:6px;">
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
+        <button type="button" class="hbtn" onclick="openFeedback()" title="Bug melden oder Wunsch">🐛</button>
       </div>
     </div>
   </div>
@@ -966,7 +970,12 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.144</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.145</div></div>
+      <div class="lr-val">›</div>
+    </div>
+    <div class="list-row" onclick="openFeedback()">
+      <div class="lr-ic">🐛</div>
+      <div class="lr-body"><div class="lr-name">Feedback senden</div><div class="lr-sub">Bug melden oder Änderungswunsch</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1477,6 +1486,43 @@ button,input,select,textarea{font-family:var(--fs-body);}
   </div>
 </div>
 
+<!-- ══ FEEDBACK (Bug / Änderungswunsch) ══ -->
+<div class="ov" id="feedbackOv" onclick="bgClose(event,'feedbackOv')">
+  <div class="mod">
+    <div class="mhan"></div>
+    <div class="mhd">
+      <button type="button" class="mcl" onclick="closeOv('feedbackOv')">✕</button>
+      <div class="mti">🐛 Feedback senden</div>
+      <div class="msu">Bug oder Änderungswunsch direkt an die Entwicklung</div>
+    </div>
+    <div class="mbd">
+      <div style="display:flex;gap:8px;margin-bottom:12px;">
+        <button type="button" id="feedbackTypeBug" class="seb" onclick="_setFeedbackType('bug')" style="flex:1;">🐛 Bug</button>
+        <button type="button" id="feedbackTypeIdea" class="seb" onclick="_setFeedbackType('enhancement')" style="flex:1;">💡 Wunsch</button>
+      </div>
+      <textarea id="feedbackText" rows="5" placeholder="Was ist passiert / was wünschst du dir? Je konkreter, desto besser."
+        style="width:100%;box-sizing:border-box;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:14px;resize:vertical;outline:none;margin-bottom:10px;"></textarea>
+      <div style="display:flex;gap:8px;margin-bottom:10px;">
+        <button type="button" class="seb" onclick="attachFeedbackScreenshot()" id="feedbackShotBtn" style="flex:1;">📸 Screenshot anhängen</button>
+        <button type="button" class="seb" onclick="_clearFeedbackScreenshot()" id="feedbackShotClear" style="flex:0 0 auto;display:none;">✕</button>
+      </div>
+      <div id="feedbackShotPreview" style="display:none;margin-bottom:10px;">
+        <img id="feedbackShotImg" alt="Screenshot-Vorschau" style="max-width:100%;border-radius:10px;border:1px solid var(--br);">
+        <div style="font-size:11px;color:var(--mu);margin-top:4px;text-align:center;">Vorschau – prüfe vor dem Senden, ob persönliche Daten sichtbar sind.</div>
+      </div>
+      <details style="margin-bottom:10px;">
+        <summary style="font-size:12px;color:var(--mu);cursor:pointer;padding:4px 0;">Was wird mitgeschickt?</summary>
+        <div id="feedbackCtxPreview" style="font-size:11px;color:var(--mu);background:var(--gl);border-radius:8px;padding:8px;margin-top:6px;font-family:monospace;white-space:pre-wrap;word-break:break-all;"></div>
+      </details>
+      <button type="button" class="svb" id="feedbackSendBtn" onclick="submitFeedback()" style="margin-top:0;margin-bottom:8px;">📤 Senden</button>
+      <button type="button" class="seb" onclick="closeOv('feedbackOv')">Abbrechen</button>
+      <div style="font-size:11px;color:var(--mu);margin-top:10px;text-align:center;line-height:1.4;">
+        Landet als GitHub-Issue auf <strong>hjolmes/nutritrack</strong>.
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- ══ FASTEN ══ -->
 <div class="ov" id="fastOv" onclick="bgClose(event,'fastOv')">
   <div class="mod">
@@ -1802,7 +1848,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.144';
+var APP_VERSION='0.145';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1831,6 +1877,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.145',items:[
+    {icon:'🐛',text:'Neuer Feedback-Button (🐛) im Top-Header jedes Screens und im „Mehr"-Hub: Bug melden oder Änderungswunsch einreichen — landet automatisch als GitHub-Issue auf hjolmes/nutritrack. Optional kann ein Auto-Screenshot der aktuellen Seite angehängt werden (Vorschau vor dem Senden, Screenshot kann persönliche Daten enthalten — bitte prüfen). Mitgesendet werden Tab, Screen, App-Version, User-Agent und Zeitpunkt',where:'Top-Header jedes Screens · Mehr-Hub'},
+  ]},
   {v:'0.144',items:[
     {icon:'🌸',text:'Bloom-Redesign: warmes Cream-Theme mit Coral-Akzent und Fraunces-Serif-Typografie – ruhigere, redaktionelle Optik auf jedem Screen',where:'App-weit'},
     {icon:'🏠',text:'Heute personalisiert: „Hej {Name}" mit Wochentag und Kalenderwoche, große Hero-Zahl „kcal verbleibend" plus Trend-Pill (über/unter Soll)',where:'Heute-Tab'},
@@ -5493,6 +5542,161 @@ function openHelp(){
   var base='https://hjolmes.github.io/nutritrack/nutritrack_anleitung.pdf';
   frame.src=base+'?v='+Date.now();
   openOv('helpOv');
+}
+
+// ════════════════════════════════════════
+// SECTION: FEEDBACK (Bug-Report / Änderungswunsch)
+// ════════════════════════════════════════
+var FEEDBACK_WORKER_URL=SHARE_WORKER_URL+'/feedback';
+var _feedbackContext=null;
+var _feedbackScreenshotB64=null;
+var _feedbackType='bug';
+var _feedbackBusy=false;
+var _html2canvasLoading=null;
+
+function _captureFeedbackContext(){
+  var tabBtn=document.querySelector('.bnav .ni.on');
+  var screen=document.querySelector('.screen.active');
+  return {
+    tab:tabBtn?tabBtn.getAttribute('data-tab'):'unknown',
+    screen:screen?screen.id:'unknown',
+    version:typeof APP_VERSION==='string'?APP_VERSION:'?',
+    ua:navigator.userAgent||'',
+    standalone:!!(navigator.standalone||(window.matchMedia&&matchMedia('(display-mode: standalone)').matches)),
+    online:navigator.onLine!==false,
+    ts:new Date().toISOString()
+  };
+}
+
+function _setFeedbackType(t){
+  _feedbackType=(t==='enhancement')?'enhancement':'bug';
+  var bug=document.getElementById('feedbackTypeBug');
+  var idea=document.getElementById('feedbackTypeIdea');
+  if(bug)bug.style.background=(_feedbackType==='bug')?'var(--g1)':'';
+  if(bug)bug.style.color=(_feedbackType==='bug')?'#fff':'';
+  if(idea)idea.style.background=(_feedbackType==='enhancement')?'var(--g1)':'';
+  if(idea)idea.style.color=(_feedbackType==='enhancement')?'#fff':'';
+}
+
+function _renderFeedbackCtxPreview(){
+  var pre=document.getElementById('feedbackCtxPreview');
+  if(!pre||!_feedbackContext)return;
+  var c=_feedbackContext;
+  pre.textContent=
+    'Tab:        '+c.tab+'\n'+
+    'Screen:     '+c.screen+'\n'+
+    'Version:    '+c.version+'\n'+
+    'PWA:        '+(c.standalone?'ja':'nein')+'\n'+
+    'Online:     '+(c.online?'ja':'nein')+'\n'+
+    'Zeitpunkt:  '+c.ts+'\n'+
+    'User-Agent: '+c.ua;
+}
+
+function _clearFeedbackScreenshot(){
+  _feedbackScreenshotB64=null;
+  var p=document.getElementById('feedbackShotPreview');
+  var img=document.getElementById('feedbackShotImg');
+  var clr=document.getElementById('feedbackShotClear');
+  if(p)p.style.display='none';
+  if(img)img.src='';
+  if(clr)clr.style.display='none';
+}
+
+function openFeedback(){
+  _feedbackContext=_captureFeedbackContext();
+  _clearFeedbackScreenshot();
+  _setFeedbackType(_feedbackType||'bug');
+  var ta=document.getElementById('feedbackText');
+  if(ta)ta.value='';
+  _renderFeedbackCtxPreview();
+  openOv('feedbackOv');
+}
+
+function _loadHtml2Canvas(){
+  if(window.html2canvas)return Promise.resolve(window.html2canvas);
+  if(_html2canvasLoading)return _html2canvasLoading;
+  _html2canvasLoading=new Promise(function(resolve,reject){
+    var s=document.createElement('script');
+    s.src='https://unpkg.com/html2canvas@1.4.1/dist/html2canvas.min.js';
+    s.onload=function(){resolve(window.html2canvas);};
+    s.onerror=function(){_html2canvasLoading=null;reject(new Error('html2canvas Lade-Fehler'));};
+    document.head.appendChild(s);
+  });
+  return _html2canvasLoading;
+}
+
+function attachFeedbackScreenshot(){
+  if(_feedbackBusy)return;
+  var btn=document.getElementById('feedbackShotBtn');
+  if(btn){btn.disabled=true;btn.textContent='📸 Aufnahme…';}
+  // Modal kurz schließen, damit es nicht im Bild landet
+  closeOv('feedbackOv');
+  setTimeout(function(){
+    _loadHtml2Canvas().then(function(h2c){
+      return h2c(document.body,{scale:0.7,logging:false,useCORS:true,backgroundColor:'#faf6f1'});
+    }).then(function(canvas){
+      // Auf max 1200px Breite begrenzen
+      var max=1200;
+      var w=canvas.width,h=canvas.height;
+      if(w>max){var f=max/w;var c2=document.createElement('canvas');c2.width=max;c2.height=Math.round(h*f);
+        c2.getContext('2d').drawImage(canvas,0,0,c2.width,c2.height);canvas=c2;}
+      var dataUrl=canvas.toDataURL('image/jpeg',0.8);
+      _feedbackScreenshotB64=dataUrl.split(',')[1];
+      var img=document.getElementById('feedbackShotImg');
+      var p=document.getElementById('feedbackShotPreview');
+      var clr=document.getElementById('feedbackShotClear');
+      if(img)img.src=dataUrl;
+      if(p)p.style.display='block';
+      if(clr)clr.style.display='inline-block';
+      openOv('feedbackOv');
+    }).catch(function(err){
+      openOv('feedbackOv');
+      showToast('Screenshot fehlgeschlagen: '+(err&&err.message||'unbekannt'));
+    }).then(function(){
+      if(btn){btn.disabled=false;btn.textContent='📸 Screenshot anhängen';}
+    });
+  },120);
+}
+
+function submitFeedback(){
+  if(_feedbackBusy)return;
+  var ta=document.getElementById('feedbackText');
+  var desc=ta?ta.value.trim():'';
+  if(!desc){showToast('Bitte Beschreibung ausfüllen');if(ta)ta.focus();return;}
+  if(desc.length>2000){showToast('Beschreibung zu lang (max 2000 Zeichen)');return;}
+  if(!_feedbackContext)_feedbackContext=_captureFeedbackContext();
+  _feedbackBusy=true;
+  var btn=document.getElementById('feedbackSendBtn');
+  if(btn){btn.disabled=true;btn.textContent='📤 Sende…';}
+  var payload={
+    type:_feedbackType,
+    description:desc,
+    context:_feedbackContext,
+    screenshotB64:_feedbackScreenshotB64
+  };
+  fetch(FEEDBACK_WORKER_URL,{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify(payload)
+  }).then(function(r){return r.json().then(function(j){return {status:r.status,j:j};});})
+  .then(function(res){
+    if(res.j&&res.j.ok&&res.j.data){
+      closeOv('feedbackOv');
+      var url=res.j.data.html_url;
+      showToast('Danke! Issue #'+res.j.data.number+' erstellt');
+      if(url)setTimeout(function(){
+        if(confirm('Issue erstellt: #'+res.j.data.number+'\n\nIm Browser öffnen?'))window.open(url,'_blank','noopener');
+      },400);
+    }else{
+      var msg=(res.j&&res.j.error&&res.j.error.message)||('Fehler '+res.status);
+      showToast('Senden fehlgeschlagen: '+msg);
+    }
+  }).catch(function(){
+    showToast('Senden fehlgeschlagen – bist du online?');
+  }).then(function(){
+    _feedbackBusy=false;
+    if(btn){btn.disabled=false;btn.textContent='📤 Senden';}
+  });
 }
 
 function showToast(msg,duration){var t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');setTimeout(function(){t.classList.remove('show');},(duration||2500));}

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.144';
+var VERSION = '0.145';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -326,6 +326,179 @@ async function handleShareLookup(request, origin, env) {
   return jsonResponse(200, "ok", "ok", origin, env, { id, code });
 }
 
+// ─── FEEDBACK ENDPOINT (creates GitHub Issue, optional screenshot upload) ───
+const MAX_FEEDBACK_BODY_BYTES = 1024 * 1024 * 1.5; // 1.5 MB total incl. screenshot
+const MAX_FEEDBACK_DESCRIPTION = 2000;
+const MAX_FEEDBACK_SCREENSHOT_BYTES = 1024 * 1024; // 1 MB raw base64
+const FEEDBACK_SCREENSHOT_BRANCH = "feedback-screenshots";
+const FEEDBACK_USER_AGENT = "nutritrack-feedback-worker";
+const FEEDBACK_DEFAULT_REPO = "hjolmes/nutritrack";
+
+function ghHeaders(env) {
+  return {
+    Authorization: "Bearer " + env.GITHUB_TOKEN,
+    Accept: "application/vnd.github+json",
+    "User-Agent": FEEDBACK_USER_AGENT,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function ensureFeedbackBranch(env, repo) {
+  let res = await fetch(`https://api.github.com/repos/${repo}/branches/${FEEDBACK_SCREENSHOT_BRANCH}`, {
+    headers: ghHeaders(env),
+  });
+  if (res.ok) return true;
+  if (res.status !== 404) return false;
+  res = await fetch(`https://api.github.com/repos/${repo}/git/ref/heads/main`, {
+    headers: ghHeaders(env),
+  });
+  if (!res.ok) return false;
+  const mainRef = await res.json();
+  const sha = mainRef && mainRef.object && mainRef.object.sha;
+  if (!sha) return false;
+  res = await fetch(`https://api.github.com/repos/${repo}/git/refs`, {
+    method: "POST",
+    headers: { ...ghHeaders(env), "Content-Type": "application/json" },
+    body: JSON.stringify({ ref: `refs/heads/${FEEDBACK_SCREENSHOT_BRANCH}`, sha }),
+  });
+  return res.ok || res.status === 422; // 422 = ref already exists (race)
+}
+
+async function uploadFeedbackScreenshot(env, repo, base64) {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const rand = Math.random().toString(36).slice(2, 8);
+  const path = `feedback/screenshots/${ts}-${rand}.jpg`;
+  const branchOk = await ensureFeedbackBranch(env, repo);
+  if (!branchOk) return null;
+  const res = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+    method: "PUT",
+    headers: { ...ghHeaders(env), "Content-Type": "application/json" },
+    body: JSON.stringify({
+      message: `feedback: screenshot ${ts}`,
+      branch: FEEDBACK_SCREENSHOT_BRANCH,
+      content: base64,
+    }),
+  });
+  if (!res.ok) return null;
+  const j = await res.json();
+  return (j && j.content && j.content.download_url) || null;
+}
+
+function mdEscapeCell(s) {
+  return String(s == null ? "" : s).replace(/\|/g, "\\|").replace(/\r?\n/g, " ").slice(0, 240);
+}
+
+async function handleFeedback(request, origin, env) {
+  if (origin && !allowedOrigins(env).has(origin)) {
+    return jsonResponse(403, "origin_not_allowed", "Origin is not allowed", origin, env);
+  }
+  if (!env.GITHUB_TOKEN) {
+    return jsonResponse(503, "github_not_configured", "Feedback endpoint is not configured", origin, env);
+  }
+  const repo = ((env.GITHUB_REPO || FEEDBACK_DEFAULT_REPO) + "").trim();
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    return jsonResponse(500, "github_repo_invalid", "GITHUB_REPO is invalid", origin, env);
+  }
+  if (getContentLength(request) > MAX_FEEDBACK_BODY_BYTES) {
+    return jsonResponse(413, "request_too_large", "Feedback is too large", origin, env);
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch (e) {
+    return jsonResponse(400, "invalid_json", "Body must be JSON", origin, env);
+  }
+  const type = body && (body.type === "bug" || body.type === "enhancement") ? body.type : null;
+  if (!type) {
+    return jsonResponse(400, "invalid_type", "type must be 'bug' or 'enhancement'", origin, env);
+  }
+  const description = body && typeof body.description === "string" ? body.description.trim() : "";
+  if (!description) {
+    return jsonResponse(400, "missing_description", "description is required", origin, env);
+  }
+  if (description.length > MAX_FEEDBACK_DESCRIPTION) {
+    return jsonResponse(400, "description_too_long", `description max ${MAX_FEEDBACK_DESCRIPTION} chars`, origin, env);
+  }
+  const ctx = body && body.context && typeof body.context === "object" ? body.context : {};
+  let screenshotB64 = body && typeof body.screenshotB64 === "string" ? body.screenshotB64 : null;
+  if (screenshotB64) {
+    // Strip a possible data:image/...;base64, prefix defensively
+    const comma = screenshotB64.indexOf(",");
+    if (comma > 0 && /^data:/i.test(screenshotB64)) screenshotB64 = screenshotB64.slice(comma + 1);
+    if (!/^[A-Za-z0-9+/=]+$/.test(screenshotB64)) {
+      return jsonResponse(400, "invalid_screenshot", "Screenshot must be base64", origin, env);
+    }
+    if (screenshotB64.length > MAX_FEEDBACK_SCREENSHOT_BYTES) {
+      return jsonResponse(413, "screenshot_too_large", "Screenshot is too large", origin, env);
+    }
+  }
+
+  let screenshotUrl = null;
+  let screenshotError = null;
+  if (screenshotB64) {
+    try {
+      screenshotUrl = await uploadFeedbackScreenshot(env, repo, screenshotB64);
+      if (!screenshotUrl) screenshotError = "upload returned no URL";
+    } catch (e) {
+      screenshotError = (e && e.message) || "upload threw";
+    }
+  }
+
+  const isBug = type === "bug";
+  const labels = [isBug ? "bug" : "enhancement", "from-app"];
+  const titlePrefix = isBug ? "[Bug]" : "[Idee]";
+  const firstLine = description.split("\n")[0].trim().slice(0, 70) || description.slice(0, 70);
+  const title = `${titlePrefix} ${firstLine}`;
+
+  const md = [
+    `**Typ:** ${isBug ? "🐛 Bug" : "💡 Änderungswunsch"}`,
+    "",
+    "### Beschreibung",
+    description,
+    "",
+    "### Kontext",
+    "| Feld | Wert |",
+    "|---|---|",
+    `| Tab | \`${mdEscapeCell(ctx.tab || "?")}\` |`,
+    `| Screen | \`${mdEscapeCell(ctx.screen || "?")}\` |`,
+    `| App-Version | \`${mdEscapeCell(ctx.version || "?")}\` |`,
+    `| Standalone (PWA) | ${ctx.standalone ? "ja" : "nein"} |`,
+    `| Online | ${ctx.online === false ? "nein" : "ja"} |`,
+    `| Zeitpunkt | ${mdEscapeCell(ctx.ts || "")} |`,
+    `| User-Agent | \`${mdEscapeCell(ctx.ua || "")}\` |`,
+    "",
+  ];
+  if (screenshotUrl) {
+    md.push("### Screenshot");
+    md.push(`![Screenshot](${screenshotUrl})`);
+    md.push("");
+  } else if (screenshotB64) {
+    md.push(`> _(Screenshot wurde mitgeschickt, konnte aber nicht hochgeladen werden${screenshotError ? ": " + screenshotError : ""}.)_`);
+    md.push("");
+  }
+  md.push("---");
+  md.push("_Gesendet via 🐛-Button in der NutriTrack-PWA._");
+
+  const issueRes = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: "POST",
+    headers: { ...ghHeaders(env), "Content-Type": "application/json" },
+    body: JSON.stringify({ title, body: md.join("\n"), labels }),
+  });
+  if (!issueRes.ok) {
+    let detail = null;
+    try {
+      detail = await issueRes.json();
+    } catch (_) {}
+    return jsonResponse(502, "github_create_failed", `GitHub returned ${issueRes.status}`, origin, env, detail);
+  }
+  const issue = await issueRes.json();
+  return jsonResponse(200, "ok", "ok", origin, env, {
+    number: issue.number,
+    html_url: issue.html_url,
+    screenshotUploaded: Boolean(screenshotUrl),
+  });
+}
+
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
@@ -369,7 +542,8 @@ export default {
         decoderConfigured: Boolean(env.DECODER_URL),
         visionFallbackEnabled: env.ENABLE_VISION_FALLBACK === "true",
         shareConfigured: Boolean(env.SHARE_KV),
-        codeVersion: "v0.142-pwa-origin-share",
+        feedbackConfigured: Boolean(env.GITHUB_TOKEN),
+        codeVersion: "v0.145-feedback",
       });
     }
 
@@ -379,6 +553,9 @@ export default {
 
     if (request.method === "POST" && url.pathname === "/share") {
       return handleShareCreate(request, origin, env);
+    }
+    if (request.method === "POST" && url.pathname === "/feedback") {
+      return handleFeedback(request, origin, env);
     }
     if (request.method === "GET" && url.pathname.startsWith("/share/")) {
       return handleShareLookup(request, origin, env);


### PR DESCRIPTION
## Summary

- Neuer 🐛-Button im Top-Header **jedes** Screens (Heute / Verlauf / Trends / Mehr) und als Eintrag im „Mehr"-Hub.
- Modal lässt Bug oder Änderungswunsch beschreiben, optional Auto-Screenshot via lazy-loaded `html2canvas` anhängen (Modal schließt kurz, damit es nicht im Bild landet; max 1200 px Breite, JPEG 0.8).
- Worker-Endpoint `POST /feedback` erstellt automatisch GitHub-Issue auf `hjolmes/nutritrack` mit Labels `bug`/`enhancement` + `from-app`. Screenshot wird auf den (lazy erstellten) Branch `feedback-screenshots` als JPEG committet und im Issue-Body eingebettet.
- Aktueller Tab/Screen wird **vor** dem Modal-Open eingefroren, damit der Kontext (Tab, Screen, App-Version, PWA, Online, Zeitpunkt, User-Agent) korrekt bleibt.

## Files

- `index.html`: Modal `feedbackOv`, 4× Header-Buttons, „Mehr"-Hub-Eintrag, `// SECTION: FEEDBACK` (`openFeedback`/`attachFeedbackScreenshot`/`submitFeedback`/`_setFeedbackType`/`_clearFeedbackScreenshot`/`_captureFeedbackContext`), `APP_VERSION='0.145'`, CHANGELOG-Eintrag.
- `worker/src/index.js`: `handleFeedback` + `ensureFeedbackBranch` + `uploadFeedbackScreenshot`, `/feedback`-Route, `feedbackConfigured` im `/health`-Output, `codeVersion: "v0.145-feedback"`.
- `sw.js`: `VERSION = '0.145'` (`unpkg.com` ist bereits in der SKIP-Liste).
- `UEBERGABE.md`: Architektur-Block, Endpoint-Tabelle, Secrets, Live-Test-Status, Versions-Historie aktualisiert.

## Required Worker Setup before deploy

1. Fine-grained GitHub PAT erstellen — Scope `hjolmes/nutritrack`, Permissions: `Issues: read & write` + `Contents: read & write`.
2. `wrangler secret put GITHUB_TOKEN` (oder via Cloudflare-Dashboard).
3. Optional: `GITHUB_REPO` als plain env var (Default `hjolmes/nutritrack`).
4. Worker deployen.

## Test plan

- [ ] Worker `GET /health` zeigt `feedbackConfigured: true` + `codeVersion: "v0.145-feedback"`.
- [ ] Auf Tab `Heute` → 🐛 → Beschreibung „Test Bug" + Typ Bug → Senden → Toast „Issue #N erstellt", Issue erscheint in Repo mit Label `bug`+`from-app` und korrekter Kontext-Tabelle.
- [ ] Auf Tab `Trends` → 🐛 → „Screenshot anhängen" → Modal verschwindet kurz → Vorschau zeigt Trends-Screen (nicht das Modal) → Senden → Issue mit eingebettetem `![Screenshot](raw.githubusercontent.com/.../feedback/screenshots/...)`.
- [ ] Erster Screenshot-Upload erstellt den Branch `feedback-screenshots` automatisch.
- [ ] Leere Beschreibung blockiert Senden mit Hinweis-Toast.
- [ ] Screenshot >1 MB Base64 → Worker-Antwort 413, UI-Toast „Senden fehlgeschlagen".
- [ ] Browser-Console + `wrangler tail` ohne neue Fehler.

https://claude.ai/code/session_01CYWAtS4zn9LEreTMZzxQZw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYWAtS4zn9LEreTMZzxQZw)_