### PR TITLE
v0.148 + v0.149 + v0.150: Feedback / Hauptseite / KI-Tagesbewertung

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.146 (2026-05-02)
+**Stand:** v0.150 (2026-05-02)
 
 ## URLs
 
@@ -15,7 +15,10 @@
 - **Theme (v0.144):** Cream `#faf6f1`, Coral `#e96e3c`, Fraunces+Inter. Override-Block `/* BLOOM REDESIGN */` am Ende von `<style>`.
 - **Screens:** `mainScreen` (Heute, Hero-kcal, 2×2-Mahlzeiten-Grid), `historyScreen`, `mealDetailScreen`, `statsScreen`, `moreScreen`. Bottom-Nav mit 5 Items, `switchTab(tab)` mappt via `data-tab`, `'stats'`→`'trends'`.
 - **Datenkompatibilität:** Alte IDs (`tP/tC/tF`, `entries-<meal>` …) bleiben befüllt parallel zu neuen Grid-IDs (`kcal-<meal>`, `mealsTotal` …).
-- **Feedback (v0.146):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` → Bug/Wunsch + Beschreibung + optional Auto-Screenshot (lazy `html2canvas@1.4.1`, JPEG 0.8, ≤1200px). Section-Marker: `// SECTION: FEEDBACK`.
+- **Feedback (v0.148):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` (eigener `z-index:350`, sitzt über anderen Modalen). Layout: Type-Buttons → Textarea → Senden → ausklappbares `<details id="feedbackShotDetails">` mit „📸 Sichtbarer Ausschnitt" (lazy `html2canvas@1.4.1`, captured nur Viewport via `x/y/width/height`+`windowWidth/Height`) + „📁 Eigenes Foto…" (`#feedbackPhotoInput`, max 8 MB, JPEG 0.8/≤1200px in `attachFeedbackPhoto`). Section-Marker: `// SECTION: FEEDBACK`.
+- **Header (v0.149):** `mainScreen`/`statsScreen` ohne `📤 shareData` — nur `?` `📥` `⚙️`. Backup nur via Settings/Datensicherung, „Mehr"-Hub-Eintrag, OneDrive-Banner und Backup-Reminder. `historyScreen`/`mealDetailScreen`/`moreScreen` haben minimale Header.
+- **Kalorien-Ampel (v0.149):** `_kcalAmpel(goal,eaten,S)` vor `renderAll()` — ±10 % grün; darüber/darunter abhängig von Diät-Richtung (lose/gain/maintain), abgeleitet aus `S.goalWeight` vs `S.weight ±0.5`. `kcalTrendPill`-Klassen `balanced`/`over`.
+- **KI-Tagesbewertung (v0.150):** `requestKIRating(ev)` baut Prompt mit Per-Mahlzeit-Makros (kcal · P · K · F), Gesamt-Makros und Makro-Zielen aus `getMacroTargets()`. Leere KI-Antwort → Toast + Button-Reset; `max_tokens=300`, model `claude-haiku-4-5`.
 - **Share/Import:** Sender → `POST /share` (Worker, KV, 1y TTL) → `?s=<id>` auf PWA-Origin. Empfänger: Android öffnet PWA via `handle_links`; iOS-Safari (non-standalone) bekommt `iosSwitchOv`-Anleitung + Auto-Clipboard, User wechselt zur PWA und tippt 📥 (`openImportPaste()`). Legacy-URL-Formen `#x=`/`#r=`/`workers.dev/s/<id>` bleiben kompatibel.
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 
@@ -44,20 +47,19 @@
 
 ## Live-Test offen
 
-- v0.142 Android Direct-PWA-Open (PWA-Reinstall ggf. nötig)
-- v0.143 iOS-Safari-Handoff 3-Schritt-Flow
-- v0.144 Bloom-Redesign in echter PWA
-- v0.145/0.146 Feedback-Flow End-to-End (braucht Worker-Deploy mit `GITHUB_TOKEN`)
+- v0.148 Feedback-Modal vor offenem anderen Modal (z-index), Viewport-Screenshot, „📁 Eigenes Foto…"
+- v0.149 Kalorien-Ampel pro Diät-Richtung (lose/gain/maintain mit/ohne Zielgewicht)
+- v0.150 KI-Tagesbewertung mit Makros + leere-Antwort-Toast
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.142 | #43 | Kurzlink auf PWA-Origin → Android öffnet PWA direkt |
-| v0.143 | #43 | iOS-Safari-Handoff via Zwischenablage |
-| v0.144 | #45 | Bloom-Redesign + 5-Tab-Bottom-Nav + Mahlzeit-Detail |
-| v0.145 | — | Feedback-Button (Header je Screen) + Worker `/feedback` |
 | v0.146 | #48 | Feedback als globaler FAB statt Header-Buttons |
