### PR TITLE
v0.155: Mahlzeit-Detail als Bottom Sheet, ⚙️ entfernt, Was-ist-neu-History

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.154 (2026-05-02)
+**Stand:** v0.155 (2026-05-04)
 
 ## URLs
 
@@ -16,10 +16,10 @@
 - **Screens:** `mainScreen` (Heute, Hero-kcal, 2×2-Mahlzeiten-Grid), `historyScreen`, `mealDetailScreen`, `statsScreen`, `moreScreen`. Bottom-Nav mit 5 Items, `switchTab(tab)` mappt via `data-tab`, `'stats'`→`'trends'`.
 - **Datenkompatibilität:** Alte IDs (`tP/tC/tF`, `entries-<meal>` …) bleiben befüllt parallel zu neuen Grid-IDs (`kcal-<meal>`, `mealsTotal` …).
 - **Feedback (v0.154):** Globaler FAB `#feedbackFab` (`bottom:84px;right:12px`, `z-index:400`) vor `</body>`, auf `setupScreen` versteckt. Modal `feedbackOv` (eigener `z-index:350`, sitzt über anderen Modalen). Layout: Type-Buttons → Textarea → Senden → ausklappbares `<details id="feedbackShotDetails">` mit „📸 Screenshot" (lazy `html2canvas@1.4.1`, captured ganze Page — kein Viewport-Crop, weil das mit Bottom-Sheets unzuverlässig war) + „📁 Eigenes Foto…" (`#feedbackPhotoInput`, max 8 MB, JPEG 0.8/≤1200px in `attachFeedbackPhoto`). `attachFeedbackScreenshot` nutzt `scale:0.7`, `foreignObjectRendering:false`, `imageTimeout:8000`, `ignoreElements`-Filter für `feedbackOv`, Auto-Retry bei Fehler mit `allowTaint:true`; Fehlertext geht in Toast (max 80 Zeichen) + `console.error('[feedback] …')`. Section-Marker: `// SECTION: FEEDBACK`.
-- **Header (v0.149/0.151):** `mainScreen`/`statsScreen` ohne `📤 shareData` — nur `?` `📥` `⚙️`. Backup nur via Settings/Datensicherung, „Mehr"-Hub-Eintrag, OneDrive-Banner und Backup-Reminder. `historyScreen`/`mealDetailScreen`/`moreScreen` haben minimale Header. `mainScreen` zeigt zusätzlich rechts neben „Hej <Name>" einen kleinen klickbaren Versions-Tag `#appVersionTag` (öffnet `whatsNewOv`); Text kommt beim DOMContentLoaded aus `APP_VERSION`.
+- **Header (v0.149/0.155):** `mainScreen`/`statsScreen` ohne `📤 shareData` und ohne `⚙️` — nur `?` `📥`. Backup nur via Settings/Datensicherung, „Mehr"-Hub-Eintrag, OneDrive-Banner und Backup-Reminder. `historyScreen`/`mealDetailScreen`/`moreScreen` haben minimale Header. `mainScreen` zeigt zusätzlich rechts neben „Hej <Name>" einen kleinen klickbaren Versions-Tag `#appVersionTag` (öffnet `whatsNewOv`); Text kommt beim DOMContentLoaded aus `APP_VERSION`.
 - **Kalorien-Ampel (v0.149):** `_kcalAmpel(goal,eaten,S)` vor `renderAll()` — ±10 % grün; darüber/darunter abhängig von Diät-Richtung (lose/gain/maintain), abgeleitet aus `S.goalWeight` vs `S.weight ±0.5`. `kcalTrendPill`-Klassen `balanced`/`over`.
 - **KI-Tagesbewertung (v0.150):** `requestKIRating(ev)` baut Prompt mit Per-Mahlzeit-Makros (kcal · P · K · F), Gesamt-Makros und Makro-Zielen aus `getMacroTargets()`. Leere KI-Antwort → Toast + Button-Reset; `max_tokens=300`, model `claude-haiku-4-5`.
