### PR TITLE
v0.163: Foto-Analyse in KI-Chat integriert (#80)

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.162</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.163</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1911,7 +1911,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.162';
+var APP_VERSION='0.163';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1940,6 +1940,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.163',items:[
+    {icon:'💬',text:'Nach der Foto-Analyse wechselt der Picker automatisch in den Chat — die KI kann jetzt Rückfragen stellen, und du kannst weitere Details zum Foto ergänzen. Fotos werden als Bildkontext mitgeschickt (Modell: claude-sonnet-4-6). (#80)',where:'Picker · Foto → Chat'},
+  ]},
   {v:'0.162',items:[
     {icon:'📸',text:'Feedback-Screenshot zeigt jetzt den tatsächlich aktiven Screen — offene Overlays (z.B. Rezeptsuche, Picker) erscheinen korrekt im Bild, nicht nur der Hintergrund (#87)',where:'Feedback · Screenshot'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -239,6 +239,8 @@ function pickerResetPhoto(){
   document.getElementById('pickerRecipeName').value='';
   document.getElementById('pickerChatRecipeName').value='';
   pickerIngredients=[];
+  var inp=document.getElementById('pickerChatInp');
+  if(inp)inp.placeholder='Was hast du gegessen?';
 }
 
 function pickerTryBarcode(canvas){
@@ -950,6 +952,12 @@ function pickerAnalyze(){
       btn.disabled=false;btn.textContent='📷 Erneut analysieren';
       if(!parsed.zutaten.length){
         pickerSetPhotoStatus(text.length?'KI: '+text.slice(0,120):'Kein Lebensmittel erkannt.',true);
+        // Ins Chat wechseln damit User das Foto erklären kann (#80)
+        var msgs=document.getElementById('pickerChatMsgs');
+        msgs.innerHTML='<div class="cm a">📷 Ich konnte keine klaren Zutaten erkennen. Beschreibe bitte was auf dem Bild zu sehen ist, dann helfe ich weiter.</div>';
+        var inp=document.getElementById('pickerChatInp');
+        if(inp)inp.placeholder='📷 Was ist auf dem Foto?';
+        pickerSetTab('chat');
         return;
       }
       if(parsed.rezept){
@@ -961,6 +969,13 @@ function pickerAnalyze(){
         pickerIngredients=resolved;
         pickerShowPhotoResult(parsed.rezept);
         pickerSetPhotoStatus('',false);
+        // Foto-Kontext in Chat übertragen — User kann jetzt Rückfragen stellen (#80)
+        var names=resolved.slice(0,4).map(function(z){return z.name;}).join(', ')+(resolved.length>4?' u.a.':'');
+        var msgs=document.getElementById('pickerChatMsgs');
+        msgs.innerHTML='<div class="cm a">📷 '+resolved.length+' Zutaten erkannt: '+names+'. Stelle Rückfragen oder ergänze Details — Zutaten-Liste im 📷 Foto-Tab bearbeiten.</div>';
+        var inp=document.getElementById('pickerChatInp');
+        if(inp)inp.placeholder='📷 Rückfragen zum Foto stellen…';
+        pickerSetTab('chat');
       });
     },
     function(err){btn.disabled=false;btn.textContent='📷 Erneut analysieren';pickerSetPhotoStatus('Fehler: '+err,true);}
@@ -1071,8 +1086,12 @@ function pickerSendChat(){
   document.getElementById('pickerChatSend').disabled=true;
   document.getElementById('pickerChatResult').classList.add('hidden');
   msgs.scrollTop=msgs.scrollHeight;
-  var prompt=getChatPrompt().replace('{MSG}',msg);
-  callClaude('claude-haiku-4-5',[{type:'text',text:prompt}],300,
+  var hasPhoto=!!window._pickerPhotoB64;
+  var content=hasPhoto
+    ?[{type:'image',source:{type:'base64',media_type:'image/jpeg',data:window._pickerPhotoB64}},{type:'text',text:getChatPrompt().replace('{MSG}',msg)}]
+    :[{type:'text',text:getChatPrompt().replace('{MSG}',msg)}];
+  var model=hasPhoto?'claude-sonnet-4-6':'claude-haiku-4-5';
+  callClaude(model,content,300,
     function(text){
       var raw=parseIngJSON(text);
       if(!raw.length){msgs.innerHTML+='<div class="cm a">❌ Konnte nicht parsen. Genauer beschreiben.</div>';document.getElementById('pickerChatSend').disabled=false;return;}

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.162';
+var VERSION = '0.163';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Changes

- **#80** Nach erfolgreicher Foto-Analyse wechselt der Picker automatisch in den Chat-Tab mit einer Zusammenfassung der erkannten Zutaten als erste KI-Nachricht
- Bei fehlgeschlagener Erkennung: Chat öffnet sich mit Aufforderung zur Beschreibung
- Chat-Nachrichten mit aktivem Foto werden mit Bild-Kontext an `claude-sonnet-4-6` geschickt (ohne Foto: haiku wie bisher)
- `pickerResetPhoto()` setzt Chat-Placeholder zurück

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRZYdMviBJPkjYircx8rGv)_