### PR TITLE
v0.171: iOS Header-Fix (BLOOM-Override) + OFT Marken-Fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@ body{font-family:var(--fs-body);background:var(--bg);color:var(--tx);letter-spac
 button,input,select,textarea{font-family:var(--fs-body);}
 
 /* HEADER ─ "Hej Hannes" headline */
-.hdr{background:var(--bg);padding:18px 18px 8px;border-bottom:none;}
+.hdr{background:var(--bg);padding:calc(18px + env(safe-area-inset-top, 0px)) 18px 8px;border-bottom:none;}
 .logo{font-family:var(--fs-display);font-weight:500;font-size:26px;color:var(--tx);letter-spacing:-0.03em;line-height:1.1;}
 .logo em{color:var(--g1);font-style:italic;font-weight:400;}
 .hbtn{background:var(--gl)!important;border:none!important;border-radius:50%!important;width:38px!important;height:38px!important;display:inline-flex;align-items:center;justify-content:center;font-size:16px!important;color:var(--tx)!important;}
@@ -970,7 +970,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.170</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.171</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1911,7 +1911,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.170';
+var APP_VERSION='0.171';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1940,6 +1940,10 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.171',items:[
+    {icon:'🔧',text:'iOS: Screen-Header jetzt korrekt unterhalb der Status-Bar (der BLOOM-Override hatte den Safe-Area-Fix überschrieben). (#104)',where:'iOS · Layout'},
+    {icon:'🔍',text:'Picker Chat: Bei Marke + Produkt (z.B. „Dean David Red Thai Curry") wird zusätzlich nach dem Gericht ohne Markenname gesucht — mehr Treffer bei Markenprodukten.',where:'Picker · Chat-Tab'},
+  ]},
   {v:'0.170',items:[
     {icon:'🔍',text:'Suche: Produkte ohne Energy-Felder (z. B. Curry, Dean & David) werden jetzt gefunden — kcal wird aus Protein/Kohlenhydrate/Fett berechnet wenn keine Energieangabe vorhanden. Chat-Suche prüft jetzt 10 statt 6 OFT-Ergebnisse. (#96 #101)',where:'Picker · Suche & Chat'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -1065,22 +1065,32 @@ function pickerPhotoAdd(saveAsRecipe){_pickerAdd('📸','pickerRecipeName','pick
 
 function pickerChatOftSearch(q,onDone){
   var proxy='https://corsproxy.io/?';
-  var url='https://world.openfoodfacts.org/cgi/search.pl?search_simple=1&action=process&json=1&page_size=10&fields=product_name,product_name_de,nutriments&search_terms='+encodeURIComponent(q);
-  fetch(proxy+encodeURIComponent(url))
-    .then(function(r){return r.json();})
-    .then(function(data){
-      var results=[];
+  var base='https://world.openfoodfacts.org/cgi/search.pl?search_simple=1&action=process&json=1&page_size=10&fields=product_name,product_name_de,nutriments';
+  var words=q.trim().split(/\s+/);
+  // Bei langen Anfragen (Marke + Gericht) auch ohne die ersten 2 Wörter suchen
+  // z.B. "Dean David Red Thai Curry" → zusätzlich "Red Thai Curry"
+  var terms=[q];
+  if(words.length>=4)terms.push(words.slice(2).join(' '));
+  var fetches=terms.map(function(t){
+    return fetch(proxy+encodeURIComponent(base+'&search_terms='+encodeURIComponent(t)))
+      .then(function(r){return r.json();}).catch(function(){return{products:[]};});
+  });
+  Promise.all(fetches).then(function(responses){
+    var seen={};
+    var results=[];
+    responses.forEach(function(data){
       (data.products||[]).forEach(function(p){
         var nm=p.nutriments||{};
         var name=(p.product_name_de||p.product_name||'').trim();
         if(!name||name.length<3)return;
         var kcal=nm['energy-kcal_100g']||Math.round((nm['energy_100g']||0)/4.184)||Math.round((nm['proteins_100g']||0)*4+(nm['carbohydrates_100g']||0)*4+(nm['fat_100g']||0)*9);
         if(kcal<=0||kcal>950)return;
+        var k=name.toLowerCase();if(seen[k])return;seen[k]=true;
         results.push({name:name,emoji:emo(name),per100:{kcal:kcal,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0}});
       });
-      onDone(results.slice(0,3));
-    })
-    .catch(function(){onDone([]);});
+    });
+    onDone(results.slice(0,3));
+  }).catch(function(){onDone([]);});
 }
 
 function pickerChatAddOft(i){

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.170';
+var VERSION = '0.171';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary

- **iOS Header (#104 Nachfix):** Die BLOOM-Redesign-Override-Regel `.hdr{padding:18px 18px 8px}` überschrieb den Safe-Area-Fix aus v0.168. Fix: `calc(18px + env(safe-area-inset-top, 0px))` im Override.
- **Picker Chat – Markenprodukte:** Bei Eingaben mit ≥4 Wörtern (z.B. „Dean David Red Thai Curry") sucht OFT jetzt parallel auch mit den Wörtern ab Position 2 weiter („Red Thai Curry") — findet Gerichte unabhängig vom vorangestellten Markennamen.

## Test plan

- [ ] iOS PWA: Header auf allen Screens korrekt unterhalb Dynamic Island / Status-Bar
- [ ] Picker Chat: „Dean David Red Thai Curry" eingeben → OFT-Karte erscheint

https://claude.ai/code/session_01Hso2quN8LjRj2SKXcrnh1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hso2quN8LjRj2SKXcrnh1e)_