-- **Mahlzeit-Detail (v0.151):** Nur noch `📋 Vorlage` als CTA im Body — `mdAdd`-Button entfernt. Stattdessen wird der zentrale `＋` der Bottom-Nav (`#cbMealDetail`) in `renderMealDetail` auf `openPicker('<meal>')` umgebogen, sodass er die geöffnete Mahlzeit als Kontext nutzt.
+- **Mahlzeit-Detail (v0.155):** `#mealDetailScreen` ist jetzt ein `ov`-Overlay (Bottom Sheet, 88 vh), kein eigener Screen mehr. `openMealDetail()` ruft `openOv()`, `closeMealDetail()` ruft `closeOv()`. Kopf sticky (`position:sticky;top:0`). CTAs: `＋ Zutat` (`#mdAdd` → `openPicker(meal)`) + `📋 Vorlage`. `switchTab()` schließt das Overlay automatisch beim Tab-Wechsel.
 - **Share/Import:** Sender → `POST /share` (Worker, KV, 1y TTL) → `?s=<id>` auf PWA-Origin. Empfänger: Android öffnet PWA via `handle_links`; iOS-Safari (non-standalone) bekommt `iosSwitchOv`-Anleitung + Auto-Clipboard, User wechselt zur PWA und tippt 📥 (`openImportPaste()`). Legacy-URL-Formen `#x=`/`#r=`/`workers.dev/s/<id>` bleiben kompatibel.
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 
@@ -38,7 +38,7 @@
 
 ## Code-Suchpfade
 
-`index.html`: `// SECTION: SHARE & IMPORT`, `// SECTION: FEEDBACK`, `_isIos()`, `_isPwaStandalone()`, `_checkSharedItemOnBoot()`, `_showIosBrowserToAppFlow()`, `openImportPaste()`, `openFeedback()`. Modale: `shareItemOv`, `importPasteOv`, `importConfirmOv`, `iosSwitchOv`, `feedbackOv`.
+`index.html`: `// SECTION: SHARE & IMPORT`, `// SECTION: FEEDBACK`, `_isIos()`, `_isPwaStandalone()`, `_checkSharedItemOnBoot()`, `_showIosBrowserToAppFlow()`, `openImportPaste()`, `openFeedback()`. Modale: `shareItemOv`, `importPasteOv`, `importConfirmOv`, `iosSwitchOv`, `feedbackOv`, `mealDetailScreen`.
 
 `worker/src/index.js`: `// ─── SHARE-LINK SHORTENER`, `// ─── FEEDBACK ENDPOINT`. Funktionen: `handleShareCreate/Lookup/Redirect`, `generateShareId` (Base58, 7 Zeichen), `handleFeedback`, `ensureFeedbackBranch`, `uploadFeedbackScreenshot`.
 
@@ -51,18 +51,18 @@
 - v0.148 Feedback-Modal vor offenem anderen Modal (z-index), „📁 Eigenes Foto…"
 - v0.149 Kalorien-Ampel pro Diät-Richtung (lose/gain/maintain mit/ohne Zielgewicht)
 - v0.150 KI-Tagesbewertung mit Makros + leere-Antwort-Toast
-- v0.151 Versions-Tag im Heute-Header (klickbar → Was ist neu) + zentraler ＋ im Mahlzeit-Detail nutzt offene Mahlzeit, „+ Zutat"-Button entfernt
 - v0.154 Feedback-Screenshot wieder Full-Page (Viewport-Crop entfernt, Bottom-Sheets jetzt vollständig im Bild)