+| v0.147 | #50 | Feedback-Modal: „✕ entfernen"-Button stacken |
+| v0.148 | — | Feedback: z-index über anderen Modals + Viewport-Screenshot + Layout (Senden direkt unter Textfeld, Screenshot ausklappbar, „📁 Eigenes Foto…") (#54, #56, #57) |
+| v0.149 | — | Header ohne 📤 + Kalorien-Ampel ±10 %/diät-zielabhängig (#52, #53) |
+| v0.150 | — | KI-Tagesbewertung mit Per-Mahlzeit-Makros + leere-Antwort-Handling (#55) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -968,7 +968,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.149</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.150</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1846,7 +1846,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.149';
+var APP_VERSION='0.150';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1875,6 +1875,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.150',items:[
+    {icon:'🤖',text:'KI-Tagesbewertung („🤖 Tag bewerten" auf der Heute-Seite): Prompt enthält jetzt Makros pro Mahlzeit (kcal · P · K · F) plus Gesamt-Makros und Makro-Ziele – die Bewertung bezieht sich nun konkret auf Kalorien- und Makroziele. Bei leerer KI-Antwort kommt eine Hinweis-Toast statt einem stummen leeren Feld; Token-Limit auf 300 erhöht (Issue #55)',where:'Heute-Tab · KI-Tagesbewertung'},
+  ]},
   {v:'0.149',items:[
     {icon:'🐛',text:'Header aufgeräumt: „📤 Sichern" ist nicht mehr im Header neben „📥 Importieren" (zu ähnlich, zu nah). Daten-Sicherung läuft jetzt nur noch über Einstellungen → Datensicherung bzw. den „Mehr"-Hub → Daten teilen / sichern (Issue #53)',where:'Heute · Trends'},
     {icon:'🎯',text:'Kalorien-Ampel auf der Heute-Seite richtet sich nach deinem Diät-Ziel: ±10 % vom Kalorienziel = grün („im Plan"); darüber/darunter ist abhängig vom Zielgewicht. Wer abnehmen will, bekommt Unterschreitungen grün („gut für dein Defizit") und Überschreitungen rot mit Bewegungstipp. Wer zunehmen will, bekommt es genau umgekehrt. Ohne Zielgewicht (Halten) wird beides als Hinweis markiert (Issue #52)',where:'Heute-Tab · Hero-Pill unter der kcal-Zahl'},
@@ -4155,7 +4158,7 @@ function renderKIButtons(){
   }
   dayWrap.innerHTML='<div style="display:flex;align-items:center;justify-content:space-between;">'
     +(rating?'<button type="button" onclick="toggleKIText()" style="font-size:12px;background:none;border:none;color:rgba(255,255,255,0.7);font-weight:700;cursor:pointer;padding:0;">'+(open?'▲ Einschätzung':'▼ Einschätzung')+'</button>':'<span></span>')
-    +'<button type="button" onclick="requestKIRating(\'day\')" '+btnDisabled+' style="'+btnStyle+'">'+btnLabel+'</button>'
+    +'<button type="button" onclick="requestKIRating(event)" '+btnDisabled+' style="'+btnStyle+'">'+btnLabel+'</button>'
     +'</div>'
     +ratingHtml;
 }
@@ -4167,38 +4170,51 @@ function toggleKIText(){
   saveS();renderKIButtons();
 }
 
-function requestKIRating(meal){
+function requestKIRating(ev){
   if(!canUseAi()){showAiUnavailable();return;}
   var day=getDay();
-  var btn=event&&event.target;
+  var btn=(ev&&ev.target)||(typeof event!=='undefined'&&event&&event.target)||null;
   if(btn){btn.disabled=true;btn.textContent='⏳ Analysiere...';}
   var items=[];
   MEALS.forEach(function(m){
     (day.meals[m]||[]).forEach(function(e){items.push(e);});
   });
-  if(!items.length){if(btn)btn.disabled=false;return;}
+  if(!items.length){if(btn){btn.disabled=false;btn.textContent='🤖 Tag bewerten';}return;}
   var hash=JSON.stringify(MEALS.map(function(m){
     return(day.meals[m]||[]).map(function(e){return e.name+(e.amount||'')+(e.kcal||'');}).join('|');
   }));
   var allPrefs=(S.dietPrefs||[]).concat(S.dietFree?[S.dietFree]:[]);
   var prefStr=allPrefs.length?'\nErnährungspräferenzen: '+allPrefs.join(', '):'';
   var goal=S.goal||2000;
-  var t={kcal:0,protein:0,carbs:0,fat:0};
-  items.forEach(function(e){t.kcal+=e.kcal||0;t.protein+=e.protein||0;t.carbs+=e.carbs||0;t.fat+=e.fat||0;});
+  var t=calcM(items);
+  var mtg=getMacroTargets()||{};
+  // Pro Mahlzeit Name + Makros anhängen, damit die KI eine vollständige Grundlage hat.
   var byMeal=MEALS.map(function(m){
     var en=day.meals[m]||[];
     if(!en.length)return '';
-    return MEAL_NAMES[m]+': '+en.map(function(e){return e.name;}).join(', ');
+    var ms=calcM(en);
+    return MEAL_NAMES[m]+' ('+Math.round(ms.kcal)+' kcal · '+Math.round(ms.protein)+'g P · '+Math.round(ms.carbs)+'g K · '+Math.round(ms.fat)+'g F): '
+      +en.map(function(e){return e.name;}).join(', ');
   }).filter(Boolean).join('\n');
-  var prompt='Bewerte den Ernährungstag auf Deutsch in maximal 2 kurzen Sätzen. Nur Fließtext.\n'
+  var goalsStr='Tagesziel: '+goal+' kcal';
+  if(mtg.protein||mtg.carbs||mtg.fat){
+    goalsStr+=' · Protein '+Math.round(mtg.protein||0)+'g · Kohlenh. '+Math.round(mtg.carbs||0)+'g · Fett '+Math.round(mtg.fat||0)+'g';
+  }
+  var prompt='Bewerte den Ernährungstag auf Deutsch in maximal 2 kurzen Sätzen. Nur Fließtext, keine Aufzählung.\n'
     +'Mahlzeiten:\n'+byMeal+'\n'
-    +'Gesamt: '+Math.round(t.kcal)+' kcal, Protein '+Math.round(t.protein)+'g, Carbs '+Math.round(t.carbs)+'g, Fett '+Math.round(t.fat)+'g\n'
-    +'Tagesziel: '+goal+' kcal'+prefStr+'\n'
-    +'1 Satz positiv, 1 Satz Verbesserungspotenzial. Maximal 50 Wörter gesamt.';
-  callClaude('claude-haiku-4-5',[{type:'text',text:prompt}],150,
+    +'Gesamt: '+Math.round(t.kcal)+' kcal · Protein '+Math.round(t.protein)+'g · Kohlenh. '+Math.round(t.carbs)+'g · Fett '+Math.round(t.fat)+'g\n'
+    +goalsStr+prefStr+'\n'
+    +'1 Satz positiv, 1 Satz Verbesserungspotenzial mit Bezug auf Kalorien- und Makroziele. Maximal 60 Wörter gesamt.';
+  callClaude('claude-haiku-4-5',[{type:'text',text:prompt}],300,
     function(text){
+      var clean=(text||'').trim();
+      if(!clean){
+        if(btn){btn.disabled=false;btn.textContent='🤖 Tag bewerten';}
+        showToast('KI-Antwort leer – bitte erneut versuchen');
+        return;
+      }
       if(!day.kiRating)day.kiRating={};
-      day.kiRating.day=text.trim();
+      day.kiRating.day=clean;
       day.kiRating.hash=hash;
       day.kiRating.open=true;
       saveS();renderKIButtons();

--- a/index.html
+++ b/index.html
@@ -658,7 +658,6 @@ button,input,select,textarea{font-family:var(--fs-body);}
       </div>
       <div style="display:flex;gap:6px;">
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
-        <button type="button" class="hbtn" onclick="shareData()" id="shareBtn" title="Daten sichern">📤</button>
         <button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button>
         <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
@@ -804,7 +803,6 @@ button,input,select,textarea{font-family:var(--fs-body);}
       </div>
       <div style="display:flex;gap:6px;">
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
-        <button type="button" class="hbtn" onclick="shareData()" title="Daten sichern">📤</button>
         <button type="button" class="hbtn" onclick="openImportPaste()" title="Importieren">📥</button>
         <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
@@ -970,7 +968,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.148</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.149</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1848,7 +1846,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.148';
+var APP_VERSION='0.149';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1877,6 +1875,10 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.149',items:[
+    {icon:'🐛',text:'Header aufgeräumt: „📤 Sichern" ist nicht mehr im Header neben „📥 Importieren" (zu ähnlich, zu nah). Daten-Sicherung läuft jetzt nur noch über Einstellungen → Datensicherung bzw. den „Mehr"-Hub → Daten teilen / sichern (Issue #53)',where:'Heute · Trends'},
+    {icon:'🎯',text:'Kalorien-Ampel auf der Heute-Seite richtet sich nach deinem Diät-Ziel: ±10 % vom Kalorienziel = grün („im Plan"); darüber/darunter ist abhängig vom Zielgewicht. Wer abnehmen will, bekommt Unterschreitungen grün („gut für dein Defizit") und Überschreitungen rot mit Bewegungstipp. Wer zunehmen will, bekommt es genau umgekehrt. Ohne Zielgewicht (Halten) wird beides als Hinweis markiert (Issue #52)',where:'Heute-Tab · Hero-Pill unter der kcal-Zahl'},
+  ]},
   {v:'0.148',items:[
     {icon:'🐛',text:'Feedback-Modal liegt jetzt über allen anderen Modalen (vorher konnte es hinter offenen Dialogen verschwinden, Issue #57)',where:'Feedback-Modal'},
     {icon:'🐛',text:'Screenshot beim Feedback nimmt nur noch den sichtbaren Ausschnitt auf (vorher die ganze Seite) – kleinere Datei, präzisere Suche (Issue #56)',where:'Feedback-Modal · 📸 Sichtbarer Ausschnitt'},
@@ -2556,6 +2558,28 @@ function totalStr(t){return Math.round(t.kcal)+' kcal · P'+Math.round(t.protein
 // ════════════════════════════════════════
 // SECTION: RENDER
 // ════════════════════════════════════════
+function _kcalAmpel(goal,eaten,S){
+  // Liefert {state:'balanced'|'over'|'under', text}.
+  // ±10 % Toleranz = grün. Außerhalb: Bewertung anhand Diät-Ziel
+  // (lose/gain/maintain), abgeleitet aus S.goalWeight vs S.weight.
+  var diff=goal-eaten;
+  var pct=goal?Math.round(Math.abs(diff)/goal*100):0;
+  if(pct<=10)return {state:'balanced',text:'✓ im Plan ('+pct+' %)'};
+  var dir='maintain';
+  if(S&&S.goalWeight&&S.weight){
+    if(S.goalWeight<S.weight-0.5)dir='lose';
+    else if(S.goalWeight>S.weight+0.5)dir='gain';
+  }
+  if(diff<0){
+    // über dem Kalorienziel
+    if(dir==='gain')return {state:'balanced',text:'⬈ '+pct+' % über Ziel · super, baut auf'};
+    return {state:'over',text:'⬈ '+pct+' % über Ziel · ein paar Schritte gehen?'};
+  }
+  // unter dem Kalorienziel
+  if(dir==='lose')return {state:'balanced',text:'⬊ '+pct+' % unter Ziel · gut für dein Defizit'};
+  return {state:'over',text:'⬊ '+pct+' % unter Ziel · noch etwas essen!'};
+}
+
 function renderAll(){
   document.getElementById('dateLabel').textContent=fmtDate(S.currentDate);
   document.getElementById('btnNext').style.opacity=S.currentDate===today()?'0.3':'1';
@@ -2655,13 +2679,11 @@ function renderAll(){
   var gs=document.getElementById('greetSub');if(gs)gs.textContent=formatGreetSub(S.currentDate);
   var pill=document.getElementById('kcalTrendPill');
   if(pill){
-    var goal=S.goal||2000,eaten=Math.max(0,t.kcal-burned);
-    var diff=goal-eaten,dpct=goal?Math.round(Math.abs(diff)/goal*100):0;
+    var ampel=_kcalAmpel(S.goal||2000,Math.max(0,t.kcal-burned),S);
     pill.classList.remove('over','balanced');
-    if(diff<0){pill.classList.add('over');pill.textContent='⬈ '+dpct+' % über Soll';}
-    else if(dpct<5){pill.classList.add('balanced');pill.textContent='✓ im Plan';}
-    else if(dpct<15){pill.textContent='⬊ '+dpct+' % unter Soll · leicht';}
-    else {pill.textContent='⬊ '+dpct+' % unter Soll · stark';}
+    if(ampel.state==='balanced')pill.classList.add('balanced');
+    else if(ampel.state==='over')pill.classList.add('over');
+    pill.textContent=ampel.text;
   }
   var mtg=getMacroTargets();
   var gpe=document.getElementById('gP');if(gpe)gpe.textContent=mtg.protein?' /'+Math.round(mtg.protein)+'g':'';

--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@ body:has(#setupScreen.active) .fb-fab{display:none;}
 
 /* ── OVERLAYS ── */
 .ov{position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:300;display:none;align-items:flex-end;justify-content:center;backdrop-filter:blur(2px);}
+#feedbackOv{z-index:350;}
 .ov .mod{position:fixed;bottom:0;left:0;right:0;max-width:430px;margin:0 auto;}
 .ov.open{display:flex;}
 .mod{background:white;border-radius:24px 24px 0 0;width:100%;max-width:430px;height:88vh;max-height:88vh;overflow-y:auto;animation:su .3s cubic-bezier(.4,0,.2,1);}
@@ -969,7 +970,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.147</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.148</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1496,19 +1497,24 @@ button,input,select,textarea{font-family:var(--fs-body);}
       </div>
       <textarea id="feedbackText" rows="5" placeholder="Was ist passiert / was wünschst du dir? Je konkreter, desto besser."
         style="width:100%;box-sizing:border-box;border:1.5px solid var(--br);border-radius:12px;padding:12px;font-size:14px;resize:vertical;outline:none;margin-bottom:10px;"></textarea>
-      <div style="margin-bottom:10px;">
-        <button type="button" class="seb" onclick="attachFeedbackScreenshot()" id="feedbackShotBtn" style="margin-top:0;">📸 Screenshot anhängen</button>
-        <button type="button" class="seb" onclick="_clearFeedbackScreenshot()" id="feedbackShotClear" style="display:none;">✕ Screenshot entfernen</button>
-      </div>
-      <div id="feedbackShotPreview" style="display:none;margin-bottom:10px;">
-        <img id="feedbackShotImg" alt="Screenshot-Vorschau" style="max-width:100%;border-radius:10px;border:1px solid var(--br);">
-        <div style="font-size:11px;color:var(--mu);margin-top:4px;text-align:center;">Vorschau – prüfe vor dem Senden, ob persönliche Daten sichtbar sind.</div>
-      </div>
+      <button type="button" class="svb" id="feedbackSendBtn" onclick="submitFeedback()" style="margin-top:0;margin-bottom:12px;">📤 Senden</button>
+      <details id="feedbackShotDetails" style="margin-bottom:10px;border:1px solid var(--br);border-radius:10px;padding:8px 12px;">
+        <summary style="font-size:13px;cursor:pointer;font-weight:600;">📸 Screenshot anhängen <span id="feedbackShotBadge" style="display:none;font-size:11px;font-weight:500;color:var(--g1);">· angehängt</span></summary>
+        <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap;">
+          <button type="button" class="seb" onclick="attachFeedbackScreenshot()" id="feedbackShotBtn" style="margin-top:0;flex:1 1 140px;">📸 Sichtbarer Ausschnitt</button>
+          <button type="button" class="seb" onclick="document.getElementById('feedbackPhotoInput').click()" id="feedbackPhotoBtn" style="margin-top:0;flex:1 1 140px;">📁 Eigenes Foto…</button>
+          <input type="file" id="feedbackPhotoInput" accept="image/*" style="display:none;" onchange="attachFeedbackPhoto(event)">
+          <button type="button" class="seb" onclick="_clearFeedbackScreenshot()" id="feedbackShotClear" style="display:none;margin-top:0;flex:1 1 100%;">✕ Entfernen</button>
+        </div>
+        <div id="feedbackShotPreview" style="display:none;margin-top:10px;">
+          <img id="feedbackShotImg" alt="Screenshot-Vorschau" style="max-width:100%;border-radius:10px;border:1px solid var(--br);">
+          <div style="font-size:11px;color:var(--mu);margin-top:4px;text-align:center;">Vorschau – prüfe vor dem Senden, ob persönliche Daten sichtbar sind.</div>
+        </div>
+      </details>
       <details style="margin-bottom:10px;">
         <summary style="font-size:12px;color:var(--mu);cursor:pointer;padding:4px 0;">Was wird mitgeschickt?</summary>
         <div id="feedbackCtxPreview" style="font-size:11px;color:var(--mu);background:var(--gl);border-radius:8px;padding:8px;margin-top:6px;font-family:monospace;white-space:pre-wrap;word-break:break-all;"></div>
       </details>
-      <button type="button" class="svb" id="feedbackSendBtn" onclick="submitFeedback()" style="margin-top:0;margin-bottom:8px;">📤 Senden</button>
       <button type="button" class="seb" onclick="closeOv('feedbackOv')">Abbrechen</button>
       <div style="font-size:11px;color:var(--mu);margin-top:10px;text-align:center;line-height:1.4;">
         Landet als GitHub-Issue auf <strong>hjolmes/nutritrack</strong>.
@@ -1842,7 +1848,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.147';
+var APP_VERSION='0.148';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1871,6 +1877,11 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.148',items:[
+    {icon:'🐛',text:'Feedback-Modal liegt jetzt über allen anderen Modalen (vorher konnte es hinter offenen Dialogen verschwinden, Issue #57)',where:'Feedback-Modal'},
+    {icon:'🐛',text:'Screenshot beim Feedback nimmt nur noch den sichtbaren Ausschnitt auf (vorher die ganze Seite) – kleinere Datei, präzisere Suche (Issue #56)',where:'Feedback-Modal · 📸 Sichtbarer Ausschnitt'},
+    {icon:'🐛',text:'Feedback-Modal aufgeräumt: „📤 Senden" sitzt jetzt direkt unter dem Textfeld, der Screenshot-Bereich ist ausklappbar und enthält neben dem Auto-Screenshot auch „📁 Eigenes Foto…" als Fallback (Issue #54)',where:'Feedback-Modal'},
+  ]},
   {v:'0.147',items:[
     {icon:'🐛',text:'Feedback-Modal: „✕ Screenshot entfernen" liegt jetzt unter dem „Screenshot anhängen"-Button (vorher daneben mit unsauber breiter leerer Fläche)',where:'Feedback-Modal'},
   ]},
@@ -5597,9 +5608,26 @@ function _clearFeedbackScreenshot(){
   var p=document.getElementById('feedbackShotPreview');
   var img=document.getElementById('feedbackShotImg');
   var clr=document.getElementById('feedbackShotClear');
+  var badge=document.getElementById('feedbackShotBadge');
+  var inp=document.getElementById('feedbackPhotoInput');
   if(p)p.style.display='none';
   if(img)img.src='';
   if(clr)clr.style.display='none';
+  if(badge)badge.style.display='none';
+  if(inp)inp.value='';
+}
+
+function _showFeedbackShotPreview(dataUrl){
+  var img=document.getElementById('feedbackShotImg');
+  var p=document.getElementById('feedbackShotPreview');
+  var clr=document.getElementById('feedbackShotClear');
+  var badge=document.getElementById('feedbackShotBadge');
+  var det=document.getElementById('feedbackShotDetails');
+  if(img)img.src=dataUrl;
+  if(p)p.style.display='block';
+  if(clr)clr.style.display='block';
+  if(badge)badge.style.display='inline';
+  if(det)det.open=true;
 }
 
 function openFeedback(){
@@ -5632,8 +5660,14 @@ function attachFeedbackScreenshot(){
   // Modal kurz schließen, damit es nicht im Bild landet
   closeOv('feedbackOv');
   setTimeout(function(){
+    var sx=window.scrollX||window.pageXOffset||0;
+    var sy=window.scrollY||window.pageYOffset||0;
+    var vw=window.innerWidth;
+    var vh=window.innerHeight;
     _loadHtml2Canvas().then(function(h2c){
-      return h2c(document.body,{scale:0.7,logging:false,useCORS:true,backgroundColor:'#faf6f1'});
+      // Nur sichtbarer Ausschnitt – das, was der Nutzer zuletzt gesehen hat
+      return h2c(document.body,{scale:0.7,logging:false,useCORS:true,backgroundColor:'#faf6f1',
+        x:sx,y:sy,width:vw,height:vh,scrollX:0,scrollY:0,windowWidth:vw,windowHeight:vh});
     }).then(function(canvas){
       // Auf max 1200px Breite begrenzen
       var max=1200;
@@ -5642,20 +5676,42 @@ function attachFeedbackScreenshot(){
         c2.getContext('2d').drawImage(canvas,0,0,c2.width,c2.height);canvas=c2;}
       var dataUrl=canvas.toDataURL('image/jpeg',0.8);
       _feedbackScreenshotB64=dataUrl.split(',')[1];
-      var img=document.getElementById('feedbackShotImg');
-      var p=document.getElementById('feedbackShotPreview');
-      var clr=document.getElementById('feedbackShotClear');
-      if(img)img.src=dataUrl;
-      if(p)p.style.display='block';
-      if(clr)clr.style.display='block';
+      _showFeedbackShotPreview(dataUrl);
       openOv('feedbackOv');
     }).catch(function(err){
       openOv('feedbackOv');
       showToast('Screenshot fehlgeschlagen: '+(err&&err.message||'unbekannt'));
     }).then(function(){
-      if(btn){btn.disabled=false;btn.textContent='📸 Screenshot anhängen';}
+      if(btn){btn.disabled=false;btn.textContent='📸 Sichtbarer Ausschnitt';}
     });
   },120);
+}
+
+function attachFeedbackPhoto(ev){
+  var f=ev&&ev.target&&ev.target.files&&ev.target.files[0];
+  if(!f)return;
+  if(!/^image\//.test(f.type)){showToast('Bitte Bild-Datei wählen');return;}
+  if(f.size>8*1024*1024){showToast('Bild zu groß (max 8 MB)');return;}
+  var reader=new FileReader();
+  reader.onload=function(e){
+    var src=e.target.result;
+    var im=new Image();
+    im.onload=function(){
+      // Auf max 1200px Breite verkleinern + JPEG 0.8
+      var max=1200;
+      var w=im.width,h=im.height;
+      if(w>max){var f2=max/w;w=max;h=Math.round(h*f2);}
+      var c=document.createElement('canvas');c.width=w;c.height=h;
+      c.getContext('2d').drawImage(im,0,0,w,h);
+      var dataUrl=c.toDataURL('image/jpeg',0.8);
+      _feedbackScreenshotB64=dataUrl.split(',')[1];
+      _showFeedbackShotPreview(dataUrl);
+    };
+    im.onerror=function(){showToast('Bild konnte nicht gelesen werden');};
+    im.src=src;
+  };
+  reader.onerror=function(){showToast('Datei konnte nicht gelesen werden');};
+  reader.readAsDataURL(f);
 }
 
 function submitFeedback(){

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.149';
+var VERSION = '0.150';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.147';
+var VERSION = '0.148';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.148';
+var VERSION = '0.149';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
3 Iterationen, 1 Topic je Version (`topic:feedback`, `topic:hauptseite`, `topic:ai-report`).

## v0.148 — `topic:feedback` (Closes #54, #56, #57)

- **#57** `#feedbackOv{z-index:350;}` — Feedback-Modal liegt jetzt über anderen offenen Modalen (vorher ging es im Stack unter, weil `.ov` einheitlich `z-index:300` hatte und feedbackOv weiter oben im DOM lag).
- **#56** `attachFeedbackScreenshot()` reicht jetzt `x/y/width/height` + `windowWidth/windowHeight` an html2canvas → captured nur den sichtbaren Ausschnitt statt der ganzen `body`. Kleinere Datei, präzisere Suche.
- **#54** Modal-Layout umgebaut:
  - „📤 Senden" sitzt direkt unter dem Textfeld
  - Screenshot-Bereich in `<details id="feedbackShotDetails">` (ausklappbar, öffnet automatisch beim Anhängen) mit Badge „· angehängt"
  - Neuer Button „📁 Eigenes Foto…" → versteckter `#feedbackPhotoInput` + neue `attachFeedbackPhoto(ev)` mit 8 MB-Limit, JPEG-Recompress 1200px/0.8 (Fallback wenn Auto-Screenshot mal nicht klappt)

## v0.149 — `topic:hauptseite` (Closes #52, #53)

- **#53** `📤 shareData` aus `mainScreen`- und `statsScreen`-Header entfernt (zu ähnlich zu `📥 Importieren`, direkt nebeneinander). Backup ist weiter erreichbar über Settings → Datensicherung, „Mehr"-Hub → Daten teilen / sichern, OneDrive-Banner und Backup-Reminder.
- **#52** Neue `_kcalAmpel(goal, eaten, S)` vor `renderAll()`:
  - `|diff/goal| ≤ 10 %` → grün („im Plan")
  - Diät-Richtung aus `S.goalWeight` vs `S.weight` (`±0.5 kg`-Schwelle): `lose` / `gain` / `maintain`
  - Über Ziel: bei `gain` grün („super, baut auf"), sonst rot („ein paar Schritte gehen?")
  - Unter Ziel: bei `lose` grün („gut für dein Defizit"), sonst rot („noch etwas essen!")
  - Render-Stelle: nur die Hero-Pill auf dem Heute-Tab — keine sonstigen Stellen geändert

## v0.150 — `topic:ai-report` (Closes #55)

- `requestKIRating(ev)` baut den Prompt jetzt mit Per-Mahlzeit-Makros (`calcM(en)` pro Meal: kcal · P · K · F), Gesamt-Makros und Makro-Zielen aus `getMacroTargets()` — die KI hat damit eine vollständige Grundlage, um sich konkret auf Kalorien- und Makroziele zu beziehen.
- `event` wird als Parameter übergeben statt unzuverlässig auf das globale `event` zu vertrauen.
- Leere KI-Antwort wird abgefangen → Toast „KI-Antwort leer – bitte erneut versuchen" + Button-Reset (vorher: stummes leeres Feld → Eindruck „nichts passiert").
- `max_tokens` 150 → 300; Wortlimit 50 → 60.

## Versionierung

- `APP_VERSION` (`index.html`) und `VERSION` (`sw.js`) auf `0.150` gleichgezogen
- Sichtbarer Versionstext: `Beta v0.150`
- 3 `CHANGELOG`-Einträge (alle nutzersichtbar)
- `UEBERGABE.md`: `Stand` auf v0.150, Architektur-Bullets für Feedback/Header/Ampel/KI-Report **überschrieben** (nicht angehängt), erledigte Live-Tests gestrichen, Versions-Historie auf letzte 5

## Manuelle Checks

- [ ] v0.148 Feedback-Modal: Settings öffnen → 🐛-FAB tippen → Modal liegt über Settings (nicht dahinter)
- [ ] v0.148 Screenshot „📸 Sichtbarer Ausschnitt" → liefert nur Viewport-Region
- [ ] v0.148 „📁 Eigenes Foto…" → Bildwahl, Recompress, Vorschau
- [ ] v0.149 Heute-Tab Hero-Pill: mit/ohne Zielgewicht, ±10 % grün, Über/Unter-Verhalten je nach Richtung
- [ ] v0.149 Header `mainScreen`/`statsScreen`: nur noch `?`/`📥`/`⚙️`
- [ ] v0.150 „🤖 Tag bewerten": Antwort kommt, enthält Makro-Bezug; Button erholt sich bei leerer Antwort

Topic-Labels für alle 6 Issues triagiert (`topic:feedback`, `topic:hauptseite`, `topic:ai-report`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4zRXBV67CKts8dNBWyxiT)_