### PR TITLE
v0.175: Picker Chat lokal-first + Ing-Delete rendert neu (#112 #113)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.170 (2026-05-06)
+**Stand:** v0.175 (2026-05-17)
 
 ## URLs
 
@@ -25,11 +25,12 @@
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
-- **Picker Chat (v0.163/v0.164/v0.165/v0.166):** Foto-Tab und Chat-Tab sind vollständig entkoppelt — kein Auto-Wechsel, keine Chat-Vorbelegung nach Foto-Analyse. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto bleibt es bei `claude-haiku-4-5`. Chat-Tab sucht zuerst in OpenFoodFacts (`pickerChatOftSearch` → corsproxy → `cgi/search.pl`); Treffer erscheinen als wählbare Karten (`pickerChatAddOft(i)`); kein Treffer → KI-Fallback via `pickerChatKiFallback(msg)`; „🤖 Stattdessen KI fragen"-Link überspringt OFT. OFT-Filter akzeptiert Einträge mit Energie nur in kJ (`energy_100g` / 4.184 als Fallback) — betrifft `pickerChatOftSearch`, `pickerFetchOnline` und `lookupNutrients`.
+- **Picker Chat (v0.175):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto `claude-haiku-4-5`. Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (intern `searchLocal`, max 6 Treffer: Rezepte, Custom Foods, Cache, DB) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus (Trefferquote zu schlecht). Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`.
 - **Layout-Fixes (v0.167):** bnav `margin:0 14px` → `margin:0 0` (horizontale Margins verursachten 14 px Rechtsversatz bei `position:fixed`+`left:50%`+`translateX(-50%)`). iOS PWA: `focusout`-Handler setzt `window.scrollTo(0,0)` nach Tastatur-Dismiss (nur `_isIos()&&_isPwaStandalone()`).
 - **iOS Safe-Area-Top (v0.168):** `.hdr` und `#mealDetailScreen .md-head` erhalten `padding-top: calc(…px + env(safe-area-inset-top, 0px))` — Screen-Header-Buttons auf allen Screens unterhalb der iOS Status-Bar / Dynamic Island (#104).
 - **Trends (v0.169):** `renderWeekBars()` schließt heutigen Tag aus avg/cnt aus. `requestWeekReport()` erkennt Zielrichtung (lose/gain/maintain) aus `S.goalWeight vs S.weight`, übergibt sie an den Prompt, Format auf Stichpunkte + Empfehlung für nächste Woche, Token-Limit 200→400 (#102 #103).
-- **Picker OFT (v0.170):** kcal-Fallback `P*4+K*4+F*9` in `pickerChatOftSearch`, `pickerFetchOnline` und `lookupNutrients` wenn beide Energy-Felder fehlen. Chat-Tab `page_size` 6→10 (#96 #101).
+- **Picker Ing-Delete (v0.175):** `pickerRenderIngList`-Callbacks rendern nach `splice` neu (Helper `_pickerChatRebind` im Chat, lokale `rebindLink`-Closure im Link-Tab). Photo-Tab war via `pickerShowPhotoResult` schon ok. Vorher blieben gelöschte DOM-Zeilen sichtbar (#112).
+- **Picker OFT (v0.170):** kcal-Fallback `P*4+K*4+F*9` in `pickerFetchOnline` und `lookupNutrients` wenn beide Energy-Felder fehlen (#96 #101). OFT im Chat-Tab seit v0.175 nicht mehr genutzt.
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
 ## Worker-Endpoints
@@ -70,16 +71,18 @@
 - v0.168 iOS: mealDetailScreen und alle anderen Screens — Buttons im Header tippbar trotz Dynamic Island / Status-Bar (#104)
 - v0.169 Trends: Kcal-Durchschnitt ohne heutigen Tag; KI-Bericht mit Stichpunkten + Zielrichtung + Empfehlung (#102 #103)
 - v0.170 Picker Chat: Curry / Dean & David → OFT findet mehr Produkte dank kcal-Macro-Fallback (#96 #101)
+- v0.175 Picker Chat: „Joghurt mit Müsli" (eigenes Rezept) tippen → erscheint als Lokal-Treffer-Karte; ＋ trägt das Rezept direkt in die Mahlzeit ein. Unbekanntes Lebensmittel → KI-Fallback springt ein (#113)
+- v0.175 Picker (Chat + Link): Zutat aus erkannter Liste löschen → DOM-Zeile verschwindet sofort (#112)
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.166 | — | Foto-Tab vollständig entkoppelt vom Chat (#80) |
-| v0.167 | #100 | bnav-Zentrierung (Android) + iOS Keyboard-Scroll-Reset (#97 #98 #99) |
-| v0.168 | — | iOS safe-area-inset-top für Screen-Header (#104) |
-| v0.169 | — | Trends: Heute aus Avg, KI-Bericht zielgerecht (#102 #103) |
-| v0.170 | — | Picker OFT: kcal-Macro-Fallback, page_size 6→10 (#96 #101) |
+| v0.171 | — | iOS Header-Fix (BLOOM-Override) + OFT Marken-Fallback |
+| v0.172 | — | Picker: Hinzufügen-Button sticky am unteren Rand (Android) |
+| v0.173 | — | Share-Import-Anleitung für alle Browser (Edge, Firefox, Samsung Internet) |
+| v0.174 | #110 | OneDrive-Redirect dynamisch via location.origin |
+| v0.175 | — | Picker Chat: Lokal-First statt OFT + Ing-Delete rendert neu (#112 #113) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -973,7 +973,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.174</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.175</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1913,7 +1913,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.174';
+var APP_VERSION='0.175';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1942,6 +1942,10 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.175',items:[
+    {icon:'🔍',text:'Picker Chat: Sucht jetzt zuerst in deinen eigenen Lebensmitteln, Rezepten und früher getrackten Sachen — Treffer erscheinen als wählbare Karten. Erst wenn nichts gefunden wird, fragt die KI. (#113)',where:'Picker · Chat-Tab'},
+    {icon:'🐛',text:'Picker: Gelöschte Zutaten verschwinden jetzt sofort aus der Liste (vorher blieben die DOM-Zeilen sichtbar bis zum nächsten Render). (#112)',where:'Picker · Zutaten-Liste'},
+  ]},
   {v:'0.173',items:[
     {icon:'📲',text:'Share-Import: „In App öffnen"-Anleitung erscheint jetzt auf allen Browsern (Edge, Firefox, Samsung Internet …) — nicht mehr nur auf iOS Safari. Link wird automatisch in die Zwischenablage kopiert.',where:'Import · Alle Browser'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -1063,55 +1063,49 @@ function pickerPhotoAdd(saveAsRecipe){_pickerAdd('📸','pickerRecipeName','pick
 
 // ─── PICKER: CHAT TAB ───
 
-function pickerChatOftSearch(q,onDone){
-  var proxy='https://corsproxy.io/?';
-  var base='https://world.openfoodfacts.org/cgi/search.pl?search_simple=1&action=process&json=1&page_size=10&fields=product_name,product_name_de,nutriments';
-  var words=q.trim().split(/\s+/);
-  // Bei langen Anfragen (Marke + Gericht) auch ohne die ersten 2 Wörter suchen
-  // z.B. "Dean David Red Thai Curry" → zusätzlich "Red Thai Curry"
-  var terms=[q];
-  if(words.length>=4)terms.push(words.slice(2).join(' '));
-  var fetches=terms.map(function(t){
-    return fetch(proxy+encodeURIComponent(base+'&search_terms='+encodeURIComponent(t)))
-      .then(function(r){return r.json();}).catch(function(){return{products:[]};});
-  });
-  Promise.all(fetches).then(function(responses){
-    var seen={};
-    var results=[];
-    responses.forEach(function(data){
-      (data.products||[]).forEach(function(p){
-        var nm=p.nutriments||{};
-        var name=(p.product_name_de||p.product_name||'').trim();
-        if(!name||name.length<3)return;
-        var kcal=nm['energy-kcal_100g']||Math.round((nm['energy_100g']||0)/4.184)||Math.round((nm['proteins_100g']||0)*4+(nm['carbohydrates_100g']||0)*4+(nm['fat_100g']||0)*9);
-        if(kcal<=0||kcal>950)return;
-        var k=name.toLowerCase();if(seen[k])return;seen[k]=true;
-        results.push({name:name,emoji:emo(name),per100:{kcal:kcal,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0}});
-      });
-    });
-    onDone(results.slice(0,3));
-  }).catch(function(){onDone([]);});
+// Bind ingredient list to pickerIngredients with a delete that re-renders the DOM (#112).
+function _pickerChatRebind(){
+  pickerRenderIngList('pickerChatIngList',pickerIngredients,
+    function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateChatTotal();},
+    function(i){pickerIngredients.splice(i,1);_pickerChatRebind();pickerUpdateChatTotal();}
+  );
 }
 
-function pickerChatAddOft(i){
-  var p=(window._pickerOftResults||[])[i];if(!p)return;
+// Suche im lokalen Bestand: Rezepte, Custom Foods, Cache, DB (#113).
+function pickerChatLocalSearch(q){
+  var hits=searchLocal(q);
+  // OFT-Suche entfernt — Chat nutzt lokalen Bestand und fällt direkt auf KI zurück.
+  return hits.slice(0,6);
+}
+
+function pickerChatAddLocal(i){
+  var p=(window._pickerLocalResults||[])[i];if(!p)return;
+  var cards=document.getElementById('pickerLocalCards');if(cards)cards.remove();
+  var msgs=document.getElementById('pickerChatMsgs');
+  if(p.isRecipe){
+    // Rezept als Ganzes in die Mahlzeit übernehmen (analog pickerAddRecent).
+    var rec=recipes.find(function(r){return r.id===p.recipeId;});
+    if(!rec){msgs.innerHTML+='<div class="cm a">❌ Rezept nicht mehr vorhanden.</div>';return;}
+    var t=ingTotal(rec.ingredients||[]);
+    var portions=rec.portions||1;
+    getDay().meals[pickerMeal].push(Object.assign({name:rec.name,emoji:rec.emoji||'📋',isRecipe:true,recipeId:rec.id,portions:portions,ingredients:rec.ingredients||[]},scaleNutrients(t,portions)));
+    saveS();renderAll();closePicker();
+    showToast('📋 '+rec.name+' eingetragen');
+    return;
+  }
   pickerIngredients=[{name:p.name,emoji:p.emoji,g:100,amount:100,per100:p.per100}];
   if(!document.getElementById('pickerChatRecipeName').value)
     document.getElementById('pickerChatRecipeName').value=p.name.slice(0,50);
-  var oft=document.getElementById('pickerOftCards');if(oft)oft.remove();
-  var msgs=document.getElementById('pickerChatMsgs');
-  msgs.innerHTML+='<div class="cm a">✓ '+p.name+' aus OpenFoodFacts übernommen.</div>';
-  pickerRenderIngList('pickerChatIngList',pickerIngredients,
-    function(idx,v){pickerIngredients[idx].amount=parseFloat(v)||0;pickerUpdateChatTotal();},
-    function(idx){pickerIngredients.splice(idx,1);pickerUpdateChatTotal();}
-  );
+  msgs.innerHTML+='<div class="cm a">✓ '+p.name+' übernommen.</div>';
+  _pickerChatRebind();
   pickerUpdateChatTotal();
   document.getElementById('pickerChatResult').classList.remove('hidden');
 }
 
 function pickerChatKiFallback(msg){
   var msgs=document.getElementById('pickerChatMsgs');
-  var oft=document.getElementById('pickerOftCards');if(oft)oft.remove();
+  var cards=document.getElementById('pickerLocalCards');if(cards)cards.remove();
+  if(!isOnline){msgs.innerHTML+='<div class="cm a">📵 KI benötigt eine Internet-Verbindung.</div>';document.getElementById('pickerChatSend').disabled=false;return;}
   msgs.innerHTML+='<div class="cm a">🤖 KI schätzt Nährwerte...</div>';
   msgs.scrollTop=msgs.scrollHeight;
   document.getElementById('pickerChatSend').disabled=true;
@@ -1130,10 +1124,7 @@ function pickerChatKiFallback(msg){
         pickerIngredients=resolved;
         if(!document.getElementById('pickerChatRecipeName').value)
           document.getElementById('pickerChatRecipeName').value=msg.slice(0,50);
-        pickerRenderIngList('pickerChatIngList',pickerIngredients,
-          function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateChatTotal();},
-          function(i){pickerIngredients.splice(i,1);pickerUpdateChatTotal();pickerRenderIngList('pickerChatIngList',pickerIngredients,function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateChatTotal();},function(i){pickerIngredients.splice(i,1);pickerUpdateChatTotal();});}
-        );
+        _pickerChatRebind();
         pickerUpdateChatTotal();
         document.getElementById('pickerChatResult').classList.remove('hidden');
         document.getElementById('pickerChatSend').disabled=false;
@@ -1145,7 +1136,6 @@ function pickerChatKiFallback(msg){
 
 function pickerSendChat(){
   var msg=document.getElementById('pickerChatInp').value.trim();if(!msg)return;
-  if(!isOnline){showToast('Internet benötigt');return;}
   var msgs=document.getElementById('pickerChatMsgs');
   msgs.innerHTML+='<div class="cm u">'+msg+'</div>';
   document.getElementById('pickerChatInp').value='';
@@ -1153,32 +1143,30 @@ function pickerSendChat(){
   document.getElementById('pickerChatResult').classList.add('hidden');
   msgs.scrollTop=msgs.scrollHeight;
   window._pickerChatLastMsg=msg;
-  // OFT-Suche zuerst — Markenprodukte direkt aus OpenFoodFacts (#79)
-  msgs.innerHTML+='<div class="cm a" id="pickerChatThinking">🔍 Suche in OpenFoodFacts...</div>';
-  pickerChatOftSearch(msg,function(results){
-    var thinking=document.getElementById('pickerChatThinking');
-    if(thinking)thinking.remove();
-    if(results.length){
-      window._pickerOftResults=results;
-      var html='<div id="pickerOftCards" style="display:flex;flex-direction:column;gap:6px;margin-top:4px;">';
-      html+='<div class="cm a">🌐 '+results.length+' Treffer in OpenFoodFacts:</div>';
-      results.forEach(function(p,i){
-        var vals=Math.round(p.per100.kcal)+' kcal · P'+p.per100.protein.toFixed(1)+'g · K'+p.per100.carbs.toFixed(1)+'g · F'+p.per100.fat.toFixed(1)+'g /100g';
-        html+='<div style="background:var(--gl);border:1px solid var(--br);border-radius:10px;padding:8px 10px;display:flex;align-items:center;gap:8px;">'
-          +'<div style="flex:1;min-width:0;"><div style="font-weight:600;font-size:13px;">'+p.emoji+' '+p.name+'</div>'
-          +'<div style="font-size:11px;color:var(--mu);">'+vals+'</div></div>'
-          +'<button type="button" onclick="pickerChatAddOft('+i+')" style="background:var(--g1);color:#fff;border:none;border-radius:8px;padding:5px 10px;font-size:14px;font-weight:700;cursor:pointer;flex-shrink:0;">＋</button>'
-          +'</div>';
-      });
-      html+='<div style="text-align:center;padding-top:2px;"><button type="button" onclick="pickerChatKiFallback(window._pickerChatLastMsg)" style="background:none;border:none;color:var(--mu);font-size:12px;cursor:pointer;padding:4px 8px;text-decoration:underline;">🤖 Stattdessen KI fragen</button></div>';
-      html+='</div>';
-      msgs.innerHTML+=html;
-      msgs.scrollTop=msgs.scrollHeight;
-      document.getElementById('pickerChatSend').disabled=false;
-    } else {
-      pickerChatKiFallback(msg);
-    }
-  });
+  // Lokale Suche zuerst (#113): Rezepte, Custom Foods, Cache, DB. KI nur als Fallback.
+  var results=pickerChatLocalSearch(msg);
+  if(results.length){
+    window._pickerLocalResults=results;
+    var html='<div id="pickerLocalCards" style="display:flex;flex-direction:column;gap:6px;margin-top:4px;">';
+    html+='<div class="cm a">📚 '+results.length+' Treffer in deinem Bestand:</div>';
+    results.forEach(function(p,i){
+      var sub=p.isRecipe?'Rezept':(p.per100?Math.round(p.per100.kcal)+' kcal · P'+(p.per100.protein||0).toFixed(1)+'g · K'+(p.per100.carbs||0).toFixed(1)+'g · F'+(p.per100.fat||0).toFixed(1)+'g /100g':'');
+      var badge=p.badge||'';
+      html+='<div style="background:var(--gl);border:1px solid var(--br);border-radius:10px;padding:8px 10px;display:flex;align-items:center;gap:8px;">'
+        +'<div style="flex:1;min-width:0;"><div style="font-weight:600;font-size:13px;">'+(p.emoji||'🍽')+' '+p.name+(badge?' <span style="font-size:11px;color:var(--mu);">'+badge+'</span>':'')+'</div>'
+        +(sub?'<div style="font-size:11px;color:var(--mu);">'+sub+'</div>':'')+'</div>'
+        +'<button type="button" onclick="pickerChatAddLocal('+i+')" style="background:var(--g1);color:#fff;border:none;border-radius:8px;padding:5px 10px;font-size:14px;font-weight:700;cursor:pointer;flex-shrink:0;">＋</button>'
+        +'</div>';
+    });
+    html+='<div style="text-align:center;padding-top:2px;"><button type="button" onclick="pickerChatKiFallback(window._pickerChatLastMsg)" style="background:none;border:none;color:var(--mu);font-size:12px;cursor:pointer;padding:4px 8px;text-decoration:underline;">🤖 Stattdessen KI fragen</button></div>';
+    html+='</div>';
+    msgs.innerHTML+=html;
+    msgs.scrollTop=msgs.scrollHeight;
+    document.getElementById('pickerChatSend').disabled=false;
+    return;
+  }
+  if(!isOnline){msgs.innerHTML+='<div class="cm a">📵 Offline und nichts im Bestand gefunden. Verbinde dich oder lege es als „Eigenes Lebensmittel" an.</div>';document.getElementById('pickerChatSend').disabled=false;return;}
+  pickerChatKiFallback(msg);
 }
 
 function pickerUpdateChatTotal(){pickerUpdateTotal('Chat');}
@@ -1235,10 +1223,13 @@ function pickerLinkImport(){
             lookupNutrients(rawItems,function(ings){
               pickerIngredients=ings;
               document.getElementById('pickerLinkRecipeName').value=d.name;
-              pickerRenderIngList('pickerLinkIngList',pickerIngredients,
-                function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateLinkTotal();},
-                function(i){pickerIngredients.splice(i,1);pickerUpdateLinkTotal();}
-              );
+              function rebindLink(){
+                pickerRenderIngList('pickerLinkIngList',pickerIngredients,
+                  function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateLinkTotal();},
+                  function(i){pickerIngredients.splice(i,1);rebindLink();pickerUpdateLinkTotal();}
+                );
+              }
+              rebindLink();
               pickerUpdateLinkTotal();
               document.getElementById('pickerLinkResult').classList.remove('hidden');
               btn.disabled=false;btn.textContent='🔗 Neu laden';btn.style.opacity='1';

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.174';
+var VERSION = '0.175';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary

- Picker Chat: lokal-first statt OFT — sucht zuerst in Rezepten, Custom Foods, Cache und DB via `searchLocal()`. Treffer als wählbare Karten; Rezepte landen direkt in der Mahlzeit, per100-Treffer in `pickerIngredients`. KI-Fallback nur bei 0 Treffern oder explizitem Klick. (#113)
- Picker: gelöschte Zutaten verschwinden jetzt sofort — `pickerRenderIngList`-Callbacks rendern nach `splice` neu (Helper `_pickerChatRebind` im Chat-Tab, `rebindLink`-Closure im Link-Tab). Photo-Pfad war schon ok. (#112)
- OFT-Anbindung im Chat entfernt (`pickerChatOftSearch`/`pickerChatAddOft`) — Trefferquote zu schlecht, lokale Suche + KI-Fallback ist robuster.
- Lokale Suche funktioniert offline; KI-Fallback fängt `!isOnline` ab.

## Test plan

- [ ] Chat-Tab: „Joghurt mit Müsli" (eigenes Rezept) → erscheint als Lokal-Treffer → ＋ trägt Rezept direkt in die Mahlzeit ein, Picker schließt
- [ ] Chat-Tab: per100-Treffer (z. B. eigenes Custom-Food) → ＋ setzt die Zutat, Zutaten-Liste wird angezeigt
- [ ] Chat-Tab: unbekannter Begriff → KI-Fallback springt an
- [ ] Chat-Tab offline + unbekannt → hinweis „📵 KI benötigt eine Internet-Verbindung"
- [ ] Chat-Tab nach KI-Fallback: mehrere Zutaten erkennen lassen, mehrere nacheinander löschen → DOM-Zeilen verschwinden jedes Mal
- [ ] Link-Tab: Rezept importieren, Zutat löschen → DOM-Zeile verschwindet

Closes #112
Closes #113

---
_Generated by [Claude Code](https://claude.ai/code/session_01U73poj3nKH68L7dE7FNpwM)_