+- v0.155 Mahlzeit-Detail als Bottom Sheet, ⚙️ entfernt, „Was ist neu" zeigt komplette History
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.150 | — | KI-Tagesbewertung mit Per-Mahlzeit-Makros + leere-Antwort-Handling (#55) |
 | v0.151 | #65 | Versions-Tag im Heute-Header + zentraler ＋ im Mahlzeit-Detail mahlzeitenkontextsensitiv, „+ Zutat" entfernt (#62, #64) |
 | v0.152 | #66 | Feedback-Screenshot robuster (foreignObject aus, Image-Timeout, Auto-Retry, genauerer Fehler-Toast) (#61) |
 | v0.153 | #68 | Feedback-Screenshot: Versuch Bottom-Sheet-Modale per Pixel-Freeze zu erfassen (klappte nicht — siehe v0.154) (#67) |
 | v0.154 | — | Feedback-Screenshot wieder Full-Page (Viewport-Crop entfernt, revertiert #56) (#67) |
+| v0.155 | — | Mahlzeit-Detail → Bottom Sheet; ⚙️ aus Hauptseite/Trends entfernt; „Was ist neu" zeigt komplette History (#70, #71, #72) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -502,7 +502,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
 #updateBanner button{background:var(--g1);}
 
 /* MEAL DETAIL SUBSCREEN */
-#mealDetailScreen .md-head{padding:14px 18px 0;display:flex;align-items:center;gap:10px;}
+#mealDetailScreen .md-head{padding:14px 18px 10px;display:flex;align-items:center;gap:10px;position:sticky;top:0;background:white;z-index:1;border-bottom:1px solid var(--br);}
 #mealDetailScreen .md-back{background:var(--gl);border:none;width:38px;height:38px;border-radius:50%;font-size:18px;color:var(--tx);display:flex;align-items:center;justify-content:center;cursor:pointer;}
 #mealDetailScreen .md-actions{margin-left:auto;display:flex;gap:6px;}
 #mealDetailScreen .md-actions button{background:var(--gl);border:none;width:38px;height:38px;border-radius:50%;font-size:16px;color:var(--tx);cursor:pointer;}
@@ -653,13 +653,12 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.154</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.155</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
         <button type="button" class="hbtn" onclick="openImportPaste()" title="Rezept/Mahlzeit/Lebensmittel importieren">📥</button>
-        <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
     </div>
     <div id="odMissingBanner" style="display:none;align-items:center;gap:10px;background:#fff3e0;border-bottom:1px solid #ffe0b2;padding:10px 16px;">
@@ -804,7 +803,6 @@ button,input,select,textarea{font-family:var(--fs-body);}
       <div style="display:flex;gap:6px;">
         <button type="button" class="hbtn" onclick="openHelp()" title="Hilfe">?</button>
         <button type="button" class="hbtn" onclick="openImportPaste()" title="Importieren">📥</button>
-        <button type="button" class="hbtn" onclick="openSettings()" title="Einstellungen">⚙️</button>
       </div>
     </div>
   </div>
@@ -891,38 +889,35 @@ button,input,select,textarea{font-family:var(--fs-body);}
 </div>
 
 <!-- MEAL DETAIL -->
-<div id="mealDetailScreen" class="screen">
-  <div class="md-head">
-    <button type="button" class="md-back" onclick="closeMealDetail()">‹</button>
-    <div class="md-actions">
-      <button type="button" id="mdCopy" title="Von gestern">⎘</button>
-      <button type="button" id="mdShare" title="Teilen">📤</button>
+<div class="ov" id="mealDetailScreen" onclick="bgClose(event,'mealDetailScreen')">
+  <div class="mod">
+    <div class="mhan"></div>
+    <div class="md-head">
+      <button type="button" class="md-back" onclick="closeMealDetail()">✕</button>
+      <div class="md-actions">
+        <button type="button" id="mdCopy" title="Von gestern">⎘</button>
+        <button type="button" id="mdShare" title="Teilen">📤</button>
+      </div>
     </div>
-  </div>
-  <div class="md-body">
-    <div>
-      <div class="md-cap" id="mdCap">— MAHLZEIT</div>
-      <div class="md-title" id="mdTitle"><em>Mahlzeit</em></div>
+    <div class="md-body">
+      <div>
+        <div class="md-cap" id="mdCap">— MAHLZEIT</div>
+        <div class="md-title" id="mdTitle"><em>Mahlzeit</em></div>
+      </div>
+      <div class="md-photo" id="mdPhoto">Foto-Platzhalter</div>
+      <div class="md-stats">
+        <div class="md-stat kcal"><div class="sv" id="mdKcal">0</div><div class="sl">kcal</div></div>
+        <div class="md-stat p"><div class="sv" id="mdP">0g</div><div class="sl">Protein</div></div>
+        <div class="md-stat c"><div class="sv" id="mdC">0g</div><div class="sl">Kohlenh.</div></div>
+        <div class="md-stat f"><div class="sv" id="mdF">0g</div><div class="sl">Fett</div></div>
+      </div>
+      <div class="md-list-head"><h4>Zutaten</h4><div class="meta" id="mdCount">0 Posten</div></div>
+      <div class="md-list" id="mdList"></div>
+      <div class="md-cta">
+        <button type="button" class="add" id="mdAdd">＋ Zutat</button>
+        <button type="button" class="tpl" id="mdTpl">📋 Vorlage</button>
+      </div>
     </div>
-    <div class="md-photo" id="mdPhoto">Foto-Platzhalter</div>
-    <div class="md-stats">
-      <div class="md-stat kcal"><div class="sv" id="mdKcal">0</div><div class="sl">kcal</div></div>
-      <div class="md-stat p"><div class="sv" id="mdP">0g</div><div class="sl">Protein</div></div>
-      <div class="md-stat c"><div class="sv" id="mdC">0g</div><div class="sl">Kohlenh.</div></div>
-      <div class="md-stat f"><div class="sv" id="mdF">0g</div><div class="sl">Fett</div></div>
-    </div>
-    <div class="md-list-head"><h4>Zutaten</h4><div class="meta" id="mdCount">0 Posten</div></div>
-    <div class="md-list" id="mdList"></div>
-    <div class="md-cta">
-      <button type="button" class="tpl" id="mdTpl">📋 Vorlage</button>
-    </div>
-  </div>
-  <div class="bnav">
-    <button type="button" class="ni on" data-tab="main" onclick="switchTab('main')"><span>🏠</span>Heute</button>
-    <button type="button" class="ni" data-tab="history" onclick="switchTab('history')"><span>📅</span>Verlauf</button>
-    <div class="cw"><button type="button" class="cb" id="cbMealDetail" onclick="openPicker(null,'search')">＋</button></div>
-    <button type="button" class="ni" data-tab="trends" onclick="switchTab('trends')"><span>📈</span>Trends</button>
-    <button type="button" class="ni" data-tab="more" onclick="switchTab('more')"><span>☰</span>Mehr</button>
   </div>
 </div>
 
@@ -967,7 +962,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.154</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.155</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1845,7 +1840,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.154';
+var APP_VERSION='0.155';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1874,6 +1869,11 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.155',items:[
+    {icon:'📋',text:'Mahlzeit-Detail öffnet jetzt als Bottom Sheet über der aktuellen Seite — kein eigener Screen mehr, kein Kontext-Verlust (Issue #72)',where:'Heute-Tab · Mahlzeit-Karten'},
+    {icon:'⚙️',text:'Einstellungs-Button oben rechts entfernt — Einstellungen erreichst du weiter über den Mehr-Tab (Issue #71)',where:'Heute-Tab & Trends · Header'},
+    {icon:'🆕',text:'„Was ist neu" zeigt jetzt die komplette Versionshistorie — nicht nur die Änderungen seit dem letzten Update (Issue #70)',where:'Mehr-Tab → Was ist neu · Header-Versions-Tag'},
+  ]},
   {v:'0.154',items:[
     {icon:'📸',text:'Screenshot beim Feedback erfasst wieder die ganze Seite (statt nur den sichtbaren Ausschnitt). Das war zuverlässiger – der Viewport-Crop hat bei offenen Bottom-Sheet-Modalen Teile abgeschnitten. Button heißt jetzt schlicht „📸 Screenshot" (Issue #67, revertiert #56)',where:'Feedback-Modal · 📸 Screenshot'},
   ]},
