### PR TITLE
v0.165/0.166: OFT kJ-Fallback + Foto-Tab entkoppelt

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.165 (2026-05-04)
+**Stand:** v0.166 (2026-05-04)
 
 ## URLs
 
@@ -25,7 +25,7 @@
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
-- **Picker Chat (v0.163/v0.164/v0.165):** Nach Foto-Analyse **bleibt der Picker im Foto-Tab** (kein Auto-Wechsel in Chat mehr); Rückfragen-Hinweis wird im Chat-Tab vorbelegt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto bleibt es bei `claude-haiku-4-5`. `pickerResetPhoto()` setzt Chat-Placeholder zurück. Chat-Tab sucht zuerst in OpenFoodFacts (`pickerChatOftSearch` → corsproxy → `cgi/search.pl`); Treffer erscheinen als wählbare Karten (`pickerChatAddOft(i)`); kein Treffer → KI-Fallback via `pickerChatKiFallback(msg)`; „🤖 Stattdessen KI fragen"-Link überspringt OFT. OFT-Filter akzeptiert jetzt auch Einträge mit Energie nur in kJ (`energy_100g` / 4.184 als Fallback) — betrifft `pickerChatOftSearch`, `pickerFetchOnline` und `lookupNutrients`.
+- **Picker Chat (v0.163/v0.164/v0.165/v0.166):** Foto-Tab und Chat-Tab sind vollständig entkoppelt — kein Auto-Wechsel, keine Chat-Vorbelegung nach Foto-Analyse. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto bleibt es bei `claude-haiku-4-5`. Chat-Tab sucht zuerst in OpenFoodFacts (`pickerChatOftSearch` → corsproxy → `cgi/search.pl`); Treffer erscheinen als wählbare Karten (`pickerChatAddOft(i)`); kein Treffer → KI-Fallback via `pickerChatKiFallback(msg)`; „🤖 Stattdessen KI fragen"-Link überspringt OFT. OFT-Filter akzeptiert Einträge mit Energie nur in kJ (`energy_100g` / 4.184 als Fallback) — betrifft `pickerChatOftSearch`, `pickerFetchOnline` und `lookupNutrients`.
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
 ## Worker-Endpoints
@@ -64,7 +64,7 @@
 - v0.161 Safe-Area: iPhone + Android — bnav + ＋-Button vollständig über System-UI sichtbar; KI-Tagesreport-Button ist verschwunden
 - v0.162 Feedback-Screenshot: Picker/Overlay offen → Feedback → Screenshot → Bild zeigt aktiven Overlay, nicht mainScreen
 - v0.163 Chat + Foto: Foto analysieren → Chat öffnet sich → Rückfrage stellen mit Foto-Kontext möglich
-- v0.165 OFT kJ-Fix: Produkt mit nur kJ-Angabe (z.B. Dean & David) suchen → OFT-Karte erscheint; Foto → Zutaten → Picker bleibt im Foto-Tab
+- v0.166 Foto-Tab: Analyse → Ergebnis bleibt in Foto-Tab, kein Chat-Wechsel, kein Chat-Vortext
 
 ## Versions-Historie (letzte 5)
 
@@ -74,7 +74,8 @@
 | v0.162 | #92 | Feedback-Screenshot zeigt aktiven Screen korrekt — fixed→absolute Freeze (#87) |
 | v0.163 | #93 | Foto-Analyse öffnet Chat-Tab; Foto als Kontext in Chat-Nachrichten (#80) |
 | v0.164 | #94 | OFT-Textsuche im Chat-Tab; Markenprodukte als Karten; KI-Fallback (#79) |
