### PR TITLE
v0.164: OpenFoodFacts-Textsuche im Chat-Tab für Markenprodukte (#79)

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.163</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.164</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1911,7 +1911,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.163';
+var APP_VERSION='0.164';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1940,6 +1940,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.164',items:[
+    {icon:'🌐',text:'Im Chat-Tab sucht die App jetzt zuerst in OpenFoodFacts — Markenprodukte (z.B. Dean & David) werden direkt mit echten Nährwerten als Karte angezeigt. Kein Treffer → KI schätzt wie bisher. „🤖 Stattdessen KI fragen" überspringt OFT. (#79)',where:'Picker · Chat-Tab'},
+  ]},
   {v:'0.163',items:[
     {icon:'💬',text:'Nach der Foto-Analyse wechselt der Picker automatisch in den Chat — die KI kann jetzt Rückfragen stellen, und du kannst weitere Details zum Foto ergänzen. Fotos werden als Bildkontext mitgeschickt (Modell: claude-sonnet-4-6). (#80)',where:'Picker · Foto → Chat'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -1077,15 +1077,49 @@ function _pickerAdd(emoji,nameId,portionsId,defaultName,saveAsRecipe,hasEditMode
 function pickerPhotoAdd(saveAsRecipe){_pickerAdd('📸','pickerRecipeName','pickerPhotoPortions','Foto-Rezept',saveAsRecipe,true);}
 
 // ─── PICKER: CHAT TAB ───
-function pickerSendChat(){
-  var msg=document.getElementById('pickerChatInp').value.trim();if(!msg)return;
-  if(!isOnline){showToast('Internet benötigt');return;}
+
+function pickerChatOftSearch(q,onDone){
+  var proxy='https://corsproxy.io/?';
+  var url='https://world.openfoodfacts.org/cgi/search.pl?search_simple=1&action=process&json=1&page_size=6&fields=product_name,product_name_de,nutriments&search_terms='+encodeURIComponent(q);
+  fetch(proxy+encodeURIComponent(url))
+    .then(function(r){return r.json();})
+    .then(function(data){
+      var results=[];
+      (data.products||[]).forEach(function(p){
+        var nm=p.nutriments||{};
+        var name=(p.product_name_de||p.product_name||'').trim();
+        if(!name||name.length<3)return;
+        var kcal=nm['energy-kcal_100g']||0;
+        if(kcal<=0||kcal>950)return;
+        results.push({name:name,emoji:emo(name),per100:{kcal:kcal,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0}});
+      });
+      onDone(results.slice(0,3));
+    })
+    .catch(function(){onDone([]);});
+}
+
+function pickerChatAddOft(i){
+  var p=(window._pickerOftResults||[])[i];if(!p)return;
+  pickerIngredients=[{name:p.name,emoji:p.emoji,g:100,amount:100,per100:p.per100}];
+  if(!document.getElementById('pickerChatRecipeName').value)
+    document.getElementById('pickerChatRecipeName').value=p.name.slice(0,50);
+  var oft=document.getElementById('pickerOftCards');if(oft)oft.remove();
   var msgs=document.getElementById('pickerChatMsgs');
-  msgs.innerHTML+='<div class="cm u">'+msg+'</div>';
-  document.getElementById('pickerChatInp').value='';
-  document.getElementById('pickerChatSend').disabled=true;
-  document.getElementById('pickerChatResult').classList.add('hidden');
+  msgs.innerHTML+='<div class="cm a">✓ '+p.name+' aus OpenFoodFacts übernommen.</div>';
+  pickerRenderIngList('pickerChatIngList',pickerIngredients,
+    function(idx,v){pickerIngredients[idx].amount=parseFloat(v)||0;pickerUpdateChatTotal();},
+    function(idx){pickerIngredients.splice(idx,1);pickerUpdateChatTotal();}
+  );
+  pickerUpdateChatTotal();
+  document.getElementById('pickerChatResult').classList.remove('hidden');
+}
+
+function pickerChatKiFallback(msg){
+  var msgs=document.getElementById('pickerChatMsgs');
+  var oft=document.getElementById('pickerOftCards');if(oft)oft.remove();
+  msgs.innerHTML+='<div class="cm a">🤖 KI schätzt Nährwerte...</div>';
   msgs.scrollTop=msgs.scrollHeight;
+  document.getElementById('pickerChatSend').disabled=true;
   var hasPhoto=!!window._pickerPhotoB64;
   var content=hasPhoto
     ?[{type:'image',source:{type:'base64',media_type:'image/jpeg',data:window._pickerPhotoB64}},{type:'text',text:getChatPrompt().replace('{MSG}',msg)}]
@@ -1112,6 +1146,44 @@ function pickerSendChat(){
     },
     function(err){msgs.innerHTML+='<div class="cm a">❌ Fehler: '+err+'</div>';document.getElementById('pickerChatSend').disabled=false;}
   );
+}
+
+function pickerSendChat(){
+  var msg=document.getElementById('pickerChatInp').value.trim();if(!msg)return;
+  if(!isOnline){showToast('Internet benötigt');return;}
+  var msgs=document.getElementById('pickerChatMsgs');
+  msgs.innerHTML+='<div class="cm u">'+msg+'</div>';
+  document.getElementById('pickerChatInp').value='';
+  document.getElementById('pickerChatSend').disabled=true;
+  document.getElementById('pickerChatResult').classList.add('hidden');
+  msgs.scrollTop=msgs.scrollHeight;
+  window._pickerChatLastMsg=msg;
+  // OFT-Suche zuerst — Markenprodukte direkt aus OpenFoodFacts (#79)
+  msgs.innerHTML+='<div class="cm a" id="pickerChatThinking">🔍 Suche in OpenFoodFacts...</div>';
+  pickerChatOftSearch(msg,function(results){
+    var thinking=document.getElementById('pickerChatThinking');
+    if(thinking)thinking.remove();
+    if(results.length){
+      window._pickerOftResults=results;
+      var html='<div id="pickerOftCards" style="display:flex;flex-direction:column;gap:6px;margin-top:4px;">';
+      html+='<div class="cm a">🌐 '+results.length+' Treffer in OpenFoodFacts:</div>';
+      results.forEach(function(p,i){
+        var vals=Math.round(p.per100.kcal)+' kcal · P'+p.per100.protein.toFixed(1)+'g · K'+p.per100.carbs.toFixed(1)+'g · F'+p.per100.fat.toFixed(1)+'g /100g';
+        html+='<div style="background:var(--gl);border:1px solid var(--br);border-radius:10px;padding:8px 10px;display:flex;align-items:center;gap:8px;">'
+          +'<div style="flex:1;min-width:0;"><div style="font-weight:600;font-size:13px;">'+p.emoji+' '+p.name+'</div>'
+          +'<div style="font-size:11px;color:var(--mu);">'+vals+'</div></div>'
+          +'<button type="button" onclick="pickerChatAddOft('+i+')" style="background:var(--g1);color:#fff;border:none;border-radius:8px;padding:5px 10px;font-size:14px;font-weight:700;cursor:pointer;flex-shrink:0;">＋</button>'
+          +'</div>';
+      });
+      html+='<div style="text-align:center;padding-top:2px;"><button type="button" onclick="pickerChatKiFallback(window._pickerChatLastMsg)" style="background:none;border:none;color:var(--mu);font-size:12px;cursor:pointer;padding:4px 8px;text-decoration:underline;">🤖 Stattdessen KI fragen</button></div>';
+      html+='</div>';
+      msgs.innerHTML+=html;
+      msgs.scrollTop=msgs.scrollHeight;
+      document.getElementById('pickerChatSend').disabled=false;
+    } else {
+      pickerChatKiFallback(msg);
+    }
+  });
 }
 
 function pickerUpdateChatTotal(){pickerUpdateTotal('Chat');}

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.163';
+var VERSION = '0.164';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Changes

- **#79** Chat-Tab sucht zuerst in OpenFoodFacts: Treffer werden als wählbare Karten angezeigt (Name, kcal/P/K/F, ＋-Button zum Hinzufügen)
- Kein OFT-Treffer → KI-Fallback wie bisher
- „🤖 Stattdessen KI fragen"-Link überspringt OFT-Ergebnisse
- Neue Funktionen: `pickerChatOftSearch`, `pickerChatAddOft`, `pickerChatKiFallback`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRZYdMviBJPkjYircx8rGv)_