### PR TITLE
docs: UEBERGABE straffen, Versioning splitten, Issue/Wunsch-Workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,15 +41,16 @@ At the start of every work session, read the current version in both places:
 - `index.html`: `APP_VERSION`
 - `sw.js`: `VERSION`
 
-For deployable functional changes:
+For **any** change to shipped files (`index.html`, `sw.js`, `worker/`, `manifest.json`) — including invisible refactors, internal cleanups, or non-user-facing bugfixes:
 
 - Increment the beta version by `0.001`.
 - Update `APP_VERSION` in `index.html`.
 - Update visible version text in `index.html` if present.
-- Add a user-readable `CHANGELOG` entry in `index.html`.
 - Update `VERSION` in `sw.js` to the same version so the service worker refreshes caches.
 
-Documentation-only changes may skip app versioning unless they affect setup, deployment, user-visible help, or agent workflow.
+Add a user-readable `CHANGELOG` entry in `index.html` **only when the user notices the change** (new features, UI changes, visible bugfixes). For purely internal changes, skip the `CHANGELOG` entry — `checkWhatsNew()` automatically suppresses the "what's new" dialog for versions without a matching entry.
+
+Pure documentation changes (`UEBERGABE.md`, `CLAUDE.md`, `AGENTS.md`, README) may skip both the version bump and the CHANGELOG entry.
 
 ## Editing Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Bei Abschluss einer funktionalen Iteration (vor dem Merge) `UEBERGABE.md` aktual
 
 **`UEBERGABE.md` muss knapp bleiben — so viel wie nötig, so wenig wie möglich.** Beim Update: Architektur-Sektion **überschreiben statt anhängen** (sie beschreibt nur den aktuellen Stand, keine pro-Version-Chronik), erledigte Live-Tests streichen, Versions-Historie auf die letzten 5 Einträge kürzen, keine Inhalte aus `CLAUDE.md`/`AGENTS.md` duplizieren (Versioning-Workflow, Git-Workflow, Datenschutz, Cross-Platform-Regel). Details siehe Sektion „Pflege" in `UEBERGABE.md`.
 
+**Bug- und Wunsch-Workflow:** Bugs werden gemäß `issues.md` abgearbeitet, Wünsche gemäß `wuensche.md`. Beide Dateien enthalten nur Regeln — die eigentlichen Issues leben in GitHub (`label:bug` / `label:enhancement`, automatisch erzeugt vom Feedback-FAB). Pflicht vor jeder Arbeit am Issue: Themen-Label `topic:<bereich>` triagieren (passendes Label finden oder neu anlegen). Pro Iteration **genau ein Topic** — zusammengehörige Issues desselben Topics gemeinsam erledigen.
+
 Befolge ausserdem immer die vollständigen Regeln in `AGENTS.md`. Die wichtigsten Punkte zusammengefasst:
 
 ## Versioning (PFLICHT bei jeder deployablen Änderung)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 > **Erste Aktion in jeder neuen Session: Lies `UEBERGABE.md`.** Diese Datei enthält den aktuellen Projekt-Stand, die Architektur, offene Live-Tests und die Versions-Historie. Sie wird bei jedem deployablen Merge aktualisiert. Ohne sie ist keine sinnvolle Iteration möglich.
 
-Bei Abschluss einer funktionalen Iteration (vor dem Merge) `UEBERGABE.md` aktualisieren: Versionsstand, Architektur-Änderungen, Live-Test-Status, Versions-Historie.
+Bei Abschluss einer funktionalen Iteration (vor dem Merge) `UEBERGABE.md` aktualisieren: Versionsstand, Architektur (aktueller Live-Zustand), Live-Test-Status, Versions-Historie.
+
+**`UEBERGABE.md` muss knapp bleiben — so viel wie nötig, so wenig wie möglich.** Beim Update: Architektur-Sektion **überschreiben statt anhängen** (sie beschreibt nur den aktuellen Stand, keine pro-Version-Chronik), erledigte Live-Tests streichen, Versions-Historie auf die letzten 5 Einträge kürzen, keine Inhalte aus `CLAUDE.md`/`AGENTS.md` duplizieren (Versioning-Workflow, Git-Workflow, Datenschutz, Cross-Platform-Regel). Details siehe Sektion „Pflege" in `UEBERGABE.md`.
 
 Befolge ausserdem immer die vollständigen Regeln in `AGENTS.md`. Die wichtigsten Punkte zusammengefasst:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,17 @@ Befolge ausserdem immer die vollständigen Regeln in `AGENTS.md`. Die wichtigste
 
 ## Versioning (PFLICHT bei jeder deployablen Änderung)
 
-Bei jeder funktionalen Änderung (neue Features, Bugfixes, UI-Änderungen) MÜSSEN folgende vier Dinge gleichzeitig aktualisiert werden:
+**Versions-Bump (Punkte 1–3) bei JEDER Änderung an deployten Dateien** (`index.html`, `sw.js`, `worker/`, `manifest.json`) — auch bei reinen Refactorings, internen Verbesserungen oder Bugfixes, von denen der Nutzer nichts mitbekommt. Damit greifen Service-Worker-Cache-Invalidierung und Versions-Trail zuverlässig.
 
 1. `APP_VERSION` in `index.html` – um `0.001` erhöhen
 2. `VERSION` in `sw.js` – auf denselben Wert setzen
 3. Sichtbarer Versionstext `Beta vX.XXX` in `index.html` – alle Vorkommen (2×)
-4. `CHANGELOG`-Eintrag in `index.html` – kurze, nutzerlesbare Beschreibung
 
-Dokumentationsänderungen ohne Auswirkung auf die App dürfen den Versionsbump überspringen.
+**`CHANGELOG`-Eintrag (Punkt 4) NUR bei nutzerwahrnehmbaren Änderungen** (neue Features, UI-Änderungen, sichtbare Bugfixes). Refactorings, interne Cleanups, Doku-im-Code, Performance-Tweaks ohne UI-Effekt usw. erhalten **keinen** CHANGELOG-Eintrag — der „Was ist neu"-Dialog bleibt für diese Versionen still (`checkWhatsNew()` überspringt Versionen ohne `CHANGELOG`-Eintrag automatisch).
+
+4. `CHANGELOG`-Eintrag in `index.html` – kurze, nutzerlesbare Beschreibung (nur bei sichtbaren Änderungen)
+
+Reine Doku-Änderungen (`UEBERGABE.md`, `CLAUDE.md`, `AGENTS.md`, README) dürfen sowohl Versions-Bump als auch CHANGELOG-Eintrag überspringen — sie werden nicht ausgeliefert.
 
 ## Architektur
 

--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -1,223 +1,75 @@
-# NutriTrack — Übergabe an die nächste Claude-Session
+# NutriTrack — Übergabe
 
-> **Anweisung für neue Sessions:** Lies diese Datei zuerst. Sie ersetzt jede manuelle Kontext-Übergabe. Beim Abschluss einer Iteration (Merge auf `main`) wird sie aktualisiert.
+> Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Letzte Aktualisierung:** 2026-05-02 (nach v0.146)
+**Stand:** v0.146 (2026-05-02)
 
----
+## URLs
 
-## Aktueller Versionsstand
+- PWA: https://hjolmes.github.io/nutritrack/
+- Worker: https://nutritrack-ai-proxy.h-jolmes.workers.dev
+- Decoder: https://nutritrack-decoder-294137824893.europe-west1.run.app
 
