### PR TITLE
v0.177: Picker Chat — nur eigene Sachen, alle Tokens müssen treffen

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.176 (2026-05-17)
+**Stand:** v0.177 (2026-05-17)
 
 ## URLs
 
@@ -25,8 +25,8 @@
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
-- **Picker Chat (v0.175/v0.176):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto `claude-haiku-4-5`. Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (eigene tokenisierte Fuzzy-Suche über Rezepte, Custom Foods, Cache, DB; max 6 Treffer) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus. Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`.
-- **Picker Chat Fuzzy-Suche (v0.176):** `_pickerFold` (ä→a, ö→o, ü→u, ß→s) + `_pickerTok` (Stoppwörter: mit/und/von/der/die/das/im/in/zum/zur/an/am/auf/bei/zu/…) + `_pickerLev` (Levenshtein) + `_pickerScoreName` (Score-Mix: qFull-Substring +10, Token === +5, startsWith +4, includes +3, Levenshtein ≤1 (kurz) bzw. ≤2 (lang) +1–2). `pickerChatLocalSearch` bevorzugt Rezepte (+10) vor Custom Foods (+6) vor Cache (+3) vor DB (+0). Min-Score 2 bei Einzelwort, 1 bei Multi-Wort — filtert zufällige Levenshtein-Treffer aus.
+- **Picker Chat (v0.175–v0.177):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto `claude-haiku-4-5`. Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (tokenisierte Fuzzy-Suche **nur** über Rezepte + Custom Foods, max 6 Treffer) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus. Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`.
+- **Picker Chat Fuzzy-Suche (v0.176/v0.177):** `_pickerFold` (ä→a, ö→o, ü→u, ß→s) + `_pickerTok` (Stoppwörter: mit/und/von/der/die/das/im/in/zum/zur/an/am/auf/bei/zu/…) + `_pickerLev` (Levenshtein) + `_pickerScoreName`. **Alle** Query-Tokens müssen treffen (sonst Score 0) — kein „Joghurt Natur"-Treffer mehr für „Joghurt mit Früchten". Pro-Token-Score: === +5, startsWith +4, includes +3, Levenshtein ≤1 (kurz) bzw. ≤2 (lang) +1–2. Voller-Query-Substring zusätzlich +10. Rezepte werden um +10 geboostet vor Custom Foods (+6). Cache und eingebaute DB werden im Chat-Tab nicht durchsucht.
 - **Layout-Fixes (v0.167):** bnav `margin:0 14px` → `margin:0 0` (horizontale Margins verursachten 14 px Rechtsversatz bei `position:fixed`+`left:50%`+`translateX(-50%)`). iOS PWA: `focusout`-Handler setzt `window.scrollTo(0,0)` nach Tastatur-Dismiss (nur `_isIos()&&_isPwaStandalone()`).
 - **iOS Safe-Area-Top (v0.168):** `.hdr` und `#mealDetailScreen .md-head` erhalten `padding-top: calc(…px + env(safe-area-inset-top, 0px))` — Screen-Header-Buttons auf allen Screens unterhalb der iOS Status-Bar / Dynamic Island (#104).
 - **Trends (v0.169):** `renderWeekBars()` schließt heutigen Tag aus avg/cnt aus. `requestWeekReport()` erkennt Zielrichtung (lose/gain/maintain) aus `S.goalWeight vs S.weight`, übergibt sie an den Prompt, Format auf Stichpunkte + Empfehlung für nächste Woche, Token-Limit 200→400 (#102 #103).
@@ -75,16 +75,17 @@
 - v0.175 Picker Chat: „Joghurt mit Müsli" (eigenes Rezept) tippen → erscheint als Lokal-Treffer-Karte; ＋ trägt das Rezept direkt in die Mahlzeit ein. Unbekanntes Lebensmittel → KI-Fallback springt ein (#113)
 - v0.175 Picker (Chat + Link): Zutat aus erkannter Liste löschen → DOM-Zeile verschwindet sofort (#112)
 - v0.176 Picker Chat Fuzzy: „Jogurt mit Frucht" findet „Joghurt mit Früchten und Müsli"; „hänchen" findet „Hähnchenbrust"; Teil-Phrasen werden Wort-für-Wort gewichtet
+- v0.177 Picker Chat: Suche nur in Rezepten + Custom Foods, Alle-Tokens-müssen-treffen → „Joghurt mit Früchten" liefert kein „Joghurt Natur" oder „Früchte gemischt" mehr
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.172 | — | Picker: Hinzufügen-Button sticky am unteren Rand (Android) |
 | v0.173 | — | Share-Import-Anleitung für alle Browser (Edge, Firefox, Samsung Internet) |
 | v0.174 | #110 | OneDrive-Redirect dynamisch via location.origin |
 | v0.175 | #114 | Picker Chat: Lokal-First statt OFT + Ing-Delete rendert neu (#112 #113) |
-| v0.176 | — | Picker Chat: Fuzzy-Suche (Tippfehler + Umlaute + Token-Match) |
+| v0.176 | #115 | Picker Chat: Fuzzy-Suche (Tippfehler + Umlaute + Token-Match) |
+| v0.177 | — | Picker Chat: nur eigene Sachen, alle Tokens müssen treffen |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -973,7 +973,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.176</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.177</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1913,7 +1913,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.176';
+var APP_VERSION='0.177';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1942,6 +1942,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.177',items:[
+    {icon:'🔍',text:'Picker Chat: Suche nur noch in deinen eigenen Rezepten und gespeicherten Lebensmitteln (Cache und eingebaute DB raus). Alle Wörter deiner Eingabe müssen treffen — „Joghurt mit Früchten" liefert kein „Joghurt Natur" oder „Früchte gemischt" mehr.',where:'Picker · Chat-Tab'},
+  ]},
   {v:'0.176',items:[
     {icon:'🔍',text:'Picker Chat: Suche im eigenen Bestand ist jetzt tippfehler- und umlauttolerant. „Jogurt mit Frucht" findet „Joghurt mit Früchten und Müsli", „hänchen" findet „Hähnchenbrust". Teilformulierungen werden Wort-für-Wort gewichtet.',where:'Picker · Chat-Tab'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -1098,12 +1098,13 @@ function _pickerLev(a,b){
 function _pickerScoreName(name,qTokens,qFull){
   var nl=_pickerFold(name);
   if(!nl)return 0;
-  var score=0;
-  if(qFull&&nl.indexOf(qFull)>=0)score+=10;
   var nTokens=_pickerTok(name);
-  if(!nTokens.length)return score;
-  qTokens.forEach(function(qt){
-    var best=0;
+  if(!nTokens.length)return 0;
+  // Alle Query-Tokens müssen treffen — sonst kein sinnvoller Treffer.
+  // (Bei „Joghurt mit Früchten" wäre sonst „Joghurt Natur" ein Treffer.)
+  var score=0;
+  for(var qi=0;qi<qTokens.length;qi++){
+    var qt=qTokens[qi],best=0;
     for(var i=0;i<nTokens.length;i++){
       var nt=nTokens[i];
       if(nt===qt){best=Math.max(best,5);break;}
@@ -1116,8 +1117,10 @@ function _pickerScoreName(name,qTokens,qFull){
       var d=_pickerLev(nt,qt);
       if(d<=allowed)best=Math.max(best,3-Math.min(d,2));
     }
+    if(best===0)return 0;
     score+=best;
-  });
+  }
+  if(qFull&&nl.indexOf(qFull)>=0)score+=10;
   return score;
 }
 function pickerChatLocalSearch(q){
@@ -1131,6 +1134,8 @@ function pickerChatLocalSearch(q){
     if(prev){if(s>prev.score)prev.score=s;return;}
     var rec={score:s,item:item};seen[k]=rec;results.push(rec);
   }
+  // Nur selbst gespeicherte Sachen: Rezepte + Custom Foods.
+  // Cache und eingebaute DB sind ausgeschlossen (nicht „selbst gespeichert").
   recipes.forEach(function(r){
     var s=_pickerScoreName(r.name,qTokens,qFull);
     if(s>0)add({name:r.name,emoji:r.emoji||'📋',isRecipe:true,recipeId:r.id,per100:null,badge:'📋'},s+10);
@@ -1139,19 +1144,6 @@ function pickerChatLocalSearch(q){
     var s=_pickerScoreName(f.name,qTokens,qFull);
     if(s>0)add({name:f.name,emoji:f.emoji,per100:f.per100,badge:'⭐'},s+6);
   });
-  Object.keys(foodCache||{}).forEach(function(k){
-    var f=foodCache[k];if(!f||!f.name)return;
-    var s=_pickerScoreName(f.name,qTokens,qFull);
-    if(s>0)add({name:f.name,emoji:f.emoji,per100:f.per100,badge:'🕐'},s+3);
-  });
-  DB.forEach(function(f){
-    var s=_pickerScoreName(f.n,qTokens,qFull);
-    if(s>0)add({name:f.n,emoji:f.e,per100:{kcal:f.k,protein:f.p,carbs:f.c,fat:f.f,sugar:0,fiber:0,salt:0}},s);
-  });
-  // Mindest-Score-Schwelle: Tippfehler-only-Treffer für Einzel-Wort-Suchen aussortieren
-  // (vermeidet, dass „xy" zufällig per Levenshtein auf alles matcht)
-  var minScore=qTokens.length===1?2:1;
-  results=results.filter(function(r){return r.score>=minScore;});
   results.sort(function(a,b){return b.score-a.score;});
   return results.slice(0,6).map(function(x){return x.item;});
 }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.176';
+var VERSION = '0.177';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Summary

- `pickerChatLocalSearch` durchsucht jetzt nur noch **eigene Rezepte + Custom Foods** — Cache und eingebaute DB raus.
- Score-Logik: **alle** Query-Tokens müssen einen Hit haben, sonst Score 0. Damit liefert „Joghurt mit Früchten" kein „Joghurt Natur" und kein „Früchte gemischt" mehr — nur Treffer, in denen beide Begriffe vorkommen.
- Tippfehler-Toleranz (Levenshtein), Umlaut-Folding (ä→a, ö→o, ü→u, ß→s) und deutsche Stoppwörter (mit/und/von/…) bleiben.
- Der Such-Tab (`searchLocal`) ist unangetastet.

## Test plan

- [ ] `Joghurt mit Früchten` → nur Rezepte/Foods, die beide Wörter enthalten
- [ ] `joghurt` allein → alle Joghurt-Items
- [ ] `Jogurt mit Frucht` (Tippfehler) → trifft das richtige Rezept
- [ ] Item aus Cache / eingebauter DB → kein Treffer mehr im Chat (Karte zeigt „Stattdessen KI fragen")
- [ ] Such-Tab unverändert (Regression-Check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U73poj3nKH68L7dE7FNpwM)_