-| v0.165 | — | OFT kJ-Fallback (mehr Produkte gefunden); Foto-Tab bleibt aktiv nach Analyse (#79/#80) |
+| v0.165 | — | OFT kJ-Fallback (mehr Produkte gefunden) (#79) |
+| v0.166 | — | Foto-Tab vollständig entkoppelt vom Chat (#80) |
 
 ---
 

--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.164 (2026-05-04)
+**Stand:** v0.165 (2026-05-04)
 
 ## URLs
 
@@ -25,7 +25,7 @@
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
-- **Picker Chat (v0.163/v0.164):** Nach Foto-Analyse wechselt der Picker automatisch in den Chat-Tab; Analyse-Zusammenfassung erscheint als erste KI-Nachricht. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto bleibt es bei `claude-haiku-4-5`. `pickerResetPhoto()` setzt Chat-Placeholder zurück. Chat-Tab sucht zuerst in OpenFoodFacts (`pickerChatOftSearch` → corsproxy → `cgi/search.pl`); Treffer erscheinen als wählbare Karten (`pickerChatAddOft(i)`); kein Treffer → KI-Fallback via `pickerChatKiFallback(msg)`; „🤖 Stattdessen KI fragen"-Link überspringt OFT.
+- **Picker Chat (v0.163/v0.164/v0.165):** Nach Foto-Analyse **bleibt der Picker im Foto-Tab** (kein Auto-Wechsel in Chat mehr); Rückfragen-Hinweis wird im Chat-Tab vorbelegt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto bleibt es bei `claude-haiku-4-5`. `pickerResetPhoto()` setzt Chat-Placeholder zurück. Chat-Tab sucht zuerst in OpenFoodFacts (`pickerChatOftSearch` → corsproxy → `cgi/search.pl`); Treffer erscheinen als wählbare Karten (`pickerChatAddOft(i)`); kein Treffer → KI-Fallback via `pickerChatKiFallback(msg)`; „🤖 Stattdessen KI fragen"-Link überspringt OFT. OFT-Filter akzeptiert jetzt auch Einträge mit Energie nur in kJ (`energy_100g` / 4.184 als Fallback) — betrifft `pickerChatOftSearch`, `pickerFetchOnline` und `lookupNutrients`.
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
 ## Worker-Endpoints
@@ -64,17 +64,17 @@
 - v0.161 Safe-Area: iPhone + Android — bnav + ＋-Button vollständig über System-UI sichtbar; KI-Tagesreport-Button ist verschwunden
 - v0.162 Feedback-Screenshot: Picker/Overlay offen → Feedback → Screenshot → Bild zeigt aktiven Overlay, nicht mainScreen
 - v0.163 Chat + Foto: Foto analysieren → Chat öffnet sich → Rückfrage stellen mit Foto-Kontext möglich
-- v0.164 OFT im Chat: „Dean & David Caesar Salat" eingeben → OFT-Karte erscheint; unbekanntes Lebensmittel → KI-Fallback
+- v0.165 OFT kJ-Fix: Produkt mit nur kJ-Angabe (z.B. Dean & David) suchen → OFT-Karte erscheint; Foto → Zutaten → Picker bleibt im Foto-Tab
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.160 | #90 | Bibliothek direkt aus Mehr-Tab (#84, #85); Layout-Fix moreScreen (#86) |
 | v0.161 | #91 | KI-Tagesreport entfernt (#81); Safe-Area iOS + Android (#88) |
 | v0.162 | #92 | Feedback-Screenshot zeigt aktiven Screen korrekt — fixed→absolute Freeze (#87) |
 | v0.163 | #93 | Foto-Analyse öffnet Chat-Tab; Foto als Kontext in Chat-Nachrichten (#80) |
 | v0.164 | #94 | OFT-Textsuche im Chat-Tab; Markenprodukte als Karten; KI-Fallback (#79) |
+| v0.165 | — | OFT kJ-Fallback (mehr Produkte gefunden); Foto-Tab bleibt aktiv nach Analyse (#79/#80) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.164</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.165</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1911,7 +1911,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.164';
+var APP_VERSION='0.165';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1940,6 +1940,10 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.165',items:[
+    {icon:'🌐',text:'OpenFoodFacts findet jetzt deutlich mehr Produkte: Einträge mit Energie-Angabe in kJ (statt kcal) werden korrekt erkannt und umgerechnet — betrifft Chat-Suche, Suche-Tab und Nährwert-Lookup. (#79)',where:'Picker · Chat & Suche'},
+    {icon:'📷',text:'Nach der Foto-Analyse bleibt der Picker im Foto-Tab — Zutaten direkt prüfen und eintragen, ohne ungewollten Sprung in den Chat. (#80)',where:'Picker · Foto-Tab'},
+  ]},
   {v:'0.164',items:[
     {icon:'🌐',text:'Im Chat-Tab sucht die App jetzt zuerst in OpenFoodFacts — Markenprodukte (z.B. Dean & David) werden direkt mit echten Nährwerten als Karte angezeigt. Kein Treffer → KI schätzt wie bisher. „🤖 Stattdessen KI fragen" überspringt OFT. (#79)',where:'Picker · Chat-Tab'},
   ]},
@@ -3011,10 +3015,11 @@ function lookupNutrients(rawItems,onDone){
       var url='https://world.openfoodfacts.org/cgi/search.pl?search_terms='+encodeURIComponent(name)+'&search_simple=1&action=process&json=1&page_size=5&fields=product_name,nutriments';
       fetch(proxy+encodeURIComponent(url)).then(function(r){return r.json();})
         .then(function(data){
-          var prods=(data.products||[]).filter(function(p){return(p.nutriments||{})['energy-kcal_100g']>0;});
+          var prods=(data.products||[]).filter(function(p){var nm=(p.nutriments||{});return(nm['energy-kcal_100g']||nm['energy_100g'])>0;});
           if(prods.length>0){
             var p=prods[0],nm=p.nutriments||{};
-            results.push({name:name,emoji:emoji,amount:grams||0,per100:{kcal:nm['energy-kcal_100g']||0,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0},missingGrams:grams===null});
+            var kcal=nm['energy-kcal_100g']||Math.round((nm['energy_100g']||0)/4.184);
+            results.push({name:name,emoji:emoji,amount:grams||0,per100:{kcal:kcal,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0},missingGrams:grams===null});
             pending--;if(!pending)onDone(results);
           } else {kiNutrientLookup(name,emoji,grams,function(res){results.push(res);pending--;if(!pending)onDone(results);});}
         }).catch(function(){kiNutrientLookup(name,emoji,grams,function(res){results.push(res);pending--;if(!pending)onDone(results);});});

--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.165</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.166</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1911,7 +1911,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.165';
+var APP_VERSION='0.166';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1940,9 +1940,11 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.166',items:[
+    {icon:'📷',text:'Foto-Tab: Nach der Analyse kein automatischer Wechsel in den Chat mehr — Ergebnis bleibt sichtbar, Zutaten direkt eintragbar.',where:'Picker · Foto-Tab'},
+  ]},
   {v:'0.165',items:[
     {icon:'🌐',text:'OpenFoodFacts findet jetzt deutlich mehr Produkte: Einträge mit Energie-Angabe in kJ (statt kcal) werden korrekt erkannt und umgerechnet — betrifft Chat-Suche, Suche-Tab und Nährwert-Lookup. (#79)',where:'Picker · Chat & Suche'},
-    {icon:'📷',text:'Nach der Foto-Analyse bleibt der Picker im Foto-Tab — Zutaten direkt prüfen und eintragen, ohne ungewollten Sprung in den Chat. (#80)',where:'Picker · Foto-Tab'},
   ]},
   {v:'0.164',items:[
     {icon:'🌐',text:'Im Chat-Tab sucht die App jetzt zuerst in OpenFoodFacts — Markenprodukte (z.B. Dean & David) werden direkt mit echten Nährwerten als Karte angezeigt. Kein Treffer → KI schätzt wie bisher. „🤖 Stattdessen KI fragen" überspringt OFT. (#79)',where:'Picker · Chat-Tab'},

--- a/picker.js
+++ b/picker.js
@@ -111,7 +111,7 @@ function pickerFetchOnline(q){
       (data.products||[]).forEach(function(p){
         var nm=p.nutriments||{},name=(p.product_name_de||p.product_name||'').trim();
         if(!name||name.length<3)return;
-        var kcal=nm['energy-kcal_100g']||0;if(kcal<=0||kcal>950)return;
+        var kcal=nm['energy-kcal_100g']||Math.round((nm['energy_100g']||0)/4.184);if(kcal<=0||kcal>950)return;
         var k=name.toLowerCase();if(seen[k])return;seen[k]=true;
         var pr=nm['proteins_100g']||0,ca=nm['carbohydrates_100g']||0,fa=nm['fat_100g']||0,su=nm['sugars_100g']||0,fi=nm['fiber_100g']||0,sa=nm['salt_100g']||0;
         var ns=(k.startsWith(ql)||k.startsWith(eng||'__'))?2:0;
@@ -969,13 +969,12 @@ function pickerAnalyze(){
         pickerIngredients=resolved;
         pickerShowPhotoResult(parsed.rezept);
         pickerSetPhotoStatus('',false);
-        // Foto-Kontext in Chat übertragen — User kann jetzt Rückfragen stellen (#80)
+        // Foto-Kontext für spätere Chat-Rückfragen bereitstellen (#80)
         var names=resolved.slice(0,4).map(function(z){return z.name;}).join(', ')+(resolved.length>4?' u.a.':'');
         var msgs=document.getElementById('pickerChatMsgs');
-        msgs.innerHTML='<div class="cm a">📷 '+resolved.length+' Zutaten erkannt: '+names+'. Stelle Rückfragen oder ergänze Details — Zutaten-Liste im 📷 Foto-Tab bearbeiten.</div>';
+        msgs.innerHTML='<div class="cm a">📷 '+resolved.length+' Zutaten erkannt: '+names+'. Rückfragen? Wechsle in den 💬 Chat-Tab.</div>';
         var inp=document.getElementById('pickerChatInp');
         if(inp)inp.placeholder='📷 Rückfragen zum Foto stellen…';
-        pickerSetTab('chat');
       });
     },
     function(err){btn.disabled=false;btn.textContent='📷 Erneut analysieren';pickerSetPhotoStatus('Fehler: '+err,true);}
@@ -1089,7 +1088,7 @@ function pickerChatOftSearch(q,onDone){
         var nm=p.nutriments||{};
         var name=(p.product_name_de||p.product_name||'').trim();
         if(!name||name.length<3)return;
-        var kcal=nm['energy-kcal_100g']||0;
+        var kcal=nm['energy-kcal_100g']||Math.round((nm['energy_100g']||0)/4.184);
         if(kcal<=0||kcal>950)return;
         results.push({name:name,emoji:emo(name),per100:{kcal:kcal,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0}});
       });

--- a/picker.js
+++ b/picker.js
@@ -239,8 +239,6 @@ function pickerResetPhoto(){
   document.getElementById('pickerRecipeName').value='';
   document.getElementById('pickerChatRecipeName').value='';
   pickerIngredients=[];
-  var inp=document.getElementById('pickerChatInp');
-  if(inp)inp.placeholder='Was hast du gegessen?';
 }
 
 function pickerTryBarcode(canvas){
@@ -952,12 +950,6 @@ function pickerAnalyze(){
       btn.disabled=false;btn.textContent='📷 Erneut analysieren';
       if(!parsed.zutaten.length){
         pickerSetPhotoStatus(text.length?'KI: '+text.slice(0,120):'Kein Lebensmittel erkannt.',true);
-        // Ins Chat wechseln damit User das Foto erklären kann (#80)
-        var msgs=document.getElementById('pickerChatMsgs');
-        msgs.innerHTML='<div class="cm a">📷 Ich konnte keine klaren Zutaten erkennen. Beschreibe bitte was auf dem Bild zu sehen ist, dann helfe ich weiter.</div>';
-        var inp=document.getElementById('pickerChatInp');
-        if(inp)inp.placeholder='📷 Was ist auf dem Foto?';
-        pickerSetTab('chat');
         return;
       }
       if(parsed.rezept){
@@ -969,12 +961,6 @@ function pickerAnalyze(){
         pickerIngredients=resolved;
         pickerShowPhotoResult(parsed.rezept);
         pickerSetPhotoStatus('',false);
-        // Foto-Kontext für spätere Chat-Rückfragen bereitstellen (#80)
-        var names=resolved.slice(0,4).map(function(z){return z.name;}).join(', ')+(resolved.length>4?' u.a.':'');
-        var msgs=document.getElementById('pickerChatMsgs');
-        msgs.innerHTML='<div class="cm a">📷 '+resolved.length+' Zutaten erkannt: '+names+'. Rückfragen? Wechsle in den 💬 Chat-Tab.</div>';
-        var inp=document.getElementById('pickerChatInp');
-        if(inp)inp.placeholder='📷 Rückfragen zum Foto stellen…';
       });
     },
     function(err){btn.disabled=false;btn.textContent='📷 Erneut analysieren';pickerSetPhotoStatus('Fehler: '+err,true);}

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.165';
+var VERSION = '0.166';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.164';
+var VERSION = '0.165';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary

- **OFT kJ-Fallback (v0.165):** Viele europäische Produkte in Open Food Facts speichern Energie nur in kJ (`energy_100g`), nicht in `energy-kcal_100g`. Der Filter hat diese Produkte komplett rausgefiltert. Fix: `energy_100g / 4.184` als Fallback — betrifft Chat-OFT-Suche, Suche-Tab und `lookupNutrients` in index.html.
- **Foto-Tab entkoppelt (v0.166):** Automatischer Chat-Wechsel, Chat-Vorbelegung und Placeholder-Override nach Foto-Analyse vollständig entfernt. Foto-Tab bleibt nach Analyse aktiv.

## Test plan

- [ ] „Dean & David Red Thai Curry" im Chat-Tab eingeben → OFT-Karte erscheint (oder KI-Fallback bei fehlendem Produkt)
- [ ] Foto aufnehmen → Analyse starten → Picker bleibt im Foto-Tab, Zutaten sichtbar
- [ ] Foto ohne erkennbare Zutaten → Fehlermeldung im Foto-Tab, kein Chat-Wechsel

https://claude.ai/code/session_01E6BCjmNtYM4CpDcj35wGhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6BCjmNtYM4CpDcj35wGhe)_