### PR TITLE
v0.182: Sicherheits- &amp; Stabilitäts-Härtung aus Code-Review

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.181 (2026-06-19)
+**Stand:** v0.182 (2026-06-19)
 
 ## URLs
 
@@ -34,6 +34,7 @@
 - **Picker OFT (v0.170):** kcal-Fallback `P*4+K*4+F*9` in `pickerFetchOnline` und `lookupNutrients` wenn beide Energy-Felder fehlen (#96 #101). OFT im Chat-Tab seit v0.175 nicht mehr genutzt.
 - **Picker Foto-Save (v0.179):** Settings-Toggle `S.savePickerPhotos` (Default off) unter „🗂 Daten → 📷 Picker-Fotos". Wenn an, ruft `_pickerSavePhotoIfWanted()` in `_pickerAdd` (vor `closePicker()`) auf — versucht zuerst `navigator.share({files:[File]})` (iOS Safari + Android Chrome unterstützen Files seit iOS 15 / Chrome 89), Fallback `<a download>` (Android: nach `Downloads/`; iOS PWA: nicht garantiert). Hinweis-Zeile `#pickerPhotoSaveHint` unter `pickerPrevWrap` zeigt Status und navigiert tippbar zu Einstellungen/Daten. Web-Capture (`<input capture>`) legt das Foto sonst weder auf iOS noch zuverlässig auf Android in die Galerie (#118).
 - **Wiederkehrende Mahlzeiten (v0.181):** `S.recurringMeals[]` = `{id,name,meal,weekdays:[0..6 JS-getDay],entries[],startDate,active}`. Anlegen über `mealDetailScreen`-CTA „🔁 Wiederholen" (`#mdRecur`→`openRecurCreate`) → `recurCreateOv` mit Wochentag-Chips (Default Mo–Fr). `applyRecurringMeals(dateKey)` fügt aktive Regeln idempotent ein: pro Tag merkt `day._recurMarks[]` angewandte Regel-IDs → keine Doppel, und gelöschte Einträge kommen am selben Tag nicht zurück. Eingefügte Einträge tragen `_recurId` (🔁-Badge in Eintrags-Listen). Hooks: Boot (`ensureRecurringForCurrentDay`), `changeDay`, `goToDay`. Verwaltung „Mehr → 🔁 Wiederkehrende Mahlzeiten" (`openRecurManage`/`recurMgmtOv`): Aktiv/Pause + Löschen. `startDate=today` → nicht rückwirkend; Zukunft ausgeschlossen.
+- **Härtung (v0.182):** Globaler `esc()` in `index.html` + `_esc()` in `picker.js` escapen alle per `innerHTML` ausgegebenen Namen/Freitexte aus untrusted Quellen (Import-Payloads, OpenFoodFacts, KI-Antworten) → kein XSS mehr. SW `install` cacht `CORE_ASSETS` vorab (`./`,`index.html`,`picker.js`,`js/health-sync.js`,`manifest.json`,`icon.svg`, best-effort `allSettled`) → echte Offline-Erstnutzung; Offline-Fallbacks awaiten jetzt das `caches.match`-Promise korrekt. Worker `/feedback` verlangt `x-app-proxy-secret` (Client sendet `getProxySecret()`) + IP-Tages-Limit (`fbrl:<ip>:<tag>`, 30/Tag) + `mdNeutralizeBody` neutralisiert @-Mentions/#-Refs in der Beschreibung. `/workouts` paginiert via Cursor (bis 20 Seiten) + parallele KV-Reads → kein Datenverlust bei >200 Workouts. Decoder optional per `DECODER_SECRET`/`X-Decoder-Secret` absicherbar (beidseitig setzen; unset = offen). Bugfix `rememberPortion(f.name,amt)` (vorher `f.amount`=undefined). Toter Code entfernt (`toggleEye`,`shareCustomFood`,`triggerBackupDownload`,`pickerOnAdd`,`_pickerIngCallbacks`).
 - **Picker KI-Fehlertexte (v0.180):** `pickerFriendlyAiError(err)` in `picker.js` mappt bekannte KI-/Proxy-Fehler (Kontingent/Billing, overloaded/rate-limit/429/529, nicht konfiguriert, offline) auf deutsche Texte; unbekannte Fehler unverändert. Genutzt in `pickerChatKiFallback` + Foto-Analyse-`onErr` (#121).
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
@@ -66,6 +67,7 @@
 
 ## Live-Test offen
 
+- v0.182 Offline: App installieren, sofort offline öffnen → lädt aus Cache (Pre-Caching); Feedback-Senden funktioniert weiter (Client sendet jetzt `x-app-proxy-secret`); Portion über Suche hinzufügen → Menge wird beim nächsten Mal vorgeschlagen (rememberPortion-Fix). Optional: Worker neu deployen (`wrangler deploy` in `worker/`); Decoder-Secret nur wenn `DECODER_SECRET` beidseitig gesetzt
 - v0.180 Picker: KI-Limit/Überlast/offline → deutsche Meldung statt englischem Roh-Text im Chat- und Foto-Tab (#121)
 - v0.181 Wiederkehrende Mahlzeit: Mahlzeit → „🔁 Wiederholen" → Mo–Fr speichern; am nächsten Werktag automatisch eingetragen (🔁-Badge); löschen an einem Tag → kommt dort nicht zurück; „Mehr → 🔁" pausieren/löschen (#122)
 - v0.157 Mahlzeit-Detail „💾 Als Rezept" — Rezept aus Mahlzeit erstellen, Editor öffnet zum Benennen (#75)
@@ -88,11 +90,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.177 | #116 | Picker Chat: nur eigene Sachen, alle Tokens müssen treffen |
 | v0.178 | — | Picker Chat: strengere Fuzzy-Toleranz — kein „Kaffee mit Milch" bei „Waffel" (#117) |
 | v0.179 | — | Picker Foto: optionales Sichern per Share-Sheet, Toggle in Einstellungen (#118) |
 | v0.180 | #123 | Picker: freundliche deutsche KI-Fehlermeldung statt englischem Roh-Text (#121) |
 | v0.181 | #124 | Wiederkehrende Mahlzeiten: automatisch an festen Wochentagen eintragen (#122) |
+| v0.182 | — | Härtung: XSS-Escaping, SW-Pre-Caching, Feedback-Auth+Rate-Limit, /workouts-Pagination, Decoder-Secret, rememberPortion-Fix |
 
 ---
 

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -88,6 +88,23 @@ two warm containers. The Cloud Run **Always-Free-Tier** (2M requests/month,
 360k vCPU-seconds, 180k GiB-seconds RAM) covers NutriTrack's expected volume
 by orders of magnitude.
 
+### Optional: shared secret (recommended)
+
+The service is deployed `--allow-unauthenticated` so the Cloudflare Worker can
+reach it without GCP IAM. To stop random callers from hitting the
+CPU-intensive `/decode` endpoint, set a shared secret on **both** sides — when
+`DECODER_SECRET` is set, `/decode` requires a matching `X-Decoder-Secret`
+header and returns `401` otherwise. When unset, the endpoint stays open
+(backward compatible).
+
+```bash
+# On Cloud Run (decoder):
+gcloud run services update nutritrack-decoder --region europe-west1 \
+  --set-env-vars DECODER_SECRET=<long-random-token>
+# On the Cloudflare Worker:
+cd ../worker && wrangler secret put DECODER_SECRET   # same value
+```
+
 After deploy, set the resulting URL on the Cloudflare Worker:
 
 ```bash

--- a/decoder/main.py
+++ b/decoder/main.py
@@ -25,6 +25,10 @@ app = FastAPI(title="NutriTrack OSS-Barcode-Decoder", version="1.0.0")
 MAX_BYTES = 1024 * 1024  # 1 MB hard cap; live frames are ~50–200 KB.
 SR_PROTO = os.environ.get("OPENCV_SR_PROTOTXT")  # optional super-resolution
 SR_MODEL = os.environ.get("OPENCV_SR_MODEL")
+# Optional shared secret. When set, /decode requires a matching
+# X-Decoder-Secret header — protects the public Cloud Run service from
+# unauthenticated abuse. When unset, the endpoint stays open (backward compat).
+DECODER_SECRET = os.environ.get("DECODER_SECRET")
 
 _DIGITS_RE = re.compile(r"^\d+$")
 
@@ -106,6 +110,8 @@ def health():
 
 @app.post("/decode")
 async def decode(request: Request):
+    if DECODER_SECRET and request.headers.get("x-decoder-secret") != DECODER_SECRET:
+        raise HTTPException(status_code=401, detail="unauthorized")
     body = await request.body()
     if not body:
         raise HTTPException(status_code=400, detail="empty_body")

--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.181</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.182</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1965,8 +1965,11 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.181';
+var APP_VERSION='0.182';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
+// HTML-Escaping für alle Namen/Freitexte aus untrusted Quellen (Import-Payloads,
+// OpenFoodFacts, KI-Antworten), die per innerHTML eingefügt werden — schützt vor XSS.
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
 function _sha256hex(str){
   return crypto.subtle.digest('SHA-256',new TextEncoder().encode(str)).then(function(buf){
     return Array.from(new Uint8Array(buf)).map(function(b){return b.toString(16).padStart(2,'0');}).join('');
@@ -1994,6 +1997,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.182',items:[
+    {icon:'🔒',text:'Stabilität & Sicherheit: Namen aus geteilten Links, Online-Datenbanken und KI-Antworten werden jetzt sicher dargestellt (Schutz vor manipulierten Inhalten). Die Offline-Nutzung wurde robuster gemacht, und das Portionsgedächtnis merkt sich nun auch Mengen, die du über die Suche hinzufügst.',where:'App-weit'},
+  ]},
   {v:'0.181',items:[
     {icon:'🔁',text:'Neu: Wiederkehrende Mahlzeiten. Öffne eine Mahlzeit (z. B. dein Frühstück), tippe „🔁 Wiederholen" und wähle die Wochentage (Standard Mo–Fr) — die Mahlzeit wird dann automatisch an diesen Tagen eingetragen. An Tagen, wo es mal nicht stimmt, einfach löschen; sie kommt an dem Tag nicht zurück. Verwalten/pausieren unter „Mehr → 🔁 Wiederkehrende Mahlzeiten". (#122)',where:'Mahlzeit-Detail · Mehr'},
   ]},
@@ -2763,7 +2769,6 @@ function recipeImportStart(){
     .catch(function(){showToast('URL konnte nicht geladen werden');});
 }
 
-function toggleEye(id){var el=document.getElementById(id);el.type=el.type==='password'?'text':'password';}
 function doSetup(){
   S.apiKey='';
   S.setupDone=true;
@@ -3693,13 +3698,6 @@ function shareLibFood(filteredIdx){
   var summary=Math.round(f.per100.kcal||0)+' kcal · '+Math.round(f.per100.protein||0)+'g P · '+Math.round(f.per100.carbs||0)+'g KH · '+Math.round(f.per100.fat||0)+'g F (pro 100g)';
   _shareItem(payload,f.name,summary);
 }
-function shareCustomFood(idx){
-  var f=customFoods[idx];
-  if(!f){showToast('Lebensmittel nicht gefunden');return;}
-  var payload={t:'f',n:f.name,em:f.emoji||'🍽',p:{k:Math.round(f.per100.kcal||0),pr:Math.round((f.per100.protein||0)*10)/10,c:Math.round((f.per100.carbs||0)*10)/10,f:Math.round((f.per100.fat||0)*10)/10}};
-  var summary=Math.round(f.per100.kcal||0)+' kcal · '+Math.round(f.per100.protein||0)+'g P · '+Math.round(f.per100.carbs||0)+'g KH · '+Math.round(f.per100.fat||0)+'g F (pro 100g)';
-  _shareItem(payload,f.name,summary);
-}
 function shareEntryAsFood(meal,idx){
   var e=getDay().meals[meal][idx];
   if(!e){showToast('Eintrag nicht gefunden');return;}
@@ -3752,7 +3750,7 @@ function _previewImport(d){
     subEl.textContent='Du hast einen Rezept-Link geöffnet';
     nameEl.textContent=(d.em||'📋')+' '+d.n;
     summaryEl.textContent=ings.length+' Zutat'+(ings.length===1?'':'en')+' · '+Math.round(totalK)+' kcal';
-    detailEl.innerHTML=ings.map(function(i){return(i.em||'🍽')+' '+i.n+' <span style="color:var(--mu);">('+(i.a||0)+'g)</span>';}).join(' · ');
+    detailEl.innerHTML=ings.map(function(i){return esc(i.em||'🍽')+' '+esc(i.n)+' <span style="color:var(--mu);">('+esc(i.a||0)+'g)</span>';}).join(' · ');
     if(d.ins){insEl.style.display='block';insEl.textContent=d.ins.length>240?d.ins.substring(0,240)+'…':d.ins;}
     btn.textContent='✅ In Bibliothek speichern';
   } else if(d.t==='f'){
@@ -3760,7 +3758,7 @@ function _previewImport(d){
     subEl.textContent='Du hast einen Lebensmittel-Link geöffnet';
     nameEl.textContent=(d.em||'🍽')+' '+d.n;
     summaryEl.textContent='Werte pro 100g';
-    detailEl.innerHTML='kcal: <strong>'+(d.p.k||0)+'</strong> · Protein: <strong>'+(d.p.pr||0)+'g</strong> · KH: <strong>'+(d.p.c||0)+'g</strong> · Fett: <strong>'+(d.p.f||0)+'g</strong>';
+    detailEl.innerHTML='kcal: <strong>'+esc(d.p.k||0)+'</strong> · Protein: <strong>'+esc(d.p.pr||0)+'g</strong> · KH: <strong>'+esc(d.p.c||0)+'g</strong> · Fett: <strong>'+esc(d.p.f||0)+'g</strong>';
     btn.textContent='✅ In Bibliothek speichern';
   } else if(d.t==='m'){
     var entries=d.e||[];
@@ -3775,7 +3773,7 @@ function _previewImport(d){
     subEl.textContent='Du hast einen Mahlzeit-Link geöffnet';
     nameEl.textContent='🍽 '+(MEAL_NAMES[d.m]||'Mahlzeit');
     summaryEl.textContent=entries.length+' Eintr'+(entries.length===1?'ag':'äge')+' · '+Math.round(totalKcal)+' kcal';
-    detailEl.innerHTML=entries.map(function(e){return(e.em||'🍽')+' '+e.n;}).join(' · ');
+    detailEl.innerHTML=entries.map(function(e){return esc(e.em||'🍽')+' '+esc(e.n);}).join(' · ');
     mealRow.style.display='block';
     document.getElementById('importConfirmMealTarget').value=d.m||'breakfast';
     btn.textContent='✅ Einträge übernehmen';
@@ -4234,8 +4232,8 @@ function showAmpelModal(results,title,subtitle){
     html+='<div style="display:flex;align-items:flex-start;gap:8px;margin-bottom:5px;padding:5px 8px;'
       +'background:'+{rot:'#fff3f3',gelb:'#fffbe6'}[r.ampel]+';border-left:3px solid '+colors[r.ampel]+';border-radius:6px;">'
       +'<span style="font-size:16px;flex-shrink:0;">'+icons[r.ampel]+'</span>'
-      +'<div><span style="font-weight:700;font-size:12px;">'+r.name+'</span>'
-      +' <span style="font-size:12px;color:#555;">– '+r.grund+'</span></div>'
+      +'<div><span style="font-weight:700;font-size:12px;">'+esc(r.name)+'</span>'
+      +' <span style="font-size:12px;color:#555;">– '+esc(r.grund)+'</span></div>'
       +'</div>';
   });
   html+='<div style="text-align:right;margin-top:4px;">'
@@ -4286,8 +4284,8 @@ function renderAmpelInfo(e){
       +'background:'+bg[w.ampel]+';border-left:3px solid '+colors[w.ampel]+';border-radius:8px;margin-bottom:5px;">'
       +'<span style="font-size:15px;">'+icons[w.ampel]+'</span>'
       +'<div><div style="font-size:11px;color:var(--mu);font-weight:700;margin-bottom:1px;">'+badge+'</div>'
-      +'<div style="font-size:12px;font-weight:700;">'+w.name+'</div>'
-      +'<div style="font-size:12px;color:#555;">'+w.grund+'</div>'
+      +'<div style="font-size:12px;font-weight:700;">'+esc(w.name)+'</div>'
+      +'<div style="font-size:12px;color:#555;">'+esc(w.grund)+'</div>'
       +'</div></div>';
   });
   html+='</div>';
@@ -5389,14 +5387,6 @@ function renderOneDriveStatus(){
   }
 }
 
-function triggerBackupDownload(){
-  var data={state:backupState(),foodCache:foodCache,customFoods:customFoods,recipes:recipes,barcodeCache:barcodeCache};
-  var blob=new Blob([JSON.stringify(data)],{type:'application/json'});
-  var url=URL.createObjectURL(blob);
-  var a=document.createElement('a');a.href=url;a.download='nutritrack-backup-'+today()+'.json';a.click();
-  URL.revokeObjectURL(url);
-}
-
 // ════════════════════════════════════════
 // SECTION: SPORT & AKTIVITÄT
 // ════════════════════════════════════════
@@ -5710,9 +5700,9 @@ function renderLibrary(){
       filtered.forEach(function(r){
         var t=ingTotal(r.ingredients||[]);
         html+='<div style="background:white;border-radius:12px;padding:12px 14px;box-shadow:var(--sh);display:flex;align-items:center;gap:10px;">'
-          +'<div style="font-size:26px;">'+(r.emoji||'📋')+'</div>'
+          +'<div style="font-size:26px;">'+esc(r.emoji||'📋')+'</div>'
           +'<div style="flex:1;min-width:0;">'
-            +'<div style="font-weight:700;font-size:14px;">'+r.name+'</div>'
+            +'<div style="font-weight:700;font-size:14px;">'+esc(r.name)+'</div>'
             +'<div style="font-size:11px;color:var(--mu);margin-top:2px;">'+r.ingredients.length+' Zutaten · '+Math.round(t.kcal)+' kcal/Portion</div>'
           +'</div>'
           +'<button type="button" onclick="openRecipeEditor(this.dataset.rid)" data-rid="'+r.id+'" style="background:none;border:none;font-size:18px;color:var(--g2);padding:4px;">✏️</button>'
@@ -5738,9 +5728,9 @@ function renderLibrary(){
       var editBtn=f.isCustom?('<button type="button" onclick="openOwnFoodEdit('+i+')" style="background:none;border:none;font-size:16px;color:var(--g2);padding:4px;">&#9998;</button>'):'';
       var shareBtn='<button type="button" onclick="shareLibFood('+i+')" style="background:none;border:none;font-size:16px;color:var(--mu);padding:4px;" title="Teilen">📤</button>';
       html+='<div style="background:white;border-radius:12px;padding:10px 14px;box-shadow:var(--sh);display:flex;align-items:center;gap:10px;">'
-        +'<div style="font-size:22px;">'+(f.emoji||'&#127374;')+'</div>'
+        +'<div style="font-size:22px;">'+esc(f.emoji||'&#127374;')+'</div>'
         +'<div style="flex:1;min-width:0;">'
-          +'<div style="font-weight:700;font-size:13px;">'+f.name+'</div>'
+          +'<div style="font-weight:700;font-size:13px;">'+esc(f.name)+'</div>'
           +'<div style="font-size:11px;color:var(--mu);margin-top:1px;">'+Math.round(f.per100.kcal)+' kcal pro 100g</div>'
         +'</div>'
         +editBtn
@@ -6179,7 +6169,7 @@ function submitFeedback(){
   };
   fetch(FEEDBACK_WORKER_URL,{
     method:'POST',
-    headers:{'Content-Type':'application/json'},
+    headers:{'Content-Type':'application/json','x-app-proxy-secret':getProxySecret()},
     body:JSON.stringify(payload)
   }).then(function(r){return r.json().then(function(j){return {status:r.status,j:j};});})
   .then(function(res){

--- a/js/health-sync.js
+++ b/js/health-sync.js
@@ -79,8 +79,9 @@
     return 'Workout';
   }
   function _dayKey(startIso){
-    // Use the local-date portion of the ISO string. Workouts at 23:50 in
-    // Europe/Berlin shouldn't get bucketed into the next UTC day.
+    // Bucket by the device's local date (same basis the rest of the app uses
+    // for day keys), so a workout at 23:50 stays on the day the user sees it
+    // instead of rolling into the next UTC day.
     var d=new Date(startIso);
     if(isNaN(d.getTime()))return null;
     var y=d.getFullYear();

--- a/picker.js
+++ b/picker.js
@@ -3,6 +3,14 @@
 // Ausgelagert aus index.html (v0.119)
 // ════════════════════════════════════════
 
+// HTML-Escaping für Namen aus untrusted Quellen (OpenFoodFacts, KI-Antworten,
+// Suchtreffer), die per innerHTML eingefügt werden — Schutz vor XSS. Nutzt den
+// globalen esc() aus index.html, fällt aber auf eine eigene Variante zurück.
+function _esc(s){
+  if(typeof window!=='undefined'&&typeof window.esc==='function')return window.esc(s);
+  return String(s==null?'':s).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});
+}
+
 // Wandelt rohe (oft englische) KI-/Proxy-Fehlermeldungen in eine kurze,
 // handlungsorientierte deutsche Meldung um (#121). Unbekannte Fehler werden
 // unverändert durchgereicht.
@@ -21,7 +29,6 @@ function pickerFriendlyAiError(err){
 
 // Picker state (global)
 var pickerMeal=null;          // which meal to add to (null = ask)
-var pickerOnAdd=null;         // callback: function(ingredient)
 var pickerSelFood=null;       // selected food in search tab
 var pickerIngredients=[];     // photo/chat detected ingredients
 var pickerBcFound=null;       // barcode found pending confirm
@@ -150,7 +157,7 @@ function pickerRenderResults(products,loading){
     var isR=p.isRecipe;
     return'<div class="ri'+(isR?' is-recipe':'')+'" onclick="pickerSelResult('+i+')" id="pri'+i+'">'+bdg
       +'<div class="ri-e">'+(p.emoji||'🍽')+'</div>'
-      +'<div style="flex:1;min-width:0;"><div class="ri-n">'+p.name+'</div>'
+      +'<div style="flex:1;min-width:0;"><div class="ri-n">'+_esc(p.name)+'</div>'
       +(p.per100?'<div class="ri-d">P '+(p.per100.protein||0).toFixed(1)+'g · K '+(p.per100.carbs||0).toFixed(1)+'g · F '+(p.per100.fat||0).toFixed(1)+'g · /100g</div>':'<div class="ri-d">Rezept</div>')
       +'</div>'
       +(p.per100?'<div class="ri-k">'+Math.round(p.per100.kcal||0)+' kcal</div>':'')
@@ -203,7 +210,7 @@ function pickerConfirmAdd(){
   var _idx=getDay().meals[pickerMeal].length-1;
   saveS();renderAll();closePicker();
   animateAdd(pickerMeal);
-  rememberPortion(f.name,f.amount);
+  rememberPortion(f.name,amt);
   checkDataQuality(f);
   checkPregWarn([f],pickerMeal,_idx);
   checkDietWarn([f],pickerMeal,_idx);
@@ -828,13 +835,13 @@ function pickerFetchBarcodeForConfirm(code){
   fetch('https://world.openfoodfacts.org/api/v0/product/'+code+'.json')
     .then(function(r){return r.json();})
     .then(function(data){
-      if(data.status!==1||!data.product)return;
+      if(data.status!==1||!data.product){showToast('Barcode '+code+' nicht gefunden – bitte manuell eintragen');return;}
       var p=data.product,nm=p.nutriments||{};
       var name=p.product_name_de||p.product_name||'Unbekannt';
       var food={name:name,emoji:emo(name),barcode:code,per100:{kcal:nm['energy-kcal_100g']||0,protein:nm['proteins_100g']||0,carbs:nm['carbohydrates_100g']||0,fat:nm['fat_100g']||0,sugar:nm['sugars_100g']||0,fiber:nm['fiber_100g']||0,salt:nm['salt_100g']||0}};
       barcodeCache[code]=food;saveBarcodeCache();cacheFood(food);
       pickerShowBcConfirm(food);
-    }).catch(function(){});
+    }).catch(function(){showToast('Produkt-Abruf fehlgeschlagen – bist du online?');});
 }
 
 function pickerShowBcConfirm(food){
@@ -918,7 +925,7 @@ function pickerShowBarcodeResult(food,fromCache){
   el.innerHTML='<div style="background:var(--gl);border:1.5px solid var(--g3);border-radius:12px;padding:12px;">'
     +'<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">'
     +'<div style="font-size:28px;">'+(food.emoji||'🍽')+'</div>'
-    +'<div style="flex:1;"><div style="font-weight:700;font-size:14px;">'+food.name+'</div>'
+    +'<div style="flex:1;"><div style="font-weight:700;font-size:14px;">'+_esc(food.name)+'</div>'
     +'<div style="font-size:11px;color:var(--mu);margin-top:2px;">P '+food.per100.protein+'g · K '+food.per100.carbs+'g · F '+food.per100.fat+'g pro 100g</div>'
     +(fromCache?'<div style="font-size:10px;color:var(--g2);margin-top:2px;">📴 Aus Cache</div>':'')
     +'</div>'
@@ -1004,7 +1011,6 @@ function pickerAnalyze(){
   var prompt=getFotoPrompt();
   callClaude('claude-sonnet-4-5',[{type:'image',source:{type:'base64',media_type:'image/jpeg',data:window._pickerPhotoB64}},{type:'text',text:prompt}],600,
     function(text){
-      console.log('[NutriTrack KI-Antwort]',text);
       var parsed=parsePhotoResponse(text);
       btn.disabled=false;btn.textContent='📷 Erneut analysieren';
       if(!parsed.zutaten.length){
@@ -1043,13 +1049,6 @@ function pickerUpdateTotal(tab){
   document.getElementById('picker'+tab+'Total').textContent='1 Portion: '+totalStr(t)+(p!==1?'  ·  '+p+'× = '+totalStr(scaleNutrients(t,p)):'');
 }
 function pickerUpdatePhotoTotal(){pickerUpdateTotal('Photo');}
-function _pickerIngCallbacks(tab){
-  return {
-    onChange:function(i,v){pickerIngredients[i].amount=parseFloat(v)||0;pickerUpdateTotal(tab);},
-    onDelete:function(i){pickerIngredients.splice(i,1);pickerUpdateTotal(tab);}
-  };
-}
-
 function pickerSetPhotoStatus(msg,isErr){
   var el=document.getElementById('pickerPhotoStatus');
   if(!msg){el.classList.add('hidden');return;}
@@ -1070,7 +1069,7 @@ function pickerPhotoAddSearch(){
   el.innerHTML=results.slice(0,8).map(function(p,i){
     return'<div class="ri" onclick="pickerPhotoAddFromResult('+i+')">'
       +'<div class="ri-e">'+(p.emoji||'🍽')+'</div>'
-      +'<div style="flex:1;min-width:0;"><div class="ri-n">'+p.name+'</div>'
+      +'<div style="flex:1;min-width:0;"><div class="ri-n">'+_esc(p.name)+'</div>'
       +(p.per100?'<div class="ri-d">'+Math.round(p.per100.kcal)+' kcal/100g</div>':'')
       +'</div>'
       +'<div style="font-size:18px;color:var(--g2);font-weight:900;">＋</div>'
@@ -1105,10 +1104,11 @@ function _pickerAdd(emoji,nameId,portionsId,defaultName,saveAsRecipe,hasEditMode
   var portions=parseFloat(document.getElementById(portionsId).value)||1;
   var t=ingTotal(ings);
   var scaled=scaleNutrients(t,portions);
+  var createdRec=null;
   if(saveAsRecipe){
-    var rec={id:Date.now().toString(),name:name,emoji:emoji,ingredients:ings};
-    recipes.unshift(rec);saveX();
-    getDay().meals[pickerMeal].push(Object.assign({name:name,emoji:emoji,isRecipe:true,recipeId:rec.id,portions:portions,ingredients:ings},scaled));
+    createdRec={id:Date.now().toString(),name:name,emoji:emoji,ingredients:ings};
+    recipes.unshift(createdRec);saveX();
+    getDay().meals[pickerMeal].push(Object.assign({name:name,emoji:emoji,isRecipe:true,recipeId:createdRec.id,portions:portions,ingredients:ings},scaled));
     showToast(emoji+' '+name+' als Rezept gespeichert');
   } else {
     getDay().meals[pickerMeal].push(Object.assign({name:name,emoji:emoji,isRecipe:true,recipeId:null,portions:portions,ingredients:ings},scaled));
@@ -1117,6 +1117,7 @@ function _pickerAdd(emoji,nameId,portionsId,defaultName,saveAsRecipe,hasEditMode
   var _idx=getDay().meals[pickerMeal].length-1;
   saveS();renderAll();_pickerSavePhotoIfWanted();closePicker();animateAdd(pickerMeal);
   checkPregWarn(ings,pickerMeal,_idx);checkDietWarn(ings,pickerMeal,_idx);
+  return createdRec;
 }
 function pickerPhotoAdd(saveAsRecipe){_pickerAdd('📸','pickerRecipeName','pickerPhotoPortions','Foto-Rezept',saveAsRecipe,true);}
 
@@ -1227,7 +1228,7 @@ function pickerChatAddLocal(i){
   pickerIngredients=[{name:p.name,emoji:p.emoji,g:100,amount:100,per100:p.per100}];
   if(!document.getElementById('pickerChatRecipeName').value)
     document.getElementById('pickerChatRecipeName').value=p.name.slice(0,50);
-  msgs.innerHTML+='<div class="cm a">✓ '+p.name+' übernommen.</div>';
+  msgs.innerHTML+='<div class="cm a">✓ '+_esc(p.name)+' übernommen.</div>';
   _pickerChatRebind();
   pickerUpdateChatTotal();
   document.getElementById('pickerChatResult').classList.remove('hidden');
@@ -1284,7 +1285,7 @@ function pickerSendChat(){
       var sub=p.isRecipe?'Rezept':(p.per100?Math.round(p.per100.kcal)+' kcal · P'+(p.per100.protein||0).toFixed(1)+'g · K'+(p.per100.carbs||0).toFixed(1)+'g · F'+(p.per100.fat||0).toFixed(1)+'g /100g':'');
       var badge=p.badge||'';
       html+='<div style="background:var(--gl);border:1px solid var(--br);border-radius:10px;padding:8px 10px;display:flex;align-items:center;gap:8px;">'
-        +'<div style="flex:1;min-width:0;"><div style="font-weight:600;font-size:13px;">'+(p.emoji||'🍽')+' '+p.name+(badge?' <span style="font-size:11px;color:var(--mu);">'+badge+'</span>':'')+'</div>'
+        +'<div style="flex:1;min-width:0;"><div style="font-weight:600;font-size:13px;">'+(p.emoji||'🍽')+' '+_esc(p.name)+(badge?' <span style="font-size:11px;color:var(--mu);">'+_esc(badge)+'</span>':'')+'</div>'
         +(sub?'<div style="font-size:11px;color:var(--mu);">'+sub+'</div>':'')+'</div>'
         +'<button type="button" onclick="pickerChatAddLocal('+i+')" style="background:var(--g1);color:#fff;border:none;border-radius:8px;padding:5px 10px;font-size:14px;font-weight:700;cursor:pointer;flex-shrink:0;">＋</button>'
         +'</div>';
@@ -1385,10 +1386,10 @@ function pickerLinkImport(){
 function pickerUpdateLinkTotal(){pickerUpdateTotal('Link');}
 
 function pickerLinkAdd(saveAsRecipe){
-  _pickerAdd('🔗','pickerLinkRecipeName','pickerLinkPortions','Rezept',saveAsRecipe,true);
-  // Kochanleitung auf das zuletzt gespeicherte Rezept übertragen
-  if(saveAsRecipe&&window._pickerLinkInstructions&&recipes.length){
-    recipes[0].instructions=window._pickerLinkInstructions;
+  var rec=_pickerAdd('🔗','pickerLinkRecipeName','pickerLinkPortions','Rezept',saveAsRecipe,true);
+  // Kochanleitung auf das tatsächlich erstellte Rezept übertragen (statt blind recipes[0])
+  if(saveAsRecipe&&window._pickerLinkInstructions&&rec){
+    rec.instructions=window._pickerLinkInstructions;
     saveX();
   }
   window._pickerLinkInstructions='';
@@ -1431,7 +1432,7 @@ function pickerRenderIngList(elId,ings,onAmtChange,onDel){
     return'<div class="ing-wrap">'
       +'<div class="ing-item">'
       +'<div class="ing-e" onclick="ingToggle(event,\''+nid+'\')">'+(ing.emoji||'🍽')+'</div>'
-      +'<div class="ing-n" onclick="ingToggle(event,\''+nid+'\')">'+ing.name+ampelDot+'</div>'
+      +'<div class="ing-n" onclick="ingToggle(event,\''+nid+'\')">'+_esc(ing.name)+ampelDot+'</div>'
       +'<input type="number" class="ing-amt" value="'+amtVal+'" min="1" placeholder="g?" style="'+borderStyle+'" data-i="'+i+'" onchange="pickerIngAmtChange(\''+elId+'\','+i+',this.value)">'
       +'<div class="ing-u">g</div>'
       +warn

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,23 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.181';
+var VERSION = '0.182';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
+// Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur
+// SW-Position (/nutritrack/), damit der GitHub-Pages-Pfad korrekt aufgelöst wird.
+var CORE_ASSETS = ['./','index.html','picker.js','js/health-sync.js','manifest.json','icon.svg'];
 
 self.addEventListener('install', function(e) {
   // Sofort aktivieren ohne auf alte Tabs zu warten
   self.skipWaiting();
+  // Kern-Assets vorab cachen, damit die PWA auch bei Erst-Nutzung offline läuft.
+  // Best-effort pro Asset (allSettled) — ein einzelner Fehlschlag bricht die
+  // Installation nicht ab.
+  e.waitUntil(
+    caches.open(CACHE).then(function(c) {
+      return Promise.allSettled(CORE_ASSETS.map(function(u) { return c.add(u); }));
+    }).catch(function() {})
+  );
 });
 
 self.addEventListener('activate', function(e) {
@@ -54,7 +65,10 @@ self.addEventListener('fetch', function(e) {
         }
         return r;
       }).catch(function() {
-        return caches.match(e.request);
+        // Offline: erst den exakten Request, sonst die vorab gecachte Start-Seite.
+        return caches.match(e.request).then(function(m) {
+          return m || caches.match('/nutritrack/');
+        });
       })
     );
     return;
@@ -70,7 +84,11 @@ self.addEventListener('fetch', function(e) {
         }
         return r;
       }).catch(function() {
-        return caches.match('/nutritrack/') || caches.match('/nutritrack/index.html');
+        // caches.match liefert immer ein (truthy) Promise – daher den ersten
+        // Treffer awaiten und erst bei Miss auf index.html zurückfallen.
+        return caches.match('/nutritrack/').then(function(m) {
+          return m || caches.match('/nutritrack/index.html');
+        });
       });
     })
   );

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -5,5 +5,9 @@ ANTHROPIC_API_KEY=sk-ant-api03-example
 NUTRITRACK_PROXY_TOKEN=replace-with-a-long-random-token
 # URL of the OSS-Decoder microservice (Cloud Run). Primary decode path.
 DECODER_URL=https://nutritrack-decoder-xxxxx-ew.a.run.app
+# Optional shared secret with the decoder. When set here AND as DECODER_SECRET
+# on the Cloud Run service, the worker sends X-Decoder-Secret and the decoder
+# rejects unauthenticated calls. Leave unset to keep the decoder open.
+DECODER_SECRET=replace-with-a-long-random-token
 # Optional: set to "true" to enable Claude Vision as fallback when OSS-Decoder misses.
 ENABLE_VISION_FALLBACK=false

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -111,11 +111,15 @@ function isValidBarcodeChecksum(code) {
 
 // Calls the OSS-Decoder microservice (OpenCV BarcodeDetector + pyzbar) and
 // returns the parsed JSON or null on any error / timeout.
-async function tryExternalDecoder(decoderUrl, buffer, mediaType) {
+async function tryExternalDecoder(decoderUrl, buffer, mediaType, decoderSecret) {
   try {
+    const headers = { "Content-Type": mediaType };
+    // Shared secret between worker and decoder (only when configured on both
+    // sides) so the Cloud Run service can reject unauthenticated public calls.
+    if (decoderSecret) headers["x-decoder-secret"] = decoderSecret;
     const response = await fetch(decoderUrl.replace(/\/+$/, "") + "/decode", {
       method: "POST",
-      headers: { "Content-Type": mediaType },
+      headers,
       body: buffer,
       signal: AbortSignal.timeout(DECODER_TIMEOUT_MS),
     });
@@ -163,7 +167,7 @@ async function handleDecodeBarcode(request, origin, env) {
 
   // Primary path: OSS-Decoder (OpenCV + pyzbar). Skips Anthropic entirely on hit.
   if (env.DECODER_URL) {
-    const decoded = await tryExternalDecoder(env.DECODER_URL, buffer, mediaType);
+    const decoded = await tryExternalDecoder(env.DECODER_URL, buffer, mediaType, env.DECODER_SECRET);
     const decodedCode = decoded && typeof decoded.code === "string" ? decoded.code : null;
     if (decodedCode && isValidBarcodeChecksum(decodedCode)) {
       return jsonResponse(200, "ok", "ok", origin, env, {
@@ -333,6 +337,7 @@ const MAX_FEEDBACK_SCREENSHOT_BYTES = 1024 * 1024; // 1 MB raw base64
 const FEEDBACK_SCREENSHOT_BRANCH = "feedback-screenshots";
 const FEEDBACK_USER_AGENT = "nutritrack-feedback-worker";
 const FEEDBACK_DEFAULT_REPO = "hjolmes/nutritrack";
+const MAX_FEEDBACK_PER_IP_DAY = 30; // simple abuse cap (defense in depth)
 
 function ghHeaders(env) {
   return {
@@ -388,12 +393,39 @@ function mdEscapeCell(s) {
   return String(s == null ? "" : s).replace(/\|/g, "\\|").replace(/\r?\n/g, " ").slice(0, 240);
 }
 
+// Neutralises GitHub @mentions and #issue-refs in free-text so a feedback
+// description cannot trigger notifications or cross-link spam. A zero-width
+// space breaks the auto-link while rendering identically to the reader.
+function mdNeutralizeBody(s) {
+  const ZWSP = String.fromCharCode(0x200B);
+  return String(s == null ? "" : s)
+    .replace(/@(?=[A-Za-z0-9_-])/g, "@" + ZWSP)
+    .replace(/(^|[^\w`])#(?=\d)/g, "$1#" + ZWSP);
+}
+
 async function handleFeedback(request, origin, env) {
   if (origin && !allowedOrigins(env).has(origin)) {
     return jsonResponse(403, "origin_not_allowed", "Origin is not allowed", origin, env);
   }
   if (!env.GITHUB_TOKEN) {
     return jsonResponse(503, "github_not_configured", "Feedback endpoint is not configured", origin, env);
+  }
+  // Auth: same app proxy secret as /v1/messages. Closes the open GitHub-issue
+  // spam vector (the endpoint used to be reachable without any credential).
+  const proxyToken = request.headers.get("x-app-proxy-secret") || "";
+  if (!env.NUTRITRACK_PROXY_TOKEN || proxyToken !== env.NUTRITRACK_PROXY_TOKEN) {
+    return jsonResponse(401, "unauthorized", "Invalid app proxy secret", origin, env);
+  }
+  // Defense in depth: cap feedback submissions per IP per day (best-effort KV).
+  if (env.SHARE_KV) {
+    const ip = request.headers.get("cf-connecting-ip") || "unknown";
+    const day = new Date().toISOString().slice(0, 10);
+    const rlKey = "fbrl:" + ip + ":" + day;
+    const cnt = parseInt((await env.SHARE_KV.get(rlKey)) || "0", 10) || 0;
+    if (cnt >= MAX_FEEDBACK_PER_IP_DAY) {
+      return jsonResponse(429, "rate_limited", "Too many feedback submissions today", origin, env);
+    }
+    await env.SHARE_KV.put(rlKey, String(cnt + 1), { expirationTtl: 60 * 60 * 24 });
   }
   const repo = ((env.GITHUB_REPO || FEEDBACK_DEFAULT_REPO) + "").trim();
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
@@ -454,7 +486,7 @@ async function handleFeedback(request, origin, env) {
     `**Typ:** ${isBug ? "🐛 Bug" : "💡 Änderungswunsch"}`,
     "",
     "### Beschreibung",
-    description,
+    mdNeutralizeBody(description),
     "",
     "### Kontext",
     "| Feld | Wert |",
@@ -508,6 +540,7 @@ async function handleFeedback(request, origin, env) {
 const WORKOUT_TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days
 const MAX_WORKOUT_BODY_BYTES = 1024 * 4; // 4 KB
 const MAX_WORKOUT_LIST_LIMIT = 200;
+const MAX_WORKOUT_LIST_PAGES = 20; // safety bound: up to 4000 keys per request
 const USER_TOKEN_RE = /^[A-Za-z0-9_-]{24,64}$/;
 const WORKOUT_ID_RE = /^[A-Za-z0-9_.:-]{1,80}$/;
 const WORKOUT_KV_PREFIX = "wo:";
@@ -603,12 +636,28 @@ async function handleWorkoutList(request, origin, env) {
   const since = Number(sinceRaw);
   const sinceMs = Number.isFinite(since) && since > 0 ? since : 0;
   const prefix = WORKOUT_KV_PREFIX + token + ":";
-  const list = await env.SHARE_KV.list({ prefix, limit: MAX_WORKOUT_LIST_LIMIT });
+  // Page through the whole namespace via cursor so tokens with >200 workouts
+  // don't silently lose older entries. Bounded by MAX_WORKOUT_LIST_PAGES.
+  const candidateKeys = [];
+  let cursor;
+  let pages = 0;
+  let complete = false;
+  do {
+    const list = await env.SHARE_KV.list({ prefix, limit: MAX_WORKOUT_LIST_LIMIT, cursor });
+    for (const k of list.keys) {
+      const meta = k.metadata && typeof k.metadata === "object" ? k.metadata : null;
+      if (sinceMs && meta && Number.isFinite(meta.startMs) && meta.startMs <= sinceMs) continue;
+      candidateKeys.push(k.name);
+    }
+    complete = list.list_complete !== false;
+    cursor = list.cursor;
+    pages++;
+  } while (!complete && cursor && pages < MAX_WORKOUT_LIST_PAGES);
+
+  // Fetch the surviving keys in parallel (KV has no batch-get).
+  const raws = await Promise.all(candidateKeys.map((name) => env.SHARE_KV.get(name)));
   const workouts = [];
-  for (const k of list.keys) {
-    const meta = k.metadata && typeof k.metadata === "object" ? k.metadata : null;
-    if (sinceMs && meta && Number.isFinite(meta.startMs) && meta.startMs <= sinceMs) continue;
-    const raw = await env.SHARE_KV.get(k.name);
+  for (const raw of raws) {
     if (!raw) continue;
     let parsed;
     try {
@@ -623,7 +672,7 @@ async function handleWorkoutList(request, origin, env) {
   return jsonResponse(200, "ok", "ok", origin, env, {
     workouts,
     count: workouts.length,
-    truncated: Boolean(list.list_complete === false),
+    truncated: Boolean(!complete),
   });
 }
 
@@ -672,7 +721,8 @@ export default {
         shareConfigured: Boolean(env.SHARE_KV),
         feedbackConfigured: Boolean(env.GITHUB_TOKEN),
         workoutsConfigured: Boolean(env.SHARE_KV),
-        codeVersion: "v0.158-workouts",
+        decoderSecretConfigured: Boolean(env.DECODER_SECRET),
+        codeVersion: "v0.182-hardening",
       });
     }
 


### PR DESCRIPTION
Behebt die Befunde einer vollständigen Code-Analyse über alle Dateien (`index.html`, `picker.js`, `worker/src/index.js`, `js/health-sync.js`, `sw.js`, `decoder/`).

## 🔴 Sicherheit (XSS — das Kernthema)
- Globaler `esc()` in `index.html` + `_esc()` in `picker.js` escapen jetzt **alle** per `innerHTML` ausgegebenen Namen/Freitexte aus untrusted Quellen:
  - Import-Payloads (`_previewImport`) — geteilte Codes/Links sind voll angreiferkontrolliert
  - OpenFoodFacts-Produktnamen, KI-Antworten, Such-/Bibliothek-Treffer, Ampel-Texte

## 🟠 Backend-Sicherheit (Worker / Decoder)
- `/feedback` verlangt jetzt `x-app-proxy-secret` (Client sendet `getProxySecret()`) + IP-Tageslimit (30/Tag) → schließt den offenen GitHub-Issue-Spam-Vektor
- `mdNeutralizeBody` neutralisiert @-Mentions/#-Refs in der Feedback-Beschreibung
- Decoder optional per `DECODER_SECRET` / `X-Decoder-Secret` absicherbar (beidseitig setzen; unset = backward-kompatibel offen)

## 🟡 Echte Bugs
- `picker.js`: `rememberPortion(f.name, amt)` statt `f.amount` (war `undefined` → Portionsgedächtnis aus der Suche wurde nie gespeichert)
- `sw.js`: Pre-Caching der Kern-Assets in `install` (echte Offline-Erstnutzung); beide Offline-Fallbacks awaiten das `caches.match`-Promise korrekt (vorher `Promise || Promise`-Bug)
- Worker `/workouts`: Cursor-Pagination + parallele KV-Reads → kein Datenverlust mehr bei >200 Workouts pro Token

## 🟢 Cleanup
- Toter Code entfernt: `toggleEye`, `shareCustomFood`, `triggerBackupDownload`, `pickerOnAdd`, `_pickerIngCallbacks`
- Debug-`console.log` raus; stiller Barcode-Fehlerpfad zeigt jetzt Toast
- `pickerLinkAdd` nutzt das von `_pickerAdd` zurückgegebene Rezept statt `recipes[0]`

## Deployment-Hinweise
- **PWA** deployt automatisch über GitHub Pages
- **Worker neu deployen** (`wrangler deploy` in `worker/`), damit Feedback-Auth, `/workouts`-Pagination und Mention-Neutralisierung live gehen
- **Decoder-Secret ist optional** — nur aktiv, wenn `DECODER_SECRET` auf Cloud Run *und* als Worker-Secret gesetzt wird

## Tests
Syntax-Checks bestehen für alle JS-Dateien (inkl. Inline-Scripts in `index.html`), den Worker (als ESM) und `decoder/main.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EatiB2D4HfCKD3bw61Wamn)_