### PR TITLE
v0.153: Feedback-Screenshot erfasst Bottom-Sheet-Modale komplett (#67)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.152 (2026-05-02)
+**Stand:** v0.153 (2026-05-02)
 
 ## URLs
 
@@ -15,7 +15,7 @@
 - **Theme (v0.144):** Cream `#faf6f1`, Coral `#e96e3c`, Fraunces+Inter. Override-Block `/* BLOOM REDESIGN */` am Ende von `<style>`.
 - **Screens:** `mainScreen` (Heute, Hero-kcal, 2×2-Mahlzeiten-Grid), `historyScreen`, `mealDetailScreen`, `statsScreen`, `moreScreen`. Bottom-Nav mit 5 Items, `switchTab(tab)` mappt via `data-tab`, `'stats'`→`'trends'`.
 - **Datenkompatibilität:** Alte IDs (`tP/tC/tF`, `entries-<meal>` …) bleiben befüllt parallel zu neuen Grid-IDs (`kcal-<meal>`, `mealsTotal` …).
-- **Feedback (v0.148/0.152):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` (eigener `z-index:350`, sitzt über anderen Modalen). Layout: Type-Buttons → Textarea → Senden → ausklappbares `<details id="feedbackShotDetails">` mit „📸 Sichtbarer Ausschnitt" (lazy `html2canvas@1.4.1`, captured nur Viewport via `x/y/width/height`+`windowWidth/Height`) + „📁 Eigenes Foto…" (`#feedbackPhotoInput`, max 8 MB, JPEG 0.8/≤1200px in `attachFeedbackPhoto`). `attachFeedbackScreenshot` nutzt `foreignObjectRendering:false`, `imageTimeout:8000`, `ignoreElements`-Filter für `feedbackOv` und macht bei Fehler einen Auto-Retry mit `allowTaint:true`; Fehlertext geht in Toast (max 80 Zeichen) + `console.error('[feedback] …')`. Section-Marker: `// SECTION: FEEDBACK`.
+- **Feedback (v0.148/0.152/0.153):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` (eigener `z-index:350`, sitzt über anderen Modalen). Layout: Type-Buttons → Textarea → Senden → ausklappbares `<details id="feedbackShotDetails">` mit „📸 Sichtbarer Ausschnitt" (lazy `html2canvas@1.4.1`, captured nur Viewport via `x/y/width/height`+`windowWidth/Height`+`scrollX/scrollY`) + „📁 Eigenes Foto…" (`#feedbackPhotoInput`, max 8 MB, JPEG 0.8/≤1200px in `attachFeedbackPhoto`). `attachFeedbackScreenshot` nutzt `foreignObjectRendering:false`, `imageTimeout:8000`, `ignoreElements`-Filter für `feedbackOv` und macht bei Fehler einen Auto-Retry mit `allowTaint:true`; Fehlertext geht in Toast (max 80 Zeichen) + `console.error('[feedback] …')`. Vor Capture friert es alle `.ov.open:not(#feedbackOv) .mod` mit Pixel-`top`/`height` aus `getBoundingClientRect()` ein (sonst rendert html2canvas `position:fixed; bottom:0` ans Document-Bottom statt ans Viewport-Bottom) und restored die inline-styles im success-/catch-Pfad. Section-Marker: `// SECTION: FEEDBACK`.
 - **Header (v0.149/0.151):** `mainScreen`/`statsScreen` ohne `📤 shareData` — nur `?` `📥` `⚙️`. Backup nur via Settings/Datensicherung, „Mehr"-Hub-Eintrag, OneDrive-Banner und Backup-Reminder. `historyScreen`/`mealDetailScreen`/`moreScreen` haben minimale Header. `mainScreen` zeigt zusätzlich rechts neben „Hej <Name>" einen kleinen klickbaren Versions-Tag `#appVersionTag` (öffnet `whatsNewOv`); Text kommt beim DOMContentLoaded aus `APP_VERSION`.
 - **Kalorien-Ampel (v0.149):** `_kcalAmpel(goal,eaten,S)` vor `renderAll()` — ±10 % grün; darüber/darunter abhängig von Diät-Richtung (lose/gain/maintain), abgeleitet aus `S.goalWeight` vs `S.weight ±0.5`. `kcalTrendPill`-Klassen `balanced`/`over`.
 - **KI-Tagesbewertung (v0.150):** `requestKIRating(ev)` baut Prompt mit Per-Mahlzeit-Makros (kcal · P · K · F), Gesamt-Makros und Makro-Zielen aus `getMacroTargets()`. Leere KI-Antwort → Toast + Button-Reset; `max_tokens=300`, model `claude-haiku-4-5`.
@@ -53,16 +53,17 @@
 - v0.150 KI-Tagesbewertung mit Makros + leere-Antwort-Toast
 - v0.151 Versions-Tag im Heute-Header (klickbar → Was ist neu) + zentraler ＋ im Mahlzeit-Detail nutzt offene Mahlzeit, „+ Zutat"-Button entfernt
 - v0.152 Feedback-Screenshot: Auto-Retry + genauerer Toast bei Fehler (Repro auf Android Chrome 147 / Edge wenn möglich)
+- v0.153 Feedback-Screenshot: Bottom-Sheet-Modale werden komplett erfasst (vorher nur Modal-Header sichtbar)
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.148 | — | Feedback: z-index über anderen Modals + Viewport-Screenshot + Layout (Senden direkt unter Textfeld, Screenshot ausklappbar, „📁 Eigenes Foto…") (#54, #56, #57) |
 | v0.149 | — | Header ohne 📤 + Kalorien-Ampel ±10 %/diät-zielabhängig (#52, #53) |
 | v0.150 | — | KI-Tagesbewertung mit Per-Mahlzeit-Makros + leere-Antwort-Handling (#55) |
 | v0.151 | #65 | Versions-Tag im Heute-Header + zentraler ＋ im Mahlzeit-Detail mahlzeitenkontextsensitiv, „+ Zutat" entfernt (#62, #64) |
-| v0.152 | — | Feedback-Screenshot robuster (foreignObject aus, Image-Timeout, Auto-Retry, genauerer Fehler-Toast) (#61) |
+| v0.152 | #66 | Feedback-Screenshot robuster (foreignObject aus, Image-Timeout, Auto-Retry, genauerer Fehler-Toast) (#61) |
+| v0.153 | — | Feedback-Screenshot: Bottom-Sheet-Modale werden komplett erfasst (Pixel-top/height-Freeze vor Capture) (#67) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.152</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.153</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -967,7 +967,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.152</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.153</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1845,7 +1845,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.152';
+var APP_VERSION='0.153';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1874,6 +1874,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.153',items:[
+    {icon:'📸',text:'Screenshot beim Feedback erfasst Bottom-Sheet-Modale (z.B. „Zutat hinzufügen") jetzt komplett — vorher wurde nur der obere Header-Streifen abgelichtet, weil html2canvas die Modal-Position falsch berechnet hat. Vor dem Capture friert die Funktion die tatsächliche Viewport-Position des offenen Modals als Pixel-Werte ein und stellt sie hinterher zurück (Issue #67)',where:'Feedback-Modal · 📸 Sichtbarer Ausschnitt'},
+  ]},
   {v:'0.152',items:[
     {icon:'📸',text:'Screenshot beim Feedback ist robuster: weniger Mobile-Chromium-Stolpersteine (deaktiviertes ForeignObject-Rendering, Bild-Timeout 8 s, Feedback-Modal selbst wird ignoriert) und ein automatischer Zweit-Versuch mit toleranteren Optionen, falls der erste fehlschlägt. Schlägt es trotzdem fehl, zeigt der Toast jetzt den genauen Fehlertext und verweist auf „📁 Eigenes Foto…" (Issue #61)',where:'Feedback-Modal · 📸 Sichtbarer Ausschnitt'},
   ]},
@@ -5710,8 +5713,26 @@ function attachFeedbackScreenshot(){
     // Negative/0-Werte vermeiden — html2canvas erzeugt sonst leere/fehlerhafte Canvas
     var vw=Math.max(1,window.innerWidth|0);
     var vh=Math.max(1,window.innerHeight|0);
+    // Bottom-Sheet-Modale haben position:fixed; bottom:0 — html2canvas platziert sie sonst
+    // ans Document-Bottom (außerhalb der Capture-Region). Wir frieren ihre tatsächliche
+    // Viewport-Position als Pixel-top/height ein und stellen das hinterher zurück.
+    var modSnaps=[];
+    try{
+      document.querySelectorAll('.ov.open:not(#feedbackOv) .mod').forEach(function(mod){
+        var rect=mod.getBoundingClientRect();
+        modSnaps.push({el:mod,attr:mod.getAttribute('style')});
+        mod.style.bottom='auto';
+        mod.style.top=Math.round(sy+rect.top)+'px';
+        mod.style.height=Math.round(rect.height)+'px';
+      });
+    }catch(e){try{console.error('[feedback] mod prep failed',e);}catch(_){}}
+    var _restoreMods=function(){
+      modSnaps.forEach(function(s){
+        if(s.attr==null)s.el.removeAttribute('style');else s.el.setAttribute('style',s.attr);
+      });
+    };
     var baseOpts={scale:0.7,logging:false,backgroundColor:'#faf6f1',
-      x:sx,y:sy,width:vw,height:vh,scrollX:0,scrollY:0,windowWidth:vw,windowHeight:vh,
+      x:sx,y:sy,width:vw,height:vh,scrollX:sx,scrollY:sy,windowWidth:vw,windowHeight:vh,
       foreignObjectRendering:false,removeContainer:true,imageTimeout:8000,
       ignoreElements:function(el){return el&&el.id==='feedbackOv';}};
     var _h2c;
@@ -5729,6 +5750,7 @@ function attachFeedbackScreenshot(){
           throw err2;
         });
     }).then(function(canvas){
+      _restoreMods();
       // Auf max 1200px Breite begrenzen
       var max=1200;
       var w=canvas.width,h=canvas.height;
@@ -5739,6 +5761,7 @@ function attachFeedbackScreenshot(){
       _showFeedbackShotPreview(dataUrl);
       openOv('feedbackOv');
     }).catch(function(err){
+      _restoreMods();
       openOv('feedbackOv');
       var m=(err&&(err.message||err.name))||'unbekannt';
       if(m.length>80)m=m.slice(0,80)+'…';

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.152';
+var VERSION = '0.153';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary
- `attachFeedbackScreenshot`: vor dem html2canvas-Aufruf wird für jedes `.ov.open:not(#feedbackOv) .mod` die tatsächliche Viewport-Position aus `getBoundingClientRect()` als inline-style `top:Xpx; height:Ypx; bottom:auto` eingefroren. html2canvas berechnete `position:fixed; bottom:0` sonst ans Document-Bottom statt ans Viewport-Bottom — dadurch wurde im Screenshot bisher nur der Modal-Header erfasst, der Body fehlte komplett.
- Inline-styles werden im success- und catch-Pfad sauber zurückgesetzt.
- `scrollX/scrollY` an html2canvas konsistent auf `pageXOffset/pageYOffset` gesetzt (statt `0,0`).
- Versions-Bump 0.152 → 0.153, CHANGELOG-Eintrag, `UEBERGABE.md` aktualisiert.

Closes #67

## Test plan
- [ ] Repro auf Android Chrome 147 / Edge: ein Bottom-Sheet-Modal öffnen (z.B. Mahlzeit-Detail → ＋ → „Abendessen – Zutat hinzufügen"), Feedback-FAB → „📸 Sichtbarer Ausschnitt": das gesamte Modal (Header + Tabs + Suchfeld) ist im Screenshot zu sehen.
- [ ] Auch ohne offene Modale: normaler Heute-Screen wird wie bisher korrekt erfasst.
- [ ] Bei html2canvas-Fehler: inline-styles auf `.mod` werden trotzdem entfernt (kein zurückgebliebener `top:Xpx`-Inline-Style nach Toast).
- [ ] Service-Worker zieht (Cache `nt-0.153`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr2DNQ7dprEEQybkcKJ1jA)_