### PR TITLE
v0.178 + v0.179: Picker Chat Fuzzy strenger + Picker Foto-Save (#117 #118)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.178 (2026-05-21)
+**Stand:** v0.179 (2026-05-21)
 
 ## URLs
 
@@ -32,6 +32,7 @@
 - **Trends (v0.169):** `renderWeekBars()` schließt heutigen Tag aus avg/cnt aus. `requestWeekReport()` erkennt Zielrichtung (lose/gain/maintain) aus `S.goalWeight vs S.weight`, übergibt sie an den Prompt, Format auf Stichpunkte + Empfehlung für nächste Woche, Token-Limit 200→400 (#102 #103).
 - **Picker Ing-Delete (v0.175):** `pickerRenderIngList`-Callbacks rendern nach `splice` neu (Helper `_pickerChatRebind` im Chat, lokale `rebindLink`-Closure im Link-Tab). Photo-Tab war via `pickerShowPhotoResult` schon ok. Vorher blieben gelöschte DOM-Zeilen sichtbar (#112).
 - **Picker OFT (v0.170):** kcal-Fallback `P*4+K*4+F*9` in `pickerFetchOnline` und `lookupNutrients` wenn beide Energy-Felder fehlen (#96 #101). OFT im Chat-Tab seit v0.175 nicht mehr genutzt.
+- **Picker Foto-Save (v0.179):** Settings-Toggle `S.savePickerPhotos` (Default off) unter „🗂 Daten → 📷 Picker-Fotos". Wenn an, ruft `_pickerSavePhotoIfWanted()` in `_pickerAdd` (vor `closePicker()`) auf — versucht zuerst `navigator.share({files:[File]})` (iOS Safari + Android Chrome unterstützen Files seit iOS 15 / Chrome 89), Fallback `<a download>` (Android: nach `Downloads/`; iOS PWA: nicht garantiert). Hinweis-Zeile `#pickerPhotoSaveHint` unter `pickerPrevWrap` zeigt Status und navigiert tippbar zu Einstellungen/Daten. Web-Capture (`<input capture>`) legt das Foto sonst weder auf iOS noch zuverlässig auf Android in die Galerie (#118).
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
 ## Worker-Endpoints
@@ -77,16 +78,17 @@
 - v0.176 Picker Chat Fuzzy: „Jogurt mit Frucht" findet „Joghurt mit Früchten und Müsli"; „hänchen" findet „Hähnchenbrust"; Teil-Phrasen werden Wort-für-Wort gewichtet
 - v0.177 Picker Chat: Suche nur in Rezepten + Custom Foods, Alle-Tokens-müssen-treffen → „Joghurt mit Früchten" liefert kein „Joghurt Natur" oder „Früchte gemischt" mehr
 - v0.178 Picker Chat: „Waffel" findet nicht mehr „Kaffee mit Milch"; „Jogurt" findet weiter „Joghurt"; „Frucht" findet weiter „Früchten" (#117)
+- v0.179 Picker Foto-Save: Toggle in Einstellungen → Daten aktivieren; Foto im Picker aufnehmen + Mahlzeit hinzufügen → System-Share-Sheet (iOS: „In Fotos sichern"; Android: Galerie/Download); Toggle aus → Hinweis-Link unter Foto zeigt Einstellungs-Verweis, kein Save (#118)
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.174 | #110 | OneDrive-Redirect dynamisch via location.origin |
 | v0.175 | #114 | Picker Chat: Lokal-First statt OFT + Ing-Delete rendert neu (#112 #113) |
 | v0.176 | #115 | Picker Chat: Fuzzy-Suche (Tippfehler + Umlaute + Token-Match) |
 | v0.177 | #116 | Picker Chat: nur eigene Sachen, alle Tokens müssen treffen |
 | v0.178 | — | Picker Chat: strengere Fuzzy-Toleranz — kein „Kaffee mit Milch" bei „Waffel" (#117) |
+| v0.179 | — | Picker Foto: optionales Sichern per Share-Sheet, Toggle in Einstellungen (#118) |
 
 ---
 

--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.177 (2026-05-17)
+**Stand:** v0.178 (2026-05-21)
 
 ## URLs
 
@@ -26,7 +26,7 @@
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
 - **Picker Chat (v0.175–v0.177):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto `claude-haiku-4-5`. Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (tokenisierte Fuzzy-Suche **nur** über Rezepte + Custom Foods, max 6 Treffer) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus. Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`.
-- **Picker Chat Fuzzy-Suche (v0.176/v0.177):** `_pickerFold` (ä→a, ö→o, ü→u, ß→s) + `_pickerTok` (Stoppwörter: mit/und/von/der/die/das/im/in/zum/zur/an/am/auf/bei/zu/…) + `_pickerLev` (Levenshtein) + `_pickerScoreName`. **Alle** Query-Tokens müssen treffen (sonst Score 0) — kein „Joghurt Natur"-Treffer mehr für „Joghurt mit Früchten". Pro-Token-Score: === +5, startsWith +4, includes +3, Levenshtein ≤1 (kurz) bzw. ≤2 (lang) +1–2. Voller-Query-Substring zusätzlich +10. Rezepte werden um +10 geboostet vor Custom Foods (+6). Cache und eingebaute DB werden im Chat-Tab nicht durchsucht.
+- **Picker Chat Fuzzy-Suche (v0.176/v0.177/v0.178):** `_pickerFold` (ä→a, ö→o, ü→u, ß→s) + `_pickerTok` (Stoppwörter: mit/und/von/der/die/das/im/in/zum/zur/an/am/auf/bei/zu/…) + `_pickerLev` (Levenshtein) + `_pickerScoreName`. **Alle** Query-Tokens müssen treffen (sonst Score 0) — kein „Joghurt Natur"-Treffer mehr für „Joghurt mit Früchten". Pro-Token-Score: === +5, startsWith +4, includes +3, Levenshtein ≤1 (Länge 5–7) bzw. ≤2 (Länge ≥8) +1–2 — kein Levenshtein unter Länge 5, sonst Distraktoren wie „kaffee"↔„waffel" (#117). Voller-Query-Substring zusätzlich +10. Rezepte werden um +10 geboostet vor Custom Foods (+6). Cache und eingebaute DB werden im Chat-Tab nicht durchsucht.
 - **Layout-Fixes (v0.167):** bnav `margin:0 14px` → `margin:0 0` (horizontale Margins verursachten 14 px Rechtsversatz bei `position:fixed`+`left:50%`+`translateX(-50%)`). iOS PWA: `focusout`-Handler setzt `window.scrollTo(0,0)` nach Tastatur-Dismiss (nur `_isIos()&&_isPwaStandalone()`).
 - **iOS Safe-Area-Top (v0.168):** `.hdr` und `#mealDetailScreen .md-head` erhalten `padding-top: calc(…px + env(safe-area-inset-top, 0px))` — Screen-Header-Buttons auf allen Screens unterhalb der iOS Status-Bar / Dynamic Island (#104).
 - **Trends (v0.169):** `renderWeekBars()` schließt heutigen Tag aus avg/cnt aus. `requestWeekReport()` erkennt Zielrichtung (lose/gain/maintain) aus `S.goalWeight vs S.weight`, übergibt sie an den Prompt, Format auf Stichpunkte + Empfehlung für nächste Woche, Token-Limit 200→400 (#102 #103).
@@ -76,16 +76,17 @@
 - v0.175 Picker (Chat + Link): Zutat aus erkannter Liste löschen → DOM-Zeile verschwindet sofort (#112)
 - v0.176 Picker Chat Fuzzy: „Jogurt mit Frucht" findet „Joghurt mit Früchten und Müsli"; „hänchen" findet „Hähnchenbrust"; Teil-Phrasen werden Wort-für-Wort gewichtet
 - v0.177 Picker Chat: Suche nur in Rezepten + Custom Foods, Alle-Tokens-müssen-treffen → „Joghurt mit Früchten" liefert kein „Joghurt Natur" oder „Früchte gemischt" mehr
+- v0.178 Picker Chat: „Waffel" findet nicht mehr „Kaffee mit Milch"; „Jogurt" findet weiter „Joghurt"; „Frucht" findet weiter „Früchten" (#117)
 
 ## Versions-Historie (letzte 5)
 
 | Version | PR | Was |
 |---|---|---|
-| v0.173 | — | Share-Import-Anleitung für alle Browser (Edge, Firefox, Samsung Internet) |
 | v0.174 | #110 | OneDrive-Redirect dynamisch via location.origin |
 | v0.175 | #114 | Picker Chat: Lokal-First statt OFT + Ing-Delete rendert neu (#112 #113) |
 | v0.176 | #115 | Picker Chat: Fuzzy-Suche (Tippfehler + Umlaute + Token-Match) |
-| v0.177 | — | Picker Chat: nur eigene Sachen, alle Tokens müssen treffen |
+| v0.177 | #116 | Picker Chat: nur eigene Sachen, alle Tokens müssen treffen |
+| v0.178 | — | Picker Chat: strengere Fuzzy-Toleranz — kein „Kaffee mit Milch" bei „Waffel" (#117) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -973,7 +973,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.177</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.178</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1913,7 +1913,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.177';
+var APP_VERSION='0.178';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1942,6 +1942,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.178',items:[
+    {icon:'🐛',text:'Picker Chat: Fuzzy-Suche ist strenger — „Waffel" findet nicht mehr fälschlich „Kaffee mit Milch". Levenshtein-Toleranz für kurze Wörter (bis 7 Zeichen) auf 1 Edit reduziert. (#117)',where:'Picker · Chat-Tab'},
+  ]},
   {v:'0.177',items:[
     {icon:'🔍',text:'Picker Chat: Suche nur noch in deinen eigenen Rezepten und gespeicherten Lebensmitteln (Cache und eingebaute DB raus). Alle Wörter deiner Eingabe müssen treffen — „Joghurt mit Früchten" liefert kein „Joghurt Natur" oder „Früchte gemischt" mehr.',where:'Picker · Chat-Tab'},
   ]},

--- a/index.html
+++ b/index.html
@@ -973,7 +973,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.178</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.179</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1039,6 +1039,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
         <div id="pickerPrevWrap" class="pprev-wrap hidden">
           <img id="pickerPrev"><button type="button" class="pchange" onclick="pickerResetPhoto()">Ändern</button>
         </div>
+        <div id="pickerPhotoSaveHint" class="hidden" onclick="openSettings();setTimeout(function(){settSetTab('daten');},50);" style="font-size:11px;color:var(--mu);margin:6px 4px 0;cursor:pointer;line-height:1.4;"></div>
         <div id="pickerBcConfirm" class="bc-confirm hidden">
           <div class="bc-confirm-name" id="pickerBcName"></div>
           <div class="bc-confirm-vals" id="pickerBcVals"></div>
@@ -1790,6 +1791,20 @@ button,input,select,textarea{font-family:var(--fs-body);}
           <button type="button" class="seb" onclick="openAutoSaves()">📂 Autospeicher anzeigen</button>
         </div>
         <div style="padding-top:12px;border-top:1px solid var(--br);margin-bottom:12px;">
+          <label class="lbl" style="margin-bottom:8px;">📷 Picker-Fotos</label>
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:10px;background:var(--gl);border-radius:10px;border:1px solid var(--g3);">
+            <div style="flex:1;min-width:0;padding-right:10px;">
+              <div style="font-size:13px;font-weight:700;">Foto auf Handy sichern</div>
+              <div style="font-size:11px;color:var(--mu);margin-top:2px;line-height:1.4;">Nach dem Hinzufügen einer Mahlzeit das Foto via Teilen-Menü speichern (z. B. in „Fotos"/Galerie).</div>
+            </div>
+            <label style="position:relative;display:inline-block;width:44px;height:24px;flex:0 0 44px;">
+              <input type="checkbox" id="ssavepickerphotos" style="opacity:0;width:0;height:0;" onchange="updateSavePickerPhotosToggle()">
+              <span id="savePickerPhotosToggle" style="position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#ccc;border-radius:24px;transition:.3s;"></span>
+              <span id="savePickerPhotosThumb" style="position:absolute;height:18px;width:18px;left:3px;bottom:3px;background:white;border-radius:50%;transition:.3s;"></span>
+            </label>
+          </div>
+        </div>
+        <div style="padding-top:12px;border-top:1px solid var(--br);margin-bottom:12px;">
           <label class="lbl" style="margin-bottom:8px;">💾 Datensicherung</label>
           <button type="button" class="seb" onclick="exportData()">📤 Exportieren</button>
           <button type="button" class="seb" onclick="document.getElementById('impInp').click()">📥 Importieren</button>
@@ -1913,7 +1928,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.178';
+var APP_VERSION='0.179';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
@@ -1942,6 +1957,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.179',items:[
+    {icon:'📷',text:'Picker · Foto: Neue Option in Einstellungen → Daten → „Foto auf Handy sichern". Wenn aktiv, wird das Foto nach dem Hinzufügen einer Mahlzeit übers System-Teilen-Menü angeboten (z. B. „In Fotos sichern" auf iOS, „In Galerie speichern" auf Android). Unter dem Foto-Preview gibt es einen Hinweis-Link zur Einstellung. (#118)',where:'Einstellungen · Daten · Picker-Fotos'},
+  ]},
   {v:'0.178',items:[
     {icon:'🐛',text:'Picker Chat: Fuzzy-Suche ist strenger — „Waffel" findet nicht mehr fälschlich „Kaffee mit Milch". Levenshtein-Toleranz für kurze Wörter (bis 7 Zeichen) auf 1 Edit reduziert. (#117)',where:'Picker · Chat-Tab'},
   ]},
@@ -3932,9 +3950,12 @@ function openSettings(){
   if(dfi)dfi.value=S.dietFree||'';
   var dwchk=document.getElementById('sdietwarn');
   if(dwchk)dwchk.checked=!!S.dietWarn;
+  var spchk=document.getElementById('ssavepickerphotos');
+  if(spchk)spchk.checked=!!S.savePickerPhotos;
   updateDietPresetBtns();
   updateDietMacroInfo();
   updateDietWarnToggle();
+  renderSavePickerPhotosToggle();
   renderSavedDietFreeList();
   document.getElementById('cacheInfo').textContent=customFoods.length+' eigene Lebensmittel · '+recipes.length+' Rezepte · '+Object.keys(foodCache).length+' gespeichert';
   var aiStatus=document.getElementById('aiProxyStatus');
@@ -4311,6 +4332,26 @@ function updateDietWarnToggle(){
   if(chk&&tog&&thumb){
     tog.style.background=chk.checked?'var(--g1)':'#ccc';
     thumb.style.transform=chk.checked?'translateX(20px)':'translateX(0)';
+  }
+}
+
+function renderSavePickerPhotosToggle(){
+  var chk=document.getElementById('ssavepickerphotos');
+  var tog=document.getElementById('savePickerPhotosToggle');
+  var thumb=document.getElementById('savePickerPhotosThumb');
+  if(chk&&tog&&thumb){
+    tog.style.background=chk.checked?'var(--g1)':'#ccc';
+    thumb.style.transform=chk.checked?'translateX(20px)':'translateX(0)';
+  }
+}
+function updateSavePickerPhotosToggle(){
+  renderSavePickerPhotosToggle();
+  var chk=document.getElementById('ssavepickerphotos');
+  S.savePickerPhotos=!!(chk&&chk.checked);
+  saveS();
+  if(typeof _pickerRefreshPhotoSaveHint==='function'){
+    var prev=document.getElementById('pickerPrevWrap');
+    if(prev&&!prev.classList.contains('hidden'))_pickerRefreshPhotoSaveHint();
   }
 }
 

--- a/picker.js
+++ b/picker.js
@@ -216,6 +216,7 @@ function pickerHandlePhoto(e){
       document.getElementById('pickerPrevWrap').classList.remove('hidden');
       document.getElementById('pickerPhotoPickArea').style.display='none';
       document.getElementById('pickerAnalyzeBtn').disabled=false;
+      _pickerRefreshPhotoSaveHint();
       // Barcode-Scan verzögert damit UI sofort reagiert
       setTimeout(function(){pickerTryBarcode(c);},100);
     };
@@ -239,6 +240,48 @@ function pickerResetPhoto(){
   document.getElementById('pickerRecipeName').value='';
   document.getElementById('pickerChatRecipeName').value='';
   pickerIngredients=[];
+  _pickerRefreshPhotoSaveHint(false);
+}
+
+// #118: Foto sichern, wenn vom User in den Einstellungen aktiviert (S.savePickerPhotos).
+// Web-Capture legt das Foto weder auf iOS noch zuverlässig auf Android in die Galerie —
+// daher aktiv via navigator.share (mit File) anbieten, Fallback: <a download> (Downloads/).
+function _pickerSavePhotoIfWanted(){
+  try{
+    if(!window._pickerPhotoB64)return;
+    if(typeof S==='undefined'||!S.savePickerPhotos)return;
+    var bin=atob(window._pickerPhotoB64);
+    var bytes=new Uint8Array(bin.length);
+    for(var i=0;i<bin.length;i++)bytes[i]=bin.charCodeAt(i);
+    var blob=new Blob([bytes],{type:'image/jpeg'});
+    var ts=new Date().toISOString().replace(/[:.]/g,'-').slice(0,19);
+    var fname='nutritrack-'+ts+'.jpg';
+    if(navigator.canShare&&typeof File!=='undefined'){
+      try{
+        var file=new File([blob],fname,{type:'image/jpeg'});
+        if(navigator.canShare({files:[file]})&&navigator.share){
+          navigator.share({files:[file],title:'NutriTrack Foto'}).catch(function(){});
+          return;
+        }
+      }catch(e){/* fall through to download */}
+    }
+    var url=URL.createObjectURL(blob);
+    var a=document.createElement('a');
+    a.href=url;a.download=fname;a.rel='noopener';a.style.display='none';
+    document.body.appendChild(a);a.click();
+    setTimeout(function(){if(a.parentNode)a.parentNode.removeChild(a);URL.revokeObjectURL(url);},100);
+  }catch(e){/* never block the meal-add flow */}
+}
+
+// Hinweis unter dem Foto-Preview synchronisieren (an/aus aus S.savePickerPhotos).
+// show=false versteckt den Hint (z. B. beim Reset, wenn kein Foto da ist).
+function _pickerRefreshPhotoSaveHint(show){
+  var el=document.getElementById('pickerPhotoSaveHint');if(!el)return;
+  if(show===false){el.classList.add('hidden');return;}
+  var on=!!(typeof S!=='undefined'&&S.savePickerPhotos);
+  el.textContent=on?'💾 Foto wird beim Hinzufügen gespeichert · in Einstellungen änderbar':'💡 Foto-Speicherung in Einstellungen aktivierbar';
+  el.style.color=on?'var(--g1)':'var(--mu)';
+  el.classList.remove('hidden');
 }
 
 function pickerTryBarcode(canvas){
@@ -1038,7 +1081,7 @@ function _pickerAdd(emoji,nameId,portionsId,defaultName,saveAsRecipe,hasEditMode
     var e=getDay().meals[window._editEntryMeal][window._editEntryIdx];
     if(e&&e.ingredients){
       ings.forEach(function(ing){e.ingredients.push(ing);});
-      saveS();closePicker();openEditEntry(window._editEntryMeal,window._editEntryIdx);
+      saveS();_pickerSavePhotoIfWanted();closePicker();openEditEntry(window._editEntryMeal,window._editEntryIdx);
       showToast(ings.length+' Zutat(en) hinzugefügt');return;
     }
   }
@@ -1056,7 +1099,7 @@ function _pickerAdd(emoji,nameId,portionsId,defaultName,saveAsRecipe,hasEditMode
     showToast(emoji+' '+name+' eingetragen');
   }
   var _idx=getDay().meals[pickerMeal].length-1;
-  saveS();renderAll();closePicker();animateAdd(pickerMeal);
+  saveS();renderAll();_pickerSavePhotoIfWanted();closePicker();animateAdd(pickerMeal);
   checkPregWarn(ings,pickerMeal,_idx);checkDietWarn(ings,pickerMeal,_idx);
 }
 function pickerPhotoAdd(saveAsRecipe){_pickerAdd('📸','pickerRecipeName','pickerPhotoPortions','Foto-Rezept',saveAsRecipe,true);}

--- a/picker.js
+++ b/picker.js
@@ -1110,10 +1110,12 @@ function _pickerScoreName(name,qTokens,qFull){
       if(nt===qt){best=Math.max(best,5);break;}
       if(nt.indexOf(qt)===0){best=Math.max(best,4);continue;}
       if(nt.indexOf(qt)>0){best=Math.max(best,3);continue;}
-      // Tippfehler-Toleranz: 1 Edit für kurze, 2 für längere Wörter
+      // Tippfehler-Toleranz: kein Levenshtein für sehr kurze Wörter, sonst sammeln sich
+      // Fehltreffer wie „kaffee"↔„waffel" (Distanz 2 bei Länge 6). Erst ab Länge 5 prüfen,
+      // 1 Edit bis 7 Zeichen, 2 Edits für längere.
       var maxLen=Math.max(nt.length,qt.length);
-      if(maxLen<3)continue;
-      var allowed=maxLen<=5?1:2;
+      if(maxLen<5)continue;
+      var allowed=maxLen<=7?1:2;
       var d=_pickerLev(nt,qt);
       if(d<=allowed)best=Math.max(best,3-Math.min(d,2));
     }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.178';
+var VERSION = '0.179';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.177';
+var VERSION = '0.178';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 


### PR DESCRIPTION
## Was

Zwei Issues aus `topic:picker`:

### v0.178 — Picker Chat: strengere Fuzzy-Suche (Closes #117)
„Waffel" lieferte fälschlich auch „Kaffee mit Milch" als Treffer, weil `_pickerLev('kaffee','waffel') === 2` mit der bisherigen 2-Edit-Toleranz ab `maxLen=6` durchging. Schwellen angehoben:
- `maxLen < 5` → kein Levenshtein
- `maxLen 5–7` → 1 Edit
- `maxLen ≥ 8` → 2 Edits (wie bisher)

Bekannte Test-Cases bleiben grün: „jogurt"↔„joghurt" (Länge 7, Distanz 1 ✓), „frucht"↔„fruchten" (Länge 8, Distanz 2 ✓).

### v0.179 — Picker Foto: optionales Sichern per Share-Sheet (Closes #118)
Web-Capture (`<input capture>`) legt Fotos weder auf iOS noch zuverlässig auf Android in die Galerie. Daher neuer Settings-Toggle „Foto auf Handy sichern" in **Einstellungen → Daten → 📷 Picker-Fotos** (`S.savePickerPhotos`, Default off).

Wenn aktiv, ruft `_pickerSavePhotoIfWanted()` in `_pickerAdd` (vor `closePicker()`) auf — primär `navigator.share({files:[File]})` mit JPEG-File, Fallback `<a download>` (Downloads/). Kein zusätzlicher Datenverbrauch — alles lokal.

Unter dem Foto-Preview ein Hinweis-Link, der zur Settings-Sektion navigiert.

## Test plan

- [ ] **v0.178:** Picker → Chat-Tab → „Waffel" suchen → nur „Waffeln aus Magerquark und Dinkelmehl" als Treffer (kein „Kaffee mit Milch")
- [ ] **v0.178:** „Jogurt" findet weiterhin „Joghurt …"; „Frucht" findet weiterhin „Früchten"
- [ ] **v0.179:** Einstellungen → Daten → 📷 Picker-Fotos → Toggle aktivieren
- [ ] **v0.179:** Picker → Foto-Tab → Kamera → Mahlzeit hinzufügen → System-Share-Sheet erscheint (iOS „In Fotos sichern", Android „In Galerie speichern")
- [ ] **v0.179:** Toggle aus → Foto-Preview zeigt Hinweis „💡 Foto-Speicherung in Einstellungen aktivierbar", Tap navigiert zu Settings/Daten


---
_Generated by [Claude Code](https://claude.ai/code/session_01Snk2iHoV9nBuc5BuJL3b8J)_