-- **Live:** v0.146 auf `main` (Feedback-FAB global statt Header-Buttons – Issue #48)
-- **PWA:** https://hjolmes.github.io/nutritrack/
-- **Worker:** https://nutritrack-ai-proxy.h-jolmes.workers.dev (codeVersion `v0.145-feedback`, `POST /feedback` Endpoint)
-- **Decoder:** https://nutritrack-decoder-294137824893.europe-west1.run.app
+## Architektur (aktueller Live-Stand)
 
-## Architektur (Stand v0.146)
+- **Theme (v0.144):** Cream `#faf6f1`, Coral `#e96e3c`, Fraunces+Inter. Override-Block `/* BLOOM REDESIGN */` am Ende von `<style>`.
+- **Screens:** `mainScreen` (Heute, Hero-kcal, 2×2-Mahlzeiten-Grid), `historyScreen`, `mealDetailScreen`, `statsScreen`, `moreScreen`. Bottom-Nav mit 5 Items, `switchTab(tab)` mappt via `data-tab`, `'stats'`→`'trends'`.
+- **Datenkompatibilität:** Alte IDs (`tP/tC/tF`, `entries-<meal>` …) bleiben befüllt parallel zu neuen Grid-IDs (`kcal-<meal>`, `mealsTotal` …).
+- **Feedback (v0.146):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` → Bug/Wunsch + Beschreibung + optional Auto-Screenshot (lazy `html2canvas@1.4.1`, JPEG 0.8, ≤1200px). Section-Marker: `// SECTION: FEEDBACK`.
+- **Share/Import:** Sender → `POST /share` (Worker, KV, 1y TTL) → `?s=<id>` auf PWA-Origin. Empfänger: Android öffnet PWA via `handle_links`; iOS-Safari (non-standalone) bekommt `iosSwitchOv`-Anleitung + Auto-Clipboard, User wechselt zur PWA und tippt 📥 (`openImportPaste()`). Legacy-URL-Formen `#x=`/`#r=`/`workers.dev/s/<id>` bleiben kompatibel.
+- **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 
-### Feedback-Button (v0.146 – globaler FAB)
-
-- **UI:** Ein einziger globaler Floating-Action-Button (`#feedbackFab`, Klasse `.fb-fab`) unten rechts (`bottom:84px;right:12px`, `z-index:400`), platziert vor dem schließenden `</body>`-Tag. Auf jedem Screen sichtbar und auch über jedem geöffneten Overlay (`.ov` hat `z-index:300`). Auf `setupScreen` automatisch ausgeblendet via `body:has(#setupScreen.active) .fb-fab{display:none}`.
-- **Entfernt in v0.146 (Issue #48):** Alle vier Header-🐛-Buttons (`mainScreen`/`statsScreen`/`historyScreen`/`moreScreen`) und der eigene `list-row`-Eintrag im „Mehr"-Hub. Onclick-Hook bleibt `openFeedback()`.
-- **Modal `feedbackOv`:** Toggle Bug/Wunsch, freie Beschreibung (max 2000 Zeichen), optional Auto-Screenshot via lazy-loaded `html2canvas@1.4.1` (Modal schließt sich kurz, damit es nicht im Bild landet, max 1200px Breite, JPEG 0.8). Detail-Section zeigt vor dem Senden, was mitgeschickt wird (Tab, Screen, App-Version, PWA-Standalone, Online, Zeitpunkt, User-Agent).
-- **JS-Hooks:** `openFeedback()`, `attachFeedbackScreenshot()`, `submitFeedback()`, `_setFeedbackType()`, `_clearFeedbackScreenshot()`, `_captureFeedbackContext()`. Section-Marker im Code: `// SECTION: FEEDBACK`.
-- **Worker-Anbindung:** `POST https://nutritrack-ai-proxy.h-jolmes.workers.dev/feedback`. Body `{type:'bug'|'enhancement', description, context, screenshotB64?}`. Origin-Check, kein Proxy-Token (wie `/share`).
-- **GitHub-Flow im Worker:** Falls Screenshot vorhanden, wird er via Contents-API auf den (lazy erstellten) Branch `feedback-screenshots` nach `feedback/screenshots/<ts>-<rand>.jpg` committed. Danach wird ein Issue im konfigurierten Repo (`GITHUB_REPO`, default `hjolmes/nutritrack`) mit Title-Prefix `[Bug]`/`[Idee]`, Labels `bug|enhancement` + `from-app`, Markdown-Body inkl. Kontext-Tabelle und eingebettetem Screenshot-Link erstellt.
-- **Worker-Secrets (manuell):** `GITHUB_TOKEN` (fine-grained PAT, Scope `hjolmes/nutritrack`, Permissions `Issues: read & write` + `Contents: read & write`), optional `GITHUB_REPO` (sonst Default).
-- **Service Worker:** `unpkg.com` ist bereits in der SKIP-Liste (war für ZXing schon nötig) — html2canvas-CDN wird also nicht gecached und dadurch beim ersten Klick lazy nachgeladen.
-
-### UI-Struktur (Stand v0.144)
-
-- **Theme:** Cream-Background `#faf6f1`, Coral-Akzent `#e96e3c`, Fraunces-Serif (display) + Inter (body). Implementiert als Override-Block ganz unten im `<style>`-Bereich von `index.html` (`/* BLOOM REDESIGN v0.144 */`) — bestehende Klassen werden re-skinned, alle JS-Hooks bleiben erhalten.
-- **Screens:**
-  - `mainScreen` — Heute mit personalisierter „Hej {Name}"-Begrüßung, Hero-Kalorienzahl + `kcalTrendPill`, 3 Makro-Pills, Mahlzeiten-Grid (2×2).
-  - `historyScreen` — Verlauf der letzten 30 Tage als anklickbare Liste (`renderHistory()` → `goToDay(k)`).
-  - `mealDetailScreen` — Mahlzeit-Detail mit Foto-Header, Stat-Pills (kcal/P/C/F) und Zutaten-Liste; geöffnet via `openMealDetail(meal)`, geschlossen via `closeMealDetail()`.
-  - `statsScreen` — Trends (orange Streak-Card, Ø-kcal, Gewicht-Card, KI-Bericht).
-  - `moreScreen` — Hub mit Bibliothek, Einstellungen, Daten, Code einlösen, Hilfe, Was-ist-neu.
-- **Navigation:** Bottom-Nav als dunkle Pille mit 5 Items (Heute / Verlauf / + / Trends / Mehr). `switchTab(tab)` mappt via `data-tab`-Attribut, `'stats'` als Alias auf `'trends'`.
-- **Datenkompatibilität:** Alle bestehenden IDs (`tP/tC/tF`, `fP/fC/fF`, `entries-<meal>`, `sub-<meal>`) bleiben funktional — die alte renderAll-Schleife befüllt sie weiter, parallel werden die neuen Grid-IDs (`kcal-<meal>`, `time-<meal>`, `preview-<meal>`, `mealsTotal`, `mealsCount`) sowie die offene Detail-Seite über `_mealDetailOpen` mit aktualisiert.
-
-### Share-Flow (Rezepte / Mahlzeiten / Lebensmittel)
-
-```
-Sender PWA → POST /share (Cloudflare Worker, KV-write, 1y TTL)
-           ← {short: "https://hjolmes.github.io/nutritrack/?s=Ab12X"}
-           → navigator.share() bzw. clipboard
-
-Empfänger:
-─── Android Chrome PWA installiert ────────────────────────
-    Link tippen → handle_links matcht PWA-Scope → PWA öffnet
-    → boot detect ?s=<id> → GET /share/<id> (Worker, KV-read)
-    → _previewImport(d) → user confirms → recipes/customFoods/meals
-
-─── Android Chrome (ohne PWA) / Desktop ───────────────────
-    Link → Browser-Tab → PWA als Webseite → identischer Flow
-
-─── iOS Safari (non-standalone) ───────────────────────────
-    Apple isoliert seit iOS 17.4 Safari-Storage von der
-    installierten PWA. Lösung:
-    Link → Safari → boot detect ?s=<id> + iOS-Safari →
-    Auto-Copy URL in Zwischenablage → iosSwitchOv-Modal mit
-    3-Schritt-Anleitung („Schließe Safari → NutriTrack vom
-    Home-Bildschirm → 📥 antippen")
-    → User wechselt zur PWA → 📥 antippen
-    → openImportPaste() liest Clipboard → Auto-Fill
-    → Vorschau → user confirms → save
-
-─── iOS PWA (standalone) ──────────────────────────────────
-    Direkt-Import wie Android-PWA-Pfad
-```
-
-### URL-Format-Kompatibilität (alles backwards-kompatibel)
-
-- `?s=<id>` — v0.142+ (Worker-KV-Lookup, primär)
-- `#x=<base64>` — v0.139 unifiziertes Schema (inline, offline-fähig)
-- `#r=<base64>` — v0.138 nur-Rezept (inline, legacy)
-- `workers.dev/s/<id>` — v0.140 Legacy-URL (Worker leitet auf `?s=<id>` um)
-- Roher Code-Paste in `importPasteOv` Textarea funktioniert ebenfalls
-
-### Payload-Schema (base64-encoded JSON)
-
-```js
-// Rezept
-{t:'r', n:name, em:emoji, ins:instructions, i:[{n,em,a,p:{k,pr,c,f}}, ...]}
-// Lebensmittel (Custom Food)
-{t:'f', n:name, em:emoji, p:{k,pr,c,f}}
-// Mahlzeit
-{t:'m', m:mealKey, e:[entries]}
-```
-
-## Endpoints / Secrets
-
-### Cloudflare Worker
-
-URL: `https://nutritrack-ai-proxy.h-jolmes.workers.dev`
+## Worker-Endpoints
 
 | Endpoint | Zweck |
 |---|---|
-| `GET /health` | JSON inkl. `shareConfigured`, `decoderConfigured`, `codeVersion` |
-| `POST /v1/messages` | Anthropic-Proxy (KI-Foto/Chat), Token-Auth |
-| `POST /decode-barcode` | OSS-Decoder + optionaler Vision-Fallback |
-| `POST /share` | Body `{code:"<base64>"}` → `{ok:true, data:{id, short}}` |
-| `GET /share/<id>` | Lookup → `{ok:true, data:{id, code}}` |
-| `GET /s/<id>` | Legacy (v0.140) → HTML-Redirect zu `?s=<id>` |
-| `POST /feedback` | Body `{type, description, context, screenshotB64?}` → erstellt GitHub-Issue, optional Screenshot-Commit auf Branch `feedback-screenshots` |
+| `GET /health` | Status + `codeVersion` |
+| `POST /v1/messages` | Anthropic-Proxy (Token-Auth) |
+| `POST /decode-barcode` | OSS-Decoder + optional Vision-Fallback |
+| `POST /share` / `GET /share/<id>` | KV-Shortener |
+| `GET /s/<id>` | Legacy-Redirect |
+| `POST /feedback` | erstellt GitHub-Issue, optional Screenshot-Commit auf Branch `feedback-screenshots` |
 
-### Worker-Bindings/Secrets
+**Bindings/Secrets:** `ANTHROPIC_API_KEY`, `NUTRITRACK_PROXY_TOKEN`, `DECODER_URL`, `SHARE_KV` (KV `873c9976307f4af087ff8205ba957b1c`), `GITHUB_TOKEN` (fine-grained PAT, `hjolmes/nutritrack`, Issues+Contents read+write), opt. `GITHUB_REPO`.
 
-- `ANTHROPIC_API_KEY` (secret, optional via `ENABLE_VISION_FALLBACK=true`)
-- `NUTRITRACK_PROXY_TOKEN` (secret)
-- `DECODER_URL` (secret)
-- `SHARE_KV` (KV-Namespace, ID `873c9976307f4af087ff8205ba957b1c`)
-- `GITHUB_TOKEN` (secret, fine-grained PAT für `/feedback` — nur `hjolmes/nutritrack`, Permissions `Issues: read & write` + `Contents: read & write`)
-- `GITHUB_REPO` (optional env var, Default `hjolmes/nutritrack`)
+## Code-Suchpfade
 
-### Cloud Run Decoder
+`index.html`: `// SECTION: SHARE & IMPORT`, `// SECTION: FEEDBACK`, `_isIos()`, `_isPwaStandalone()`, `_checkSharedItemOnBoot()`, `_showIosBrowserToAppFlow()`, `openImportPaste()`, `openFeedback()`. Modale: `shareItemOv`, `importPasteOv`, `importConfirmOv`, `iosSwitchOv`, `feedbackOv`.
 
-URL: `https://nutritrack-decoder-294137824893.europe-west1.run.app`
-- OpenCV `BarcodeDetector` + pyzbar Fallback
-- Schutz: `--max-instances=2` + Budget-Alarm 1 €/Monat
+`worker/src/index.js`: `// ─── SHARE-LINK SHORTENER`, `// ─── FEEDBACK ENDPOINT`. Funktionen: `handleShareCreate/Lookup/Redirect`, `generateShareId` (Base58, 7 Zeichen), `handleFeedback`, `ensureFeedbackBranch`, `uploadFeedbackScreenshot`.
 
-## Code-Layout
+`manifest.json`: `handle_links: "preferred"`, `launch_handler.client_mode: "navigate-existing"`.
 
-### `index.html` (Hauptdatei)
+`sw.js`: SKIP-Liste enthält `workers.dev`, `is.gd`, `v.gd`, `unpkg.com`.
 
-Suchpfade für die wichtigsten Sektionen:
+## Live-Test offen
 
-- `// SECTION: SHARE & IMPORT` — universaler Share-/Import-Code
-- `_isIos()`, `_isPwaStandalone()` — Plattform-Detection
-- `_checkSharedItemOnBoot()` — Boot-Hook, verzweigt nach Plattform
-- `_showIosBrowserToAppFlow()` — iOS-Safari-Modal-Trigger
-- `openImportPaste()` — liest Clipboard, füllt Eingabefeld
-- Modale: `shareItemOv`, `importPasteOv`, `importConfirmOv`, `iosSwitchOv`
-- Top-Header `<button onclick="openImportPaste()">📥</button>` (Hauptansicht)
+- v0.142 Android Direct-PWA-Open (PWA-Reinstall ggf. nötig)
+- v0.143 iOS-Safari-Handoff 3-Schritt-Flow
+- v0.144 Bloom-Redesign in echter PWA
+- v0.145/0.146 Feedback-Flow End-to-End (braucht Worker-Deploy mit `GITHUB_TOKEN`)
 
-### `worker/src/index.js`
-
-- `// ─── SHARE-LINK SHORTENER (KV-backed) ───`
-- `handleShareCreate()` — POST /share
-- `handleShareLookup()` — GET /share/<id>
-- `handleShareRedirect()` — GET /s/<id> (Legacy)
-- `generateShareId()` — Base58-7-char IDs (kein 0/O/1/I/l)
-- `// ─── FEEDBACK ENDPOINT (creates GitHub Issue, optional screenshot upload) ───`
-- `handleFeedback()` — POST /feedback
-- `ensureFeedbackBranch()` — lazy create `feedback-screenshots` branch
-- `uploadFeedbackScreenshot()` — Contents-API PUT JPEG, returns `download_url`
-
-### `manifest.json`
-
-- `"handle_links": "preferred"` (Android Chrome ≥97 PWA-Routing)
-- `"launch_handler": {"client_mode": "navigate-existing"}`
-
-### `sw.js`
-
-- `VERSION = '0.145'`
-- SKIP-Liste: `workers.dev`, `is.gd`, `v.gd`, `unpkg.com`, etc. (kein SW-Caching für Shortener / CDN-Libs wie html2canvas)
-
-## Versioning-Workflow (PFLICHT bei jedem deployablen Bump)
-
-1. `APP_VERSION` in `index.html`
-2. `VERSION` in `sw.js` (gleicher Wert)
-3. Sichtbarer Versionstext `Beta vX.XXX` in `index.html` (2× Vorkommen via `replace_all`)
-4. CHANGELOG-Eintrag in `index.html` ganz oben
-5. **Diese `UEBERGABE.md` aktualisieren** (Versionsstand, evtl. Architektur, Live-Test-Status)
-
-Doku-only Änderungen dürfen den App-Bump überspringen.
-
-## Git-Workflow
-
-- Aktiver Default-Branch: `main`
-- Branch-Namen: `claude/nutritrack-vX.XXX` (Features), `claude/nutritrack-fix-*` (Fixes), `claude/nutritrack-<topic>` (sonstiges)
-- PRs werden via **squash** gemerged
-- Nach Merge: `git checkout main && git pull origin main`
-- Nie direkt auf `main` pushen
-
-## Cross-Platform-Regel (vom User explizit verlangt)
-
-**Eine Codebase, identische Features auf iOS und Android.** Nur der Barcode-Live-Scanner darf Plattform-Pfade haben (iOS Safari Live-Stream-Workaround). Alles andere muss auf beiden Plattformen identisch funktionieren. Manifest-Einträge die auf einer Plattform ignoriert werden (z. B. `handle_links` auf iOS) sind OK — kein Code-Fork.
-
-## Datenschutz
-
-Niemals committen: API Keys, OAuth Tokens, exportierte Backups, persönliche Ernährungsdaten, `.env`-Dateien, `.dev.vars`.
-
-## Live-Test-Status (offen)
-
-- ✅ Android Chrome PWA: Kurzlink funktioniert grundsätzlich (User-bestätigt)
-- ⏳ Android Direct-PWA-Open (v0.142): noch nicht live-getestet (eventuell PWA-Reinstall nötig damit Manifest neu geladen wird)
-- ⏳ iOS Safari-Handoff (v0.143): 3-Schritt-Flow noch nicht in der Praxis durchgespielt
-- ⏳ iOS PWA standalone Direct-Import: noch nicht getestet
-- ⏳ v0.144 Bloom-Redesign: nicht in echter PWA durchgespielt — Heute-Header personalisiert, 2×2-Grid und Mahlzeit-Detail bisher nur über statisches HTTP-Serving + JS-Syntax-Check verifiziert
-- ⏳ v0.145 Feedback-Button: End-to-End-Test ausstehend — benötigt erst Worker-Deploy mit gesetztem `GITHUB_TOKEN`-Secret + Issues-Schreibrechten auf `hjolmes/nutritrack`. Erst danach lässt sich der Flow (Modal → Beschreibung + Auto-Screenshot → Issue erscheint in GitHub mit Screenshot-Bild) verifizieren
-
-## Versions-Historie
+## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.138 | #36 | Rezepte als Link teilen (`#x=<base64>`) + Auto-Import-Dialog |
-| v0.139 | #37 | DRY-Refactor (Rezept/Mahlzeit/Lebensmittel ein Pfad), Custom-Food-Sharing |
-| v0.140 | #38 | Eigener Cloudflare-Worker-Shortener mit KV-Storage |
-| v0.141 | #39 | 📥 Import-Button in Top-Header der Hauptansicht |
-| v0.142 | #43 | Kurzlink wandert auf PWA-Origin → Android öffnet PWA direkt |
-| v0.143 | #43 | iOS-Safari-Handoff via Zwischenablage + Auto-Paste |
-| v0.144 | #45 | Bloom-Redesign (Cream/Coral/Fraunces) + 5-Tab-Bottom-Nav + Mahlzeit-Detail-Subseite + Verlauf/Mehr-Hub |
-| v0.145 | TBD | 🐛 Feedback-Button im Header jedes Screens + Mehr-Hub: Bug/Wunsch direkt aus der App als GitHub-Issue auf `hjolmes/nutritrack`, optional mit Auto-Screenshot (html2canvas, lazy-loaded). Worker-Endpoint `POST /feedback` mit lazy-erstelltem `feedback-screenshots` Branch für Screenshot-Commits |
-
-## Mögliche Folge-Iterationen (nicht eingeplant)
-
-- iOS-Live-Test des v0.143 Handoff-Flows in der Praxis durchspielen
-- Android-Live-Test mit PWA-Reinstall (damit neues Manifest greift)
-- KV-TTL evtl. von 1 Jahr auf 90 Tage senken wenn Volumen wächst
-- Wenn der Anthropic-Vision-Fallback nach Wochen ungenutzt: kompletter Removal aus `worker/src/index.js` (~60 LOC weniger)
-- v0.144 Folgearbeit: echte Foto-Vorschau im Mahlzeit-Detail (aktuell orange Platzhalter wenn keiner der Einträge ein `photo`-Feld hat), Trends-Card 12M-Toggle, „Mehr" um Datenexport-Slots erweitern
-
-## Cost / Limits
-
-- Cloud Run Decoder: Always-Free-Tier (2M req/Monat)
-- Anthropic Vision: 0 Calls (`ENABLE_VISION_FALLBACK=false`)
-- Cloudflare Workers KV: 100k Reads/Tag, 1k Writes/Tag, 1 GB — weit unter NutriTrack-Volumen
-- Worker selbst: Free-Tier, 100k req/Tag
+| v0.142 | #43 | Kurzlink auf PWA-Origin → Android öffnet PWA direkt |
+| v0.143 | #43 | iOS-Safari-Handoff via Zwischenablage |
+| v0.144 | #45 | Bloom-Redesign + 5-Tab-Bottom-Nav + Mahlzeit-Detail |
+| v0.145 | — | Feedback-Button (Header je Screen) + Worker `/feedback` |
+| v0.146 | #48 | Feedback als globaler FAB statt Header-Buttons |
 
 ---
 
-**Pflege-Hinweis für Claude:** Beim Abschluss jeder funktionalen Iteration vor dem Merge die Felder _Letzte Aktualisierung_, _Aktueller Versionsstand_, _Live-Test-Status_ und _Versions-Historie_ aktualisieren. Architektur-Änderungen entsprechend. Diese Datei ist die Single Source of Truth für den Projekt-Stand.
+## Pflege (PFLICHT)
+
+Diese Datei muss **knapp** bleiben — so viel wie nötig, so wenig wie möglich.
+
+Bei jedem deployablen Merge:
+
+1. `Stand` aktualisieren.
+2. Architektur-Sektion **überschreiben statt anhängen** — sie beschreibt nur den aktuellen Live-Zustand, keine Änderungs-Chronik. Veraltete oder durch Folge-Versionen ersetzte Bullets entfernen.
+3. Erledigte Live-Tests aus „Live-Test offen" streichen.
+4. Versions-Historie auf die letzten **5 Einträge** kürzen.
+
+Verboten in dieser Datei: pro-Version-Architektur-Beschreibungen, Wiederholungen aus `CLAUDE.md`/`AGENTS.md` (Versioning-Workflow, Git-Workflow, Datenschutz, Cross-Platform-Regel), Cost/Limits-Tabellen, Wunschlisten für Folge-Iterationen (gehören in GitHub-Issues).

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,33 @@
+# NutriTrack — Bug-Workflow
+
+Bugs werden ausschließlich als GitHub-Issues mit `label:bug` geführt — der Feedback-FAB in der App legt sie automatisch an (`bug` + `from-app`). Diese Datei beschreibt nur den Triage- und Abarbeitungs-Workflow, **keine Issue-Liste** (die lebt in GitHub).
+
+## Triage (vor jeder Arbeit am Issue)
+
+Jeder Bug bekommt zusätzlich zum `bug`-Label genau ein **Themen-Label** `topic:<kebab-case>`.
+
+1. Bestehende `topic:*`-Labels prüfen (GitHub MCP-Tools).
+2. Passt eines thematisch → anwenden.
+3. Passt keines → neues `topic:<bereich>` anlegen (kurze Beschreibung) + anwenden.
+
+**Themen-Schnitt:** Seiten und Funktionen, die zusammengehören, teilen sich ein Topic. Bugs und Wünsche teilen denselben Topic-Namensraum (siehe `wuensche.md`). Beispiele:
+
+- `topic:feedback` — Feedback-FAB, Feedback-Modal, Worker `/feedback`, Bug-/Wunsch-Reports
+- `topic:hauptseite` — Heute-Tab, Hero-kcal, Mahlzeiten-Grid, Begrüßung
+- `topic:share-import` — `/share`, `?s=<id>`, Import-Paste, iOS-Handoff, `iosSwitchOv`
+- `topic:trends` — Stats-Screen, Streak, Gewicht-Card, KI-Bericht
+- `topic:scanner` — Barcode-Scan, Decoder, ZXing
+- `topic:onedrive` — OAuth-PKCE, Graph-API, Backup-Sync
+- `topic:setup` — Einrichtung, `setupScreen`, Zielwerte
+- (weitere analog bei Bedarf)
+
+## Abarbeitung (pro Iteration)
+
+- **Genau ein Topic pro Iteration.** Mehrere offene Issues mit demselben `topic:` werden in einer Iteration / einem PR gemeinsam erledigt, wenn sie kohärent sind.
+- Reihenfolge: User-Priorität (Chat) > kritischste Bugs > Topic-Volumen. Nicht nach Erstelldatum.
+- Branch-Name `claude/nutritrack-fix-<topic>` oder `claude/nutritrack-vX.XXX`.
+- PR-Body: `Closes #N` für jedes erledigte Issue. Versionierung laut `CLAUDE.md`.
+
+## Verboten
+
+Issue-Listen, -Kopien oder -Backlogs in dieser Datei. Quelle ist ausschließlich GitHub.

--- a/wuensche.md
+++ b/wuensche.md
@@ -1,0 +1,19 @@
+# NutriTrack — Wunsch-Workflow
+
+Feature-Wünsche und Verbesserungsvorschläge werden ausschließlich als GitHub-Issues mit `label:enhancement` geführt — der Feedback-FAB in der App legt sie automatisch an (`enhancement` + `from-app`). Diese Datei beschreibt nur den Triage- und Abarbeitungs-Workflow, **keine Wunschliste** (die lebt in GitHub).
+
+## Triage
+
+Jeder Wunsch bekommt zusätzlich zum `enhancement`-Label genau ein **Themen-Label** `topic:<kebab-case>`. Vorgehen und Themen-Beispiele identisch zu `issues.md` — Bugs und Wünsche teilen denselben Topic-Namensraum.
+
+## Abarbeitung (pro Iteration)
+
+- **Genau ein Topic pro Iteration.** Wünsche desselben Topics werden zusammen umgesetzt, soweit sie kohärent sind.
+- Reihenfolge: User-Priorität (Chat) > Topic-Volumen. Nicht nach Erstelldatum.
+- Wünsche sind ein **Backlog, keine Zusagen** — was nicht passt, bleibt offen.
+- Bug + Wunsch desselben Topics dürfen in einer Iteration kombiniert werden, wenn sie kohärent sind.
+- Branch-Name `claude/nutritrack-vX.XXX` (ggf. mit Topic-Suffix). Versionierung laut `CLAUDE.md`.
+
+## Verboten
+
+Wunschlisten, -Kopien oder -Backlogs in dieser Datei. Quelle ist ausschließlich GitHub.


### PR DESCRIPTION
## Summary

Reine Doku-Änderung — kein App-Code betroffen, kein Versions-Bump.

- **`UEBERGABE.md`**: 223 → 75 Zeilen (−66 %). Architektur beschreibt nur den aktuellen Live-Zustand statt einer pro-Version-Chronik. Versions-Historie auf letzte 5 Einträge reduziert. Duplikate aus `CLAUDE.md`/`AGENTS.md` (Versioning, Git-Workflow, Datenschutz, Cross-Platform-Regel) entfernt. Cost/Limits- und Wunschlisten raus. Neue „Pflege"-Sektion macht die Knappheits-Regel verbindlich.
- **`CLAUDE.md` + `AGENTS.md`**: Versioning-Regel gesplittet. Versions-Bump (Punkte 1–3) ist Pflicht bei *jeder* Änderung an deployten Dateien — auch bei internen Refactorings ohne UI-Effekt. CHANGELOG-Eintrag (Punkt 4) **nur** bei nutzerwahrnehmbaren Änderungen. `checkWhatsNew()` überspringt Versionen ohne CHANGELOG-Eintrag bereits automatisch.
- **`issues.md` + `wuensche.md` (neu)**: Workflow-Regeln für Bugs (`label:bug`) und Wünsche (`label:enhancement`). Quelle bleibt GitHub — keine Issue-Listen in den Files. Pflicht-Triage: Themen-Label `topic:<bereich>` setzen (passendes prüfen, sonst neu anlegen). Pro Iteration genau ein Topic. Bug- und Wunsch-Topics teilen denselben Namensraum, Beispiele: `topic:feedback`, `topic:hauptseite`, `topic:share-import`, `topic:trends`, `topic:scanner`, `topic:onedrive`, `topic:setup`.

## Test plan

- [x] `wc -l UEBERGABE.md` → 75 Zeilen
- [x] Kein `index.html`/`sw.js`/`worker/`/`manifest.json` verändert → kein Versions-Bump nötig
- [x] Verweise auf `issues.md`/`wuensche.md` in `CLAUDE.md` vorhanden

https://claude.ai/code/session_01ML2JcUMrJqxJQ3bMyaXfcy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ML2JcUMrJqxJQ3bMyaXfcy)_