### PR TITLE
docs: Chat-Vorschau pro Topic + Re-Labeling-Regel in issues.md/wuensche.md

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -6,9 +6,10 @@ Bugs werden ausschließlich als GitHub-Issues mit `label:bug` geführt — der F
 
 Jeder Bug bekommt zusätzlich zum `bug`-Label genau ein **Themen-Label** `topic:<kebab-case>`.
 
-1. Bestehende `topic:*`-Labels prüfen (GitHub MCP-Tools).
-2. Passt eines thematisch → anwenden.
-3. Passt keines → neues `topic:<bereich>` anlegen (kurze Beschreibung) + anwenden.
+1. **Typ prüfen:** ist das wirklich ein Bug oder eigentlich ein Wunsch? Falls Wunsch → `bug`-Label entfernen, `enhancement` setzen, ab da gilt `wuensche.md`. Spiegelregel auch andersrum: ein als `enhancement` gelabeltes Item, das in Wahrheit ein Bug ist, wird ent-`enhancement`et und mit `bug` versehen. Reine Mischfälle (Bug **und** Wunsch in einem Issue) bekommen beide Labels.
+2. Bestehende `topic:*`-Labels prüfen (GitHub MCP-Tools).
+3. Passt eines thematisch → anwenden.
+4. Passt keines → neues `topic:<bereich>` anlegen (kurze Beschreibung) + anwenden.
 
 **Themen-Schnitt:** Seiten und Funktionen, die zusammengehören, teilen sich ein Topic. Bugs und Wünsche teilen denselben Topic-Namensraum (siehe `wuensche.md`). Beispiele:
 
@@ -20,6 +21,16 @@ Jeder Bug bekommt zusätzlich zum `bug`-Label genau ein **Themen-Label** `topic:
 - `topic:onedrive` — OAuth-PKCE, Graph-API, Backup-Sync
 - `topic:setup` — Einrichtung, `setupScreen`, Zielwerte
 - (weitere analog bei Bedarf)
+
+## Vorschau im Chat (vor Code-Edits)
+
+Bevor Branch oder Code-Edits beginnen, fasst der Agent **direkt im Chat** zusammen — **gruppiert nach Topic**, eine Iteration nach der anderen:
+
+- Topic-Überschrift
+- Pro Issue 1 Satz: Problem laut Reporter + `#N`
+- Pro Issue 1 Satz: geplanter Fix (was wird wo geändert)
+
+Erst nach Bestätigung („ok", „los", „mach") im Chat geht es an den Code. Die Vorschau ist auch bei „mach alle nacheinander" Pflicht — **pro Topic** eine Vorschau, dann Bestätigung, dann Code, dann Commit/PR. Grund: der Mensch kennt die einzelnen Issues nicht auswendig und soll nicht raten müssen, was gerade passiert.
 
 ## Abarbeitung (pro Iteration)
 

--- a/wuensche.md
+++ b/wuensche.md
@@ -6,6 +6,12 @@ Feature-Wünsche und Verbesserungsvorschläge werden ausschließlich als GitHub-
 
 Jeder Wunsch bekommt zusätzlich zum `enhancement`-Label genau ein **Themen-Label** `topic:<kebab-case>`. Vorgehen und Themen-Beispiele identisch zu `issues.md` — Bugs und Wünsche teilen denselben Topic-Namensraum.
 
+**Re-Labeling (Spiegelregel zu `issues.md`):** Ist ein als `enhancement` angelegtes Item in Wahrheit ein Bug → `enhancement`-Label entfernen, `bug` setzen, ab da gilt `issues.md`. Mischfälle bekommen beide Labels.
+
+## Vorschau im Chat (vor Code-Edits)
+
+Identisch zu `issues.md` → „Vorschau im Chat (vor Code-Edits)": pro Topic zuerst im Chat Items + geplanten Fix (je 1 Satz) zusammenfassen, auf Bestätigung warten, dann Code. Gilt auch wenn der Mensch „mach alle nacheinander" sagt — pro Topic eine Vorschau, dann Bestätigung.
+
 ## Abarbeitung (pro Iteration)
 
 - **Genau ein Topic pro Iteration.** Wünsche desselben Topics werden zusammen umgesetzt, soweit sie kohärent sind.


### PR DESCRIPTION
Reine Doku-Änderung an `issues.md` und `wuensche.md` — kein Versions-Bump, kein CHANGELOG (laut `CLAUDE.md`).

## Was

### Neue Sektion „Vorschau im Chat (vor Code-Edits)" in `issues.md`

Bevor Branch oder Code-Edits beginnen, fasst der Agent **direkt im Chat**, **gruppiert nach Topic**, eine Iteration nach der anderen zusammen:

- Topic-Überschrift
- Pro Issue 1 Satz: Problem laut Reporter + `#N`
- Pro Issue 1 Satz: geplanter Fix (was, wo)

Erst nach Bestätigung („ok"/„los"/„mach") geht es an den Code. Auch bei „mach alle nacheinander": pro Topic **eine** Vorschau, dann Bestätigung, dann Code.

`wuensche.md` verweist auf dieselbe Regel — keine Duplikation.

### Re-Labeling beim Triage

Triage-Schritt 1 in `issues.md` neu: ist das wirklich ein Bug oder eigentlich ein Wunsch? Falls Wunsch → `bug` entfernen, `enhancement` setzen, ab da gilt `wuensche.md`. Spiegelregel in `wuensche.md` für die Gegenrichtung. Mischfälle: beide Labels.

## Warum

User-Feedback: bei „mach alle drei nacheinander" wusste der Mensch nicht, welche Issues konkret in welcher Iteration angefasst werden — er hätte raten müssen. Die Vorschau pro Topic ersetzt das Raten durch eine kurze Bestätigungsschleife.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4zRXBV67CKts8dNBWyxiT)_