### PR TITLE
v0.157: Mahlzeit-Detail „💾 Als Rezept" (#75)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.156 (2026-05-04)
+**Stand:** v0.157 (2026-05-04)
 
 ## URLs
 
@@ -19,7 +19,7 @@
 - **Header (v0.149/0.155):** `mainScreen`/`statsScreen` ohne `📤 shareData` und ohne `⚙️` — nur `?` `📥`. Backup nur via Settings/Datensicherung, „Mehr"-Hub-Eintrag, OneDrive-Banner und Backup-Reminder. `historyScreen`/`mealDetailScreen`/`moreScreen` haben minimale Header. `mainScreen` zeigt zusätzlich rechts neben „Hej <Name>" einen kleinen klickbaren Versions-Tag `#appVersionTag` (öffnet `whatsNewOv`); Text kommt beim DOMContentLoaded aus `APP_VERSION`.
 - **Kalorien-Ampel (v0.149):** `_kcalAmpel(goal,eaten,S)` vor `renderAll()` — ±10 % grün; darüber/darunter abhängig von Diät-Richtung (lose/gain/maintain), abgeleitet aus `S.goalWeight` vs `S.weight ±0.5`. `kcalTrendPill`-Klassen `balanced`/`over`.
 - **KI-Tagesbewertung (v0.150):** `requestKIRating(ev)` baut Prompt mit Per-Mahlzeit-Makros (kcal · P · K · F), Gesamt-Makros und Makro-Zielen aus `getMacroTargets()`. Leere KI-Antwort → Toast + Button-Reset; `max_tokens=300`, model `claude-haiku-4-5`.
-- **Mahlzeit-Detail (v0.151):** Nur noch `📋 Vorlage` als CTA im Body — kein separater Zutat-Button. Der zentrale `＋` der Bottom-Nav (`#cbMealDetail`) wird in `renderMealDetail` auf `openPicker('<meal>')` umgebogen, sodass er die geöffnete Mahlzeit als Kontext nutzt.
+- **Mahlzeit-Detail (v0.151/0.157):** CTAs im Body: `📋 Vorlage` (`#mdTpl` → `openTemplateOv`) + `💾 Als Rezept` (`#mdSaveRecipe` → `saveMealAsRecipe`, nur sichtbar wenn Einträge vorhanden). Der zentrale `＋` der Bottom-Nav (`#cbMealDetail`) wird in `renderMealDetail` auf `openPicker('<meal>')` umgebogen. `saveMealAsRecipe(meal)` flacht alle Einträge zu Zutaten ab (Recipe-Einträge anteilig nach `portions`, Single-Foods 1:1), persistiert das Rezept sofort in `recipes`, setzt `recEditOpenedFrom='mealDetail'` und öffnet `recEditOv` direkt zum Benennen. `recEditSave`/`recEditDelete` springen nur dann zurück in Settings, wenn `recEditOpenedFrom!=='mealDetail'`.
 - **Share/Import:** Sender → `POST /share` (Worker, KV, 1y TTL) → `?s=<id>` auf PWA-Origin. Empfänger: Android öffnet PWA via `handle_links`; iOS-Safari (non-standalone) bekommt `iosSwitchOv`-Anleitung + Auto-Clipboard, User wechselt zur PWA und tippt 📥 (`openImportPaste()`). Legacy-URL-Formen `#x=`/`#r=`/`workers.dev/s/<id>` bleiben kompatibel.
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 
@@ -52,18 +52,17 @@
 - v0.149 Kalorien-Ampel pro Diät-Richtung (lose/gain/maintain mit/ohne Zielgewicht)
 - v0.150 KI-Tagesbewertung mit Makros + leere-Antwort-Toast
 - v0.154 Feedback-Screenshot wieder Full-Page (Viewport-Crop entfernt, Bottom-Sheets jetzt vollständig im Bild)
-- v0.155 (revertiert) Mahlzeit-Detail als Bottom Sheet — zurückgedreht in v0.156
-- v0.156 ⚙️ aus Hauptseite/Trends entfernt; „Was ist neu" zeigt komplette History (#70, #71)
+- v0.157 Mahlzeit-Detail „💾 Als Rezept" — Rezept aus Mahlzeit erstellen, Editor öffnet zum Benennen (#75)
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.152 | #66 | Feedback-Screenshot robuster (foreignObject aus, Image-Timeout, Auto-Retry, genauerer Fehler-Toast) (#61) |
 | v0.153 | #68 | Feedback-Screenshot: Versuch Bottom-Sheet-Modale per Pixel-Freeze zu erfassen (klappte nicht — siehe v0.154) (#67) |
 | v0.154 | — | Feedback-Screenshot wieder Full-Page (Viewport-Crop entfernt, revertiert #56) (#67) |
 | v0.155 | #73 | Mahlzeit-Detail → Bottom Sheet; ⚙️ entfernt; Was-ist-neu-History — Bottom Sheet in v0.156 revertiert |
 | v0.156 | — | Revert Bottom Sheet (#72); ⚙️ entfernt + Was-ist-neu-History bleiben (#70, #71) |
+| v0.157 | — | Mahlzeit-Detail: „💾 Als Rezept" speichert die Mahlzeit als Rezept und öffnet den Editor (#75) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.156</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.157</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -913,6 +913,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     <div class="md-list" id="mdList"></div>
     <div class="md-cta">
       <button type="button" class="tpl" id="mdTpl">📋 Vorlage</button>
+      <button type="button" class="tpl" id="mdSaveRecipe">💾 Als Rezept</button>
     </div>
   </div>
   <div class="bnav">
@@ -965,7 +966,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.156</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.157</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1843,7 +1844,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.156';
+var APP_VERSION='0.157';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1872,6 +1873,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.157',items:[
+    {icon:'📋',text:'Aus einer Mahlzeit lässt sich jetzt ein Rezept erstellen: im Mahlzeit-Detail neuer Button „💾 Als Rezept" — bündelt alle Einträge der Mahlzeit (inkl. enthaltener Rezepte, anteilig nach Portionen) zu einem neuen Rezept und öffnet direkt den Editor zum Benennen (Issue #75)',where:'Mahlzeit-Detail · 💾 Als Rezept'},
+  ]},
   {v:'0.156',items:[
     {icon:'⚙️',text:'Einstellungs-Button oben rechts entfernt — Einstellungen erreichst du weiter über den Mehr-Tab (Issue #71)',where:'Heute-Tab & Trends · Header'},
     {icon:'🆕',text:'„Was ist neu" zeigt jetzt die komplette Versionshistorie — nicht nur die Änderungen seit dem letzten Update (Issue #70)',where:'Mehr-Tab → Was ist neu · Header-Versions-Tag'},
@@ -2071,6 +2075,7 @@ var foodCache={}, customFoods=[], recipes=[], barcodeCache={};
 // Edit state
 var editMeal=null, editIdx=null;   // diary entry being edited
 var recEditId=null;                // recipe being edited in settings
+var recEditOpenedFrom=null;        // 'settings' | 'mealDetail' — controls return target
 
 var isOnline=navigator.onLine;
 
@@ -3204,6 +3209,7 @@ var _origPickerConfirmAdd=null;
 // ════════════════════════════════════════
 function openRecipeEditor(recipeId){
   recEditId=recipeId;
+  recEditOpenedFrom='settings';
   var rec=recipes.find(function(r){return r.id===recipeId;});
   if(!rec)return;
   document.getElementById('recEditTitle').textContent=(rec.emoji||'📋')+' '+rec.name;
@@ -3287,14 +3293,20 @@ function recEditSave(){
   var insEl=document.getElementById('recEditInstructions');
   if(insEl)rec.instructions=insEl.value.trim();
   saveX();
+  var from=recEditOpenedFrom;
   closeOv('recEditOv');
-  setTimeout(function(){openSettings();},200);
+  recEditOpenedFrom=null;
+  if(from!=='mealDetail'){setTimeout(function(){openSettings();},200);}
   showToast('Rezept gespeichert ✓');
 }
 
 function recEditDelete(){
   recipes=recipes.filter(function(r){return r.id!==recEditId;});
-  saveX();renderSettFoodList();closeOv('recEditOv');showToast('Rezept gelöscht');
+  saveX();
+  if(recEditOpenedFrom!=='mealDetail'){renderSettFoodList();}
+  closeOv('recEditOv');
+  recEditOpenedFrom=null;
+  showToast('Rezept gelöscht');
 }
 
 // ════════════════════════════════════════
@@ -5561,6 +5573,40 @@ function renderMealDetail(meal){
   var ctaTpl=document.getElementById('mdTpl');if(ctaTpl)ctaTpl.setAttribute('onclick',"openTemplateOv('"+meal+"')");
   var ctaCpy=document.getElementById('mdCopy');if(ctaCpy)ctaCpy.setAttribute('onclick',"copyMealFromYesterday('"+meal+"')");
   var ctaShr=document.getElementById('mdShare');if(ctaShr)ctaShr.setAttribute('onclick',"shareMeal('"+meal+"')");
+  var ctaSav=document.getElementById('mdSaveRecipe');
+  if(ctaSav){ctaSav.setAttribute('onclick',"saveMealAsRecipe('"+meal+"')");ctaSav.style.display=en.length?'':'none';}
+}
+
+function saveMealAsRecipe(meal){
+  var day=getDay(),en=day.meals[meal]||[];
+  if(!en.length){showToast('Keine Einträge in dieser Mahlzeit');return;}
+  var ings=[];
+  en.forEach(function(e){
+    if(e.isRecipe&&e.ingredients&&e.ingredients.length){
+      var portions=e.portions||1;
+      e.ingredients.forEach(function(ing){
+        if(!ing.per100)return;
+        ings.push({name:ing.name,emoji:ing.emoji||'🍽',amount:Math.round((ing.amount||0)*portions),per100:ing.per100});
+      });
+    } else if(e.per100){
+      ings.push({name:e.name,emoji:e.emoji||'🍽',amount:e.amount||100,per100:e.per100});
+    }
+  });
+  if(!ings.length){showToast('Keine geeigneten Zutaten für ein Rezept gefunden');return;}
+  var firstName=en[0].name||MEAL_NAMES[meal]||'Mahlzeit';
+  var defaultName=en.length>1?firstName+' & '+(en.length-1)+' weitere':firstName;
+  var rec={id:Date.now().toString(),name:defaultName,emoji:en[0].emoji||'📋',ingredients:JSON.parse(JSON.stringify(ings)),instructions:''};
+  recipes.unshift(rec);saveX();
+  recEditOpenedFrom='mealDetail';
+  recEditId=rec.id;
+  document.getElementById('recEditTitle').textContent=(rec.emoji||'📋')+' '+rec.name;
+  document.getElementById('recEditName').value=rec.name;
+  document.getElementById('recEditEmoji').value=rec.emoji||'';
+  var insEl=document.getElementById('recEditInstructions');if(insEl)insEl.value='';
+  recEditRenderIng(rec.ingredients);
+  recEditSearch();
+  openOv('recEditOv');
+  showToast('📋 Rezept erstellt – Name & Zutaten anpassen');
 }
 
 // ── HISTORY (Verlauf) ──

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.156';
+var VERSION = '0.157';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary

Issue **#75** (Aus einer Mahlzeit ein Rezept erstellen können) — neuer CTA `💾 Als Rezept` im Mahlzeit-Detail neben `📋 Vorlage`. Bündelt alle Einträge der geöffneten Mahlzeit zu Zutaten (Recipe-Einträge anteilig nach Portionen, Single-Foods 1:1), persistiert das Rezept sofort und öffnet den `recEditOv`-Editor direkt zum Benennen / Feintunen.

Begleit-Refactor: neuer Tracker `recEditOpenedFrom` (`'settings' | 'mealDetail'`) — verhindert, dass `recEditSave`/`recEditDelete` nach dem Speichern fälschlich in die Settings zurückspringen, wenn der Editor aus dem Mahlzeit-Detail geöffnet wurde.

Issue **#72** (Mahlzeit-Detail-Screen störend) wurde im Vorfeld als gelöst geschlossen — Bottom-Sheet-Versuch in v0.155 → revertiert in v0.156.

## Test plan

- [ ] Mahlzeit mit gemischten Einträgen (Single-Foods + Rezept-Einträge mit `portions != 1`) → `💾 Als Rezept`: Rezept enthält alle Zutaten, Recipe-Mengen sind anteilig nach Portionen skaliert
- [ ] Editor öffnet direkt im Mahlzeit-Detail (nicht in Settings); nach `💾 Rezept speichern` schließt der Editor und das Mahlzeit-Detail bleibt sichtbar
- [ ] Nach `🗑️ Rezept löschen` schließt der Editor sauber, kein Settings-Sprung
- [ ] Bei leerer Mahlzeit ist der Button ausgeblendet
- [ ] Aus Settings → Bibliothek → Rezept öffnen verhält sich unverändert (Settings → Editor → zurück zu Settings)
- [ ] Service-Worker-Cache-Invalidierung greift (v0.156 → v0.157), Versions-Tag im Header zeigt v0.157

https://claude.ai/code/session_01NuuvwiJTpjg21eRnJShsgA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuuvwiJTpjg21eRnJShsgA)_