### PR TITLE
worker: ALLOWED_ORIGINS um https://nutritrack.hjolmes.org erweitern

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,7 +4,7 @@ compatibility_date = "2026-04-27"
 
 [vars]
 ANTHROPIC_VERSION = "2023-06-01"
-ALLOWED_ORIGINS = "https://hjolmes.github.io,http://localhost:8000,http://127.0.0.1:8000,http://localhost:8787,http://127.0.0.1:8787"
+ALLOWED_ORIGINS = "https://hjolmes.github.io,https://nutritrack.hjolmes.org,http://localhost:8000,http://127.0.0.1:8000,http://localhost:8787,http://127.0.0.1:8787"
 # When "true", a failed OSS-decode falls back to Claude Vision (costs money).
 # Default off so the OSS-Decoder is the only server path.
 ENABLE_VISION_FALLBACK = "false"


### PR DESCRIPTION
## Summary

- Self-Hosted-Variante der PWA läuft jetzt zusätzlich unter `https://nutritrack.hjolmes.org/nutritrack/` (Cloudflare Tunnel → lokaler Caddy auf Hetzner)
- Damit der AI-Proxy (Bilderkennung, Vision-Fallback, Share-Shortener) auch CORS-mäßig die neue Origin akzeptiert, muss `https://nutritrack.hjolmes.org` in `ALLOWED_ORIGINS` gelistet sein
- Keine deployten App-Dateien (`index.html` / `sw.js` / `manifest.json`) geändert → kein Versions-Bump nötig (CHANGELOG/About-Dialog bleiben still)

## Test plan

- [ ] Merge → GitHub-Action "Deploy Cloudflare Worker" läuft grün
- [ ] Worker antwortet auf `OPTIONS`-Preflight von `https://nutritrack.hjolmes.org` mit `Access-Control-Allow-Origin` korrekt
- [ ] Bestehende Origin `https://hjolmes.github.io` funktioniert weiter (Regression-Check für Live-Nutzer)