### PR TITLE
v0.152: Feedback-Screenshot robuster + Auto-Retry + Diagnose-Toast (#61)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.151 (2026-05-02)
+**Stand:** v0.152 (2026-05-02)
 
 ## URLs
 
@@ -15,7 +15,7 @@
 - **Theme (v0.144):** Cream `#faf6f1`, Coral `#e96e3c`, Fraunces+Inter. Override-Block `/* BLOOM REDESIGN */` am Ende von `<style>`.
 - **Screens:** `mainScreen` (Heute, Hero-kcal, 2×2-Mahlzeiten-Grid), `historyScreen`, `mealDetailScreen`, `statsScreen`, `moreScreen`. Bottom-Nav mit 5 Items, `switchTab(tab)` mappt via `data-tab`, `'stats'`→`'trends'`.
 - **Datenkompatibilität:** Alte IDs (`tP/tC/tF`, `entries-<meal>` …) bleiben befüllt parallel zu neuen Grid-IDs (`kcal-<meal>`, `mealsTotal` …).
-- **Feedback (v0.148):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` (eigener `z-index:350`, sitzt über anderen Modalen). Layout: Type-Buttons → Textarea → Senden → ausklappbares `<details id="feedbackShotDetails">` mit „📸 Sichtbarer Ausschnitt" (lazy `html2canvas@1.4.1`, captured nur Viewport via `x/y/width/height`+`windowWidth/Height`) + „📁 Eigenes Foto…" (`#feedbackPhotoInput`, max 8 MB, JPEG 0.8/≤1200px in `attachFeedbackPhoto`). Section-Marker: `// SECTION: FEEDBACK`.
+- **Feedback (v0.148/0.152):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` (eigener `z-index:350`, sitzt über anderen Modalen). Layout: Type-Buttons → Textarea → Senden → ausklappbares `<details id="feedbackShotDetails">` mit „📸 Sichtbarer Ausschnitt" (lazy `html2canvas@1.4.1`, captured nur Viewport via `x/y/width/height`+`windowWidth/Height`) + „📁 Eigenes Foto…" (`#feedbackPhotoInput`, max 8 MB, JPEG 0.8/≤1200px in `attachFeedbackPhoto`). `attachFeedbackScreenshot` nutzt `foreignObjectRendering:false`, `imageTimeout:8000`, `ignoreElements`-Filter für `feedbackOv` und macht bei Fehler einen Auto-Retry mit `allowTaint:true`; Fehlertext geht in Toast (max 80 Zeichen) + `console.error('[feedback] …')`. Section-Marker: `// SECTION: FEEDBACK`.
 - **Header (v0.149/0.151):** `mainScreen`/`statsScreen` ohne `📤 shareData` — nur `?` `📥` `⚙️`. Backup nur via Settings/Datensicherung, „Mehr"-Hub-Eintrag, OneDrive-Banner und Backup-Reminder. `historyScreen`/`mealDetailScreen`/`moreScreen` haben minimale Header. `mainScreen` zeigt zusätzlich rechts neben „Hej <Name>" einen kleinen klickbaren Versions-Tag `#appVersionTag` (öffnet `whatsNewOv`); Text kommt beim DOMContentLoaded aus `APP_VERSION`.
 - **Kalorien-Ampel (v0.149):** `_kcalAmpel(goal,eaten,S)` vor `renderAll()` — ±10 % grün; darüber/darunter abhängig von Diät-Richtung (lose/gain/maintain), abgeleitet aus `S.goalWeight` vs `S.weight ±0.5`. `kcalTrendPill`-Klassen `balanced`/`over`.
 - **KI-Tagesbewertung (v0.150):** `requestKIRating(ev)` baut Prompt mit Per-Mahlzeit-Makros (kcal · P · K · F), Gesamt-Makros und Makro-Zielen aus `getMacroTargets()`. Leere KI-Antwort → Toast + Button-Reset; `max_tokens=300`, model `claude-haiku-4-5`.
@@ -52,16 +52,17 @@
 - v0.149 Kalorien-Ampel pro Diät-Richtung (lose/gain/maintain mit/ohne Zielgewicht)
 - v0.150 KI-Tagesbewertung mit Makros + leere-Antwort-Toast
 - v0.151 Versions-Tag im Heute-Header (klickbar → Was ist neu) + zentraler ＋ im Mahlzeit-Detail nutzt offene Mahlzeit, „+ Zutat"-Button entfernt
+- v0.152 Feedback-Screenshot: Auto-Retry + genauerer Toast bei Fehler (Repro auf Android Chrome 147 / Edge wenn möglich)
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.147 | #50 | Feedback-Modal: „✕ entfernen"-Button stacken |
 | v0.148 | — | Feedback: z-index über anderen Modals + Viewport-Screenshot + Layout (Senden direkt unter Textfeld, Screenshot ausklappbar, „📁 Eigenes Foto…") (#54, #56, #57) |
 | v0.149 | — | Header ohne 📤 + Kalorien-Ampel ±10 %/diät-zielabhängig (#52, #53) |
 | v0.150 | — | KI-Tagesbewertung mit Per-Mahlzeit-Makros + leere-Antwort-Handling (#55) |
-| v0.151 | — | Versions-Tag im Heute-Header + zentraler ＋ im Mahlzeit-Detail mahlzeitenkontextsensitiv, „+ Zutat" entfernt (#62, #64) |
+| v0.151 | #65 | Versions-Tag im Heute-Header + zentraler ＋ im Mahlzeit-Detail mahlzeitenkontextsensitiv, „+ Zutat" entfernt (#62, #64) |
+| v0.152 | — | Feedback-Screenshot robuster (foreignObject aus, Image-Timeout, Auto-Retry, genauerer Fehler-Toast) (#61) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.151</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.152</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -967,7 +967,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.151</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.152</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1845,7 +1845,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.151';
+var APP_VERSION='0.152';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1874,6 +1874,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.152',items:[
+    {icon:'📸',text:'Screenshot beim Feedback ist robuster: weniger Mobile-Chromium-Stolpersteine (deaktiviertes ForeignObject-Rendering, Bild-Timeout 8 s, Feedback-Modal selbst wird ignoriert) und ein automatischer Zweit-Versuch mit toleranteren Optionen, falls der erste fehlschlägt. Schlägt es trotzdem fehl, zeigt der Toast jetzt den genauen Fehlertext und verweist auf „📁 Eigenes Foto…" (Issue #61)',where:'Feedback-Modal · 📸 Sichtbarer Ausschnitt'},
+  ]},
   {v:'0.151',items:[
     {icon:'🔢',text:'Versionsnummer ist jetzt im Heute-Header sichtbar (kleiner Tag rechts neben „Hej …") – Tippen öffnet „Was ist neu" (Issue #62)',where:'Heute-Tab · Header'},
     {icon:'➕',text:'Mahlzeit-Detail entrümpelt: der separate „+ Zutat"-Button im Body fällt weg. Stattdessen kennt der zentrale ＋ in der unteren Leiste jetzt die geöffnete Mahlzeit und legt direkt dort an (Issue #64)',where:'Mahlzeit-Detail'},
@@ -5704,12 +5707,27 @@ function attachFeedbackScreenshot(){
   setTimeout(function(){
     var sx=window.scrollX||window.pageXOffset||0;
     var sy=window.scrollY||window.pageYOffset||0;
-    var vw=window.innerWidth;
-    var vh=window.innerHeight;
+    // Negative/0-Werte vermeiden — html2canvas erzeugt sonst leere/fehlerhafte Canvas
+    var vw=Math.max(1,window.innerWidth|0);
+    var vh=Math.max(1,window.innerHeight|0);
+    var baseOpts={scale:0.7,logging:false,backgroundColor:'#faf6f1',
+      x:sx,y:sy,width:vw,height:vh,scrollX:0,scrollY:0,windowWidth:vw,windowHeight:vh,
+      foreignObjectRendering:false,removeContainer:true,imageTimeout:8000,
+      ignoreElements:function(el){return el&&el.id==='feedbackOv';}};
+    var _h2c;
     _loadHtml2Canvas().then(function(h2c){
-      // Nur sichtbarer Ausschnitt – das, was der Nutzer zuletzt gesehen hat
-      return h2c(document.body,{scale:0.7,logging:false,useCORS:true,backgroundColor:'#faf6f1',
-        x:sx,y:sy,width:vw,height:vh,scrollX:0,scrollY:0,windowWidth:vw,windowHeight:vh});
+      _h2c=h2c;
+      // 1. Versuch: CORS-konform (sicher gegen tainted Canvas)
+      return h2c(document.body,Object.assign({useCORS:true,allowTaint:false},baseOpts));
+    }).catch(function(err1){
+      try{console.error('[feedback] screenshot pass 1 failed',err1);}catch(e){}
+      // 2. Versuch: tainted erlauben — manche Mobile-Chromium-Builds brauchen das
+      if(!_h2c)throw err1;
+      return _h2c(document.body,Object.assign({useCORS:false,allowTaint:true},baseOpts))
+        .catch(function(err2){
+          try{console.error('[feedback] screenshot pass 2 failed',err2);}catch(e){}
+          throw err2;
+        });
     }).then(function(canvas){
       // Auf max 1200px Breite begrenzen
       var max=1200;
@@ -5722,7 +5740,9 @@ function attachFeedbackScreenshot(){
       openOv('feedbackOv');
     }).catch(function(err){
       openOv('feedbackOv');
-      showToast('Screenshot fehlgeschlagen: '+(err&&err.message||'unbekannt'));
+      var m=(err&&(err.message||err.name))||'unbekannt';
+      if(m.length>80)m=m.slice(0,80)+'…';
+      showToast('Screenshot fehlgeschlagen: '+m+' — bitte „📁 Eigenes Foto…" nutzen');
     }).then(function(){
       if(btn){btn.disabled=false;btn.textContent='📸 Sichtbarer Ausschnitt';}
     });

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.151';
+var VERSION = '0.152';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary
- `attachFeedbackScreenshot` härter konfiguriert: `foreignObjectRendering:false`, `imageTimeout:8000`, `ignoreElements`-Filter für `feedbackOv`, `vw`/`vh` gegen 0/negativ geclampt.
- Erster Versuch CORS-konform; bei Fehler automatisch zweiter Versuch mit `allowTaint:true` (Mobile-Chromium-Bug).
- Schlägt es trotzdem fehl: Toast zeigt erste 80 Zeichen des Fehlertexts + Hinweis auf „📁 Eigenes Foto…"; `console.error('[feedback] …')` mit Stack für Remote-Debug.
- Versions-Bump 0.151 → 0.152, CHANGELOG-Eintrag, `UEBERGABE.md` aktualisiert.

Closes #61

## Test plan
- [ ] Feedback-FAB → „📸 Sichtbarer Ausschnitt": Screenshot wird (wie bisher) korrekt erzeugt und im Modal angezeigt.
- [ ] Falls fehlerhaft: Toast zeigt konkreten Fehlertext (kein generisches „unbekannt"); DevTools-Konsole hat `[feedback] …` mit Stack.
- [ ] Auch mit offenem anderem Modal (z.B. Settings) im Hintergrund: Screenshot enthält den sichtbaren Ausschnitt, das `feedbackOv` selbst ist nicht im Bild.
- [ ] Service-Worker-Update zieht (Cache `nt-0.152`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr2DNQ7dprEEQybkcKJ1jA)_