@@ -2375,6 +2375,22 @@ function checkWhatsNew(){
   setTimeout(function(){openOv('whatsNewOv');},1000);
 }
 function closeWhatsNew(){closeOv('whatsNewOv');}
+function showWhatsNew(){
+  var html='';
+  CHANGELOG.forEach(function(c){
+    html+='<div style="font-size:11px;font-weight:800;color:var(--mu);text-transform:uppercase;margin:12px 0 6px;">Beta v'+c.v+'</div>';
+    c.items.forEach(function(item){
+      html+='<div style="display:flex;gap:10px;align-items:flex-start;padding:10px;background:var(--gl);border-radius:10px;margin-bottom:6px;">'
+        +'<div style="font-size:22px;flex-shrink:0;">'+item.icon+'</div>'
+        +'<div><div style="font-size:13px;font-weight:700;color:var(--tx);margin-bottom:2px;">'+item.text+'</div>'
+        +'<div style="font-size:11px;color:var(--g1);">📍 '+item.where+'</div></div></div>';
+    });
+  });
+  html+='<button type="button" class="cb2" onclick="closeWhatsNew()" style="width:100%;margin-top:12px;">Alles klar ✓</button>';
+  document.getElementById('whatsNewBody').innerHTML=html;
+  document.getElementById('whatsNewVersion').textContent='Beta v'+APP_VERSION;
+  openOv('whatsNewOv');
+}
 function showBackupReminder(){
   var el=document.getElementById('backupReminder');
   if(el)el.classList.remove('hidden');
@@ -5459,7 +5475,7 @@ function openPromptSettings(){
 // ════════════════════════════════════════
 function switchTab(tab){
   if(tab==='stats')tab='trends'; // legacy alias
-  var screens={main:'mainScreen',history:'historyScreen',trends:'statsScreen',more:'moreScreen',mealDetail:'mealDetailScreen'};
+  var screens={main:'mainScreen',history:'historyScreen',trends:'statsScreen',more:'moreScreen'};
   document.querySelectorAll('.screen').forEach(function(s){s.classList.remove('active');});
   var target=document.getElementById(screens[tab]||'mainScreen');
   if(target)target.classList.add('active');
@@ -5469,6 +5485,7 @@ function switchTab(tab){
   if(tab==='trends')switchStatsTab('stats');
   if(tab==='history')renderHistory();
   if(tab==='more')renderMore();
+  closeOv('mealDetailScreen');
   if(tab==='main')window._mealDetailOpen=null;
   try{window.scrollTo(0,0);}catch(e){}
 }
@@ -5492,9 +5509,9 @@ var MEAL_LABELS={breakfast:{label:'Frühstück',icon:'🌅',cap:'Frühstück'},l
 function openMealDetail(meal){
   window._mealDetailOpen=meal;
   renderMealDetail(meal);
-  switchTab('mealDetail');
+  openOv('mealDetailScreen');
 }
-function closeMealDetail(){window._mealDetailOpen=null;switchTab('main');}
+function closeMealDetail(){window._mealDetailOpen=null;closeOv('mealDetailScreen');}
 function renderMealDetail(meal){
   var info=MEAL_LABELS[meal];if(!info)return;
   var day=getDay(),en=day.meals[meal]||[],s=calcM(en);
@@ -5534,7 +5551,7 @@ function renderMealDetail(meal){
         +'</div>';
     }).join('');
   }
-  var cbMd=document.getElementById('cbMealDetail');if(cbMd)cbMd.setAttribute('onclick',"openPicker('"+meal+"')");
+  var ctaAdd=document.getElementById('mdAdd');if(ctaAdd)ctaAdd.setAttribute('onclick',"openPicker('"+meal+"')");
   var ctaTpl=document.getElementById('mdTpl');if(ctaTpl)ctaTpl.setAttribute('onclick',"openTemplateOv('"+meal+"')");
   var ctaCpy=document.getElementById('mdCopy');if(ctaCpy)ctaCpy.setAttribute('onclick',"copyMealFromYesterday('"+meal+"')");
   var ctaShr=document.getElementById('mdShare');if(ctaShr)ctaShr.setAttribute('onclick',"shareMeal('"+meal+"')");

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.154';
+var VERSION = '0.155';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Änderungen

- **#72** `mealDetailScreen` von eigenem Vollbild-Screen zu `ov`-Overlay (Bottom Sheet, 88 vh) umgebaut — öffnet über `openOv`/`closeOv`, kein Tab-Wechsel mehr, Hauptseite bleibt darunter sichtbar. CTAs: `＋ Zutat` + `📋 Vorlage`. Tab-Wechsel schließt das Sheet automatisch.
- **#71** Einstellungs-Button (⚙️) aus `mainScreen`- und `statsScreen`-Header entfernt — Einstellungen weiter über Mehr-Tab erreichbar.
- **#70** `showWhatsNew()` hinzugefügt — zeigt die komplette CHANGELOG-Historie mit allen Versionsnummern, nicht nur Neues seit dem letzten Update.

## Version

`0.154` → `0.155` · `APP_VERSION`, `sw.js`, sichtbare Versions-Tags, CHANGELOG-Eintrag, `UEBERGABE.md` aktualisiert.

## Manuelle Checks

- [ ] Mahlzeit-Karte tippen → Bottom Sheet öffnet sich über Heute-Tab
- [ ] Backdrop tippen → Sheet schließt sich
- [ ] `＋ Zutat` im Sheet öffnet Picker für die richtige Mahlzeit
- [ ] `📋 Vorlage` funktioniert
- [ ] `📤 Teilen` und `⎘ Von gestern` im Sheet-Header funktionieren
- [ ] Tab-Wechsel schließt offenes Sheet
- [ ] Mehr-Tab → „Was ist neu" zeigt alle Versionen
- [ ] Versions-Tag im Header (`v0.155`) öffnet „Was ist neu" mit kompletter Liste
- [ ] ⚙️ nicht mehr im Heute- und Trends-Header sichtbar
- [ ] Einstellungen über Mehr-Tab weiterhin erreichbar

Closes #70, Closes #71, Closes #72

https://claude.ai/code/session_017gpdKyQccWEri7uTqWpSNc

---
_Generated by [Claude Code](https://claude.ai/code/session_017gpdKyQccWEri7uTqWpSNc)_