### PR TITLE
fix(onedrive): Reconnect-Modal, Autospeicher-Slot-Fix, Button-Layout v0.159 (#77, #78, #83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,18 @@ Concrete rules:
 
 These rules apply to every agent (Claude Code, Codex, automation scripts) interacting with this repository, on every branch, including this file's own contents.
 
+## CSS Pitfalls
+
+**`.seb` buttons in flex rows:** The `.seb` class sets `width:100%` and `margin-top:8px`. Inside a `display:flex` row container these properties break the layout — the button expands to full container width regardless of `flex-shrink:0`, and `margin-top` shifts it vertically within the row. This manifests as a misaligned or oversized button and reproduces identically on Android Chrome and iOS Safari.
+
+Rule: whenever a `.seb` button sits as a flex child in a row container, always override both properties inline:
+
+```html
+<button class="seb" style="width:auto;margin-top:0;…">…</button>
+```
+
+Add any further flex-specific overrides (`flex:1`, `flex-shrink:0`, explicit `padding`, …) as needed, but `width:auto;margin-top:0;` are always the baseline.
+
 ## GitHub Workflow
 
 Prefer PRs over direct pushes to `main`.

--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.158 (2026-05-04)
+**Stand:** v0.159 (2026-05-04)
 
 ## URLs
 
@@ -22,6 +22,8 @@
 - **Mahlzeit-Detail (v0.151/0.157):** CTAs im Body: `📋 Vorlage` (`#mdTpl` → `openTemplateOv`) + `💾 Als Rezept` (`#mdSaveRecipe` → `saveMealAsRecipe`, nur sichtbar wenn Einträge vorhanden). Der zentrale `＋` der Bottom-Nav (`#cbMealDetail`) wird in `renderMealDetail` auf `openPicker('<meal>')` umgebogen. `saveMealAsRecipe(meal)` flacht alle Einträge zu Zutaten ab (Recipe-Einträge anteilig nach `portions`, Single-Foods 1:1), persistiert das Rezept sofort in `recipes`, setzt `recEditOpenedFrom='mealDetail'` und öffnet `recEditOv` direkt zum Benennen. `recEditSave`/`recEditDelete` springen nur dann zurück in Settings, wenn `recEditOpenedFrom!=='mealDetail'`.
 - **Share/Import:** Sender → `POST /share` (Worker, KV, 1y TTL) → `?s=<id>` auf PWA-Origin. Empfänger: Android öffnet PWA via `handle_links`; iOS-Safari (non-standalone) bekommt `iosSwitchOv`-Anleitung + Auto-Clipboard, User wechselt zur PWA und tippt 📥 (`openImportPaste()`). Legacy-URL-Formen `#x=`/`#r=`/`workers.dev/s/<id>` bleiben kompatibel.
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
+- **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
+- **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
 ## Worker-Endpoints
@@ -59,16 +61,17 @@
 - v0.154 Feedback-Screenshot wieder Full-Page (Viewport-Crop entfernt, Bottom-Sheets jetzt vollständig im Bild)
 - v0.157 Mahlzeit-Detail „💾 Als Rezept" — Rezept aus Mahlzeit erstellen, Editor öffnet zum Benennen (#75)
 - v0.158 Sport-Sync: Worker-Endpoints `/workout` + `/workouts` deployen (`wrangler deploy` im `worker/`), in „Mehr → Sport-Sync" Token erzeugen, je eine iOS-Shortcut-Automation und ein Android-HTTP-Request-Shortcut bauen, echtes Workout durchspielen → in PWA muss „Apple"/„Samsung"-Badge erscheinen, Hero-kcal um den Wert reduziert sein
+- v0.159 OneDrive Reconnect-Modal: Token ablaufen lassen (oder manuell `_odClearTokens()` in DevTools), dann sync triggern → `odReconnectOv` muss aufgehen; „Neu verbinden" startet PKCE-Flow neu
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.154 | — | Feedback-Screenshot wieder Full-Page (Viewport-Crop entfernt, revertiert #56) (#67) |
 | v0.155 | #73 | Mahlzeit-Detail → Bottom Sheet; ⚙️ entfernt; Was-ist-neu-History — Bottom Sheet in v0.156 revertiert |
 | v0.156 | — | Revert Bottom Sheet (#72); ⚙️ entfernt + Was-ist-neu-History bleiben (#70, #71) |
 | v0.157 | — | Mahlzeit-Detail: „💾 Als Rezept" speichert die Mahlzeit als Rezept und öffnet den Editor (#75) |
 | v0.158 | — | Sport-Sync: Apple-Health- und Samsung-Health-Workouts werden via Worker-Endpoint + per-User-Token automatisch importiert; erstes ausgelagertes Modul `js/health-sync.js` |
+| v0.159 | — | OneDrive: Reconnect-Modal bei abgelaufener Sitzung (#77); Autospeicher-Slot-Rotation war durch doppelte Funktionsdefinition deaktiviert, gefixt (#78); Bestätigen-Button Ordnerpfad-Dialog Layout (#83) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -971,7 +971,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.158</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.159</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1913,7 +1913,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.158';
+var APP_VERSION='0.159';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1942,6 +1942,10 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.159',items:[
+    {icon:'☁️',text:'Läuft die OneDrive-Sitzung ab, erscheint jetzt sofort ein Dialog zum Neu-Verbinden — ein Tipp reicht, kein stiller Datenverlust mehr (#77)',where:'OneDrive · Verbindung'},
+    {icon:'💾',text:'Autospeicher-Slots werden jetzt täglich automatisch befüllt — ein Fehler hatte die Slot-Rotation deaktiviert (#78)',where:'OneDrive · Autospeicher'},
+  ]},
   {v:'0.158',items:[
     {icon:'🏃',text:'Sport-Sync: Workouts aus Apple Health (über iOS-Kurzbefehle) und Samsung Health / Health Connect (über Android HTTP-Shortcuts oder Tasker) werden automatisch importiert. Die verbrannten Kalorien werden vom Tagesziel abgezogen. Einrichten unter „Mehr" → „Sport-Sync".',where:'Mehr · Sport-Sync'},
   ]},
@@ -2390,14 +2394,6 @@ function _odAutoSync(){
   if(!isOnline)return;
   if(localStorage.getItem('nt_od_sync_date')===today())return;
   oneDriveSyncSlot().catch(function(){});
-}
-function _odAutoSync(){
-  if(!_odLoadTokens())return;
-  if(!isOnline)return;
-  if(localStorage.getItem('nt_od_sync_date')===today())return;
-  oneDriveSyncUp().then(function(){
-    localStorage.setItem('nt_od_sync_date',today());
-  }).catch(function(){});
 }
 function _checkOdBanner(){
   if(_odLoadTokens())return;
@@ -5021,6 +5017,10 @@ function _odHandleCallback(code,state){
   }).catch(function(){showToast('OneDrive Token-Fehler');});
 }
 
+function _odShowReconnect(){
+  localStorage.removeItem('nt_od_banner_date');
+  openOv('odReconnectOv');
+}
 function _odGetToken(){
   var tok=_odLoadTokens();
   if(!tok)return Promise.reject('not_connected');
@@ -5034,7 +5034,12 @@ function _odGetToken(){
       +'&refresh_token='+encodeURIComponent(tok.refresh_token)
       +'&scope='+encodeURIComponent(OD_SCOPES)
   }).then(function(r){return r.json();}).then(function(t){
-    if(t.error){_odClearTokens();throw new Error(t.error);}
+    if(t.error){
+      if(t.error==='invalid_grant'||t.error==='interaction_required'||t.error==='unauthorized_client'){
+        _odClearTokens();renderOneDriveStatus();_odShowReconnect();
+      }
+      throw new Error(t.error);
+    }
     var updated={access_token:t.access_token,refresh_token:t.refresh_token||tok.refresh_token,expires_at:Date.now()+(t.expires_in-60)*1000};
     _odSaveTokens(updated);
     return updated.access_token;
@@ -5170,7 +5175,7 @@ function renderOneDriveStatus(){
       +'<div style="font-size:12px;color:var(--mu);margin-bottom:4px;">📁 OneDrive-Ordner</div>'
       +'<div style="display:flex;gap:6px;">'
       +'<input id="odPathInput" type="text" value="'+folder+'" placeholder="/NutriTrack" style="flex:1;padding:8px 10px;border:2px solid var(--br);border-radius:8px;font-size:13px;outline:none;">'
-      +'<button type="button" class="seb" style="flex-shrink:0;" onclick="_odSaveFolder(document.getElementById(\'odPathInput\').value)">✓</button>'
+      +'<button type="button" class="seb" style="width:auto;margin-top:0;flex-shrink:0;" onclick="_odSaveFolder(document.getElementById(\'odPathInput\').value)">✓</button>'
       +'</div>'
       +'</div>'
       +'<button type="button" class="seb" onclick="oneDriveSyncUp()">☁️ Jetzt sichern</button>'
@@ -6058,5 +6063,14 @@ function hsTestSync(){
 <script src="picker.js"></script>
 <script src="js/health-sync.js"></script>
 <button type="button" id="feedbackFab" class="fb-fab" onclick="openFeedback()" title="Feedback senden" aria-label="Feedback senden">🐛</button>
+<div class="ov" id="odReconnectOv" onclick="bgClose(event,'odReconnectOv')">
+  <div style="background:var(--bg);border-radius:20px 20px 0 0;padding:28px 24px 32px;max-width:480px;width:100%;text-align:center;">
+    <div style="font-size:36px;margin-bottom:12px;">☁️</div>
+    <div style="font-weight:700;font-size:17px;margin-bottom:8px;">OneDrive abgemeldet</div>
+    <div style="font-size:14px;color:var(--mu);margin-bottom:20px;">Deine OneDrive-Sitzung ist abgelaufen. Verbinde dich neu, um automatische Backups fortzusetzen.</div>
+    <button type="button" class="seb" style="margin-top:0;margin-bottom:8px;" onclick="closeOv('odReconnectOv');oneDriveConnect()">🔗 Neu verbinden</button>
+    <button type="button" onclick="closeOv('odReconnectOv')" style="background:none;border:none;color:var(--mu);font-size:14px;width:100%;padding:8px;cursor:pointer;font-family:inherit;">Später</button>
+  </div>
+</div>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.158';
+var VERSION = '0.159';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Was wurde geändert

### #77 — OneDrive-Verbindung geht täglich verloren
`_odGetToken()` unterscheidet jetzt echte Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern. Bei Auth-Fehlern: Tokens löschen + `renderOneDriveStatus()` + sofort `odReconnectOv`-Modal öffnen (Bottom-Sheet, ein Tipp zum Neu-Verbinden reicht). Netzwerkfehler lassen Tokens intakt.

### #78 — Autospeicher ist leer
Doppelte `_odAutoSync()`-Definition entfernt. Die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf) — dadurch wurden Autospeicher-Slots nie automatisch befüllt. Jetzt wird täglich korrekt ein Slot rotiert.

### #83 — Bestätigen-Button Ordnerpfad verschoben (iOS + Android)
`width:auto;margin-top:0;` inline ergänzt — überschreibt die `.seb`-Klassenwerte `width:100%` und `margin-top:8px`, die in Flex-Row-Containern das Layout zerstören.

### AGENTS.md
CSS-Pitfall-Regel für `.seb` in Flex-Row-Containern dokumentiert, damit dieser Fehler nicht wiederholt wird.

## Versioning
- `APP_VERSION`: 0.158 → 0.159
- `VERSION` (sw.js): 0.158 → 0.159
- CHANGELOG-Eintrag für #77 und #78 hinzugefügt

## Manuelle Checks
- Kein Build-Schritt, statische PWA
- Flow für Reconnect-Modal: `_odClearTokens()` in DevTools → Sync triggern → Modal erscheint → „Neu verbinden" startet PKCE-Flow
- Autospeicher: nach Fix läuft täglich `oneDriveSyncSlot()` beim App-Start
- Button-Layout: Ordnerpfad-Input + ✓-Button korrekt nebeneinander

Closes #77
Closes #78
Closes #83

---
_Generated by [Claude Code](https://claude.ai/code/session_01HacMFs61daDqpGJQfppSNw)_