### PR TITLE
v0.185: Picker-Chat Kaffee→Cappuccino per Few-Shot-Prompt (#127)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.184 (2026-06-19)
+**Stand:** v0.185 (2026-06-19)
 
 ## URLs
 
@@ -25,7 +25,8 @@
 - **Payload-Schema (base64-JSON):** `{t:'r'|'f'|'m', …}`.
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
-- **Picker Chat (v0.175–v0.177):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten gehen an `claude-sonnet-4-6` (mit Foto als Image-Content, ohne Foto als reiner Text-Parse). Haiku reichte für den Text-Parse nicht — es ignorierte die Negativ-Regel „genanntes Lebensmittel nicht aufwerten" (Kaffee→Cappuccino, #127). Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (tokenisierte Fuzzy-Suche **nur** über Rezepte + Custom Foods, max 6 Treffer) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus. Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`. `DEFAULT_CHAT_PROMPT` (`index.html`, `PROMPT_VERSION='5'`): ausdrücklich genannte Lebensmittel behalten exakt ihren Begriff — kein eigenmächtiges Aufwerten zu einer reichhaltigeren/kombinierten Variante (Kaffee bleibt Kaffee, nicht Cappuccino), separat genannte Milch gehört nicht zusätzlich ins Grundprodukt (#127).
+- **Picker Chat (v0.175–v0.177):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto `claude-haiku-4-5`. Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (tokenisierte Fuzzy-Suche **nur** über Rezepte + Custom Foods, max 6 Treffer) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus. Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`.
+- **Picker Chat Prompt — Few-Shot (v0.185):** `DEFAULT_CHAT_PROMPT` (`index.html`, `PROMPT_VERSION='6'`) arbeitet mit **Few-Shot-Beispielen** statt nur abstrakter Regeln — Haiku (`temperature:0`) befolgte die reine Negativ-Regel nicht und wertete „Kaffee" zu „Cappuccino" auf (#127). Das erste Beispiel demonstriert genau diesen Fall (Kaffee + Hafer-/Sojamilch bleiben getrennt, kein Cappuccino), ein weiteres lehrt das Aufschlüsseln echter Gerichtsnamen (Hamburger → Bestandteile). Bewusst **kein** Modell-Upgrade und **keine** deterministische Nachkorrektur/Lebensmittel-Tabelle.
 - **Picker Chat Fuzzy-Suche (v0.176/v0.177/v0.178):** `_pickerFold` (ä→a, ö→o, ü→u, ß→s) + `_pickerTok` (Stoppwörter: mit/und/von/der/die/das/im/in/zum/zur/an/am/auf/bei/zu/…) + `_pickerLev` (Levenshtein) + `_pickerScoreName`. **Alle** Query-Tokens müssen treffen (sonst Score 0) — kein „Joghurt Natur"-Treffer mehr für „Joghurt mit Früchten". Pro-Token-Score: === +5, startsWith +4, includes +3, Levenshtein ≤1 (Länge 5–7) bzw. ≤2 (Länge ≥8) +1–2 — kein Levenshtein unter Länge 5, sonst Distraktoren wie „kaffee"↔„waffel" (#117). Voller-Query-Substring zusätzlich +10. Rezepte werden um +10 geboostet vor Custom Foods (+6). Cache und eingebaute DB werden im Chat-Tab nicht durchsucht.
 - **Layout-Fixes (v0.167):** bnav `margin:0 14px` → `margin:0 0` (horizontale Margins verursachten 14 px Rechtsversatz bei `position:fixed`+`left:50%`+`translateX(-50%)`). iOS PWA: `focusout`-Handler setzt `window.scrollTo(0,0)` nach Tastatur-Dismiss (nur `_isIos()&&_isPwaStandalone()`).
 - **iOS Safe-Area-Top (v0.168):** `.hdr` und `#mealDetailScreen .md-head` erhalten `padding-top: calc(…px + env(safe-area-inset-top, 0px))` — Screen-Header-Buttons auf allen Screens unterhalb der iOS Status-Bar / Dynamic Island (#104).
@@ -67,7 +68,7 @@
 
 ## Live-Test offen
 
-- v0.184 Picker Chat: „Kaffee mit Hafermilch und Sojamilch" tippen → KI (jetzt Sonnet) listet „Kaffee" (schwarz) + Hafermilch + Sojamilch, keinen Cappuccino (#127)
+- v0.185 Picker Chat: „Kaffee mit Hafermilch und Sojamilch" tippen → KI (Haiku, Few-Shot-Prompt) listet „Kaffee" (schwarz) + Hafermilch + Sojamilch, keinen Cappuccino (#127)
 - v0.182 Offline: App installieren, sofort offline öffnen → lädt aus Cache (Pre-Caching); Feedback-Senden funktioniert weiter (Client sendet jetzt `x-app-proxy-secret`); Portion über Suche hinzufügen → Menge wird beim nächsten Mal vorgeschlagen (rememberPortion-Fix). Optional: Worker neu deployen (`wrangler deploy` in `worker/`); Decoder-Secret nur wenn `DECODER_SECRET` beidseitig gesetzt
 - v0.180 Picker: KI-Limit/Überlast/offline → deutsche Meldung statt englischem Roh-Text im Chat- und Foto-Tab (#121)
 - v0.181 Wiederkehrende Mahlzeit: Mahlzeit → „🔁 Wiederholen" → Mo–Fr speichern; am nächsten Werktag automatisch eingetragen (🔁-Badge); löschen an einem Tag → kommt dort nicht zurück; „Mehr → 🔁" pausieren/löschen (#122)
@@ -91,11 +92,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.180 | #123 | Picker: freundliche deutsche KI-Fehlermeldung statt englischem Roh-Text (#121) |
 | v0.181 | #124 | Wiederkehrende Mahlzeiten: automatisch an festen Wochentagen eintragen (#122) |
 | v0.182 | #125 #126 | Härtung: XSS-Escaping, SW-Pre-Caching, Feedback-Auth+Rate-Limit, /workouts-Pagination, Decoder-Secret, rememberPortion-Fix |
 | v0.183 | #128 | Picker Chat: Prompt-Regel gegen Aufwerten genannter Lebensmittel (#127) |
-| v0.184 | — | Picker Chat: Text-Parse auf Sonnet hochgezogen, da Haiku die Regel ignorierte — „Kaffee" bleibt Kaffee statt Cappuccino (#127) |
+| v0.184 | #130 | Picker Chat: Text-Parse kurzzeitig auf Sonnet (in v0.185 zurückgenommen) (#127) |
+| v0.185 | — | Picker Chat: Few-Shot-Prompt löst Kaffee→Cappuccino ohne stärkeres Modell, zurück auf Haiku (#127) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.184</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.185</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1965,7 +1965,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.184';
+var APP_VERSION='0.185';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 // HTML-Escaping für alle Namen/Freitexte aus untrusted Quellen (Import-Payloads,
 // OpenFoodFacts, KI-Antworten), die per innerHTML eingefügt werden — schützt vor XSS.
@@ -1997,8 +1997,8 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
-  {v:'0.184',items:[
-    {icon:'🐛',text:'Picker · Chat: Die Zutaten-Erkennung im Text-Chat nutzt jetzt das stärkere KI-Modell. „Kaffee mit Hafermilch und Sojamilch" wird damit korrekt als Kaffee (schwarz) + Hafermilch + Sojamilch erkannt statt als Cappuccino. (#127)',where:'Picker · Chat'},
+  {v:'0.185',items:[
+    {icon:'🐛',text:'Picker · Chat: Die Zutaten-Erkennung versteht jetzt zuverlässig, dass genannte Lebensmittel genau so übernommen werden. „Kaffee mit Hafermilch und Sojamilch" ergibt korrekt Kaffee (schwarz) + Hafermilch + Sojamilch statt Cappuccino. (#127)',where:'Picker · Chat'},
   ]},
   {v:'0.183',items:[
     {icon:'🐛',text:'Picker · Chat: Genannte Lebensmittel werden nicht mehr eigenmächtig „aufgewertet". Tippst du z. B. „Kaffee mit Hafermilch und Sojamilch", bleibt Kaffee jetzt Kaffee (schwarz) — statt fälschlich als Cappuccino erkannt zu werden. (#127)',where:'Picker · Chat'},
@@ -2264,9 +2264,9 @@ var CHANGELOG=[
 // Default prompts - editable in settings
 var DEFAULT_FOTO_PROMPT='Analysiere dieses Bild auf Deutsch. Es kann ein Essensfoto ODER ein Screenshot einer Tracking-App (z.B. MyFitnessPal, Cronometer, Yazio, Samsung Health) sein.\n\nGib ein JSON-Objekt zurueck:\n{"rezept":"Gesamtgerichtname auf Deutsch","zutaten":[{"name":"Zutat auf Deutsch","emoji":"Emoji","g":GRAMM}]}\n\nFall 1 – Essensfoto:\n- zutaten: erkenne was SICHTBAR auf dem Teller/Bild liegt\n- Nenne das fertige Lebensmittel, nicht seine Rohzutaten\n- 1 Einheit schatzen (Nutzer gibt Menge selbst an)\n- Logisch notwendige Beilagen erganzen\n\nFall 2 – Screenshot einer Tracking-App oder Ernaehrungsuebersicht:\n- Lies ALLE eingetragenen Lebensmittel/Gerichte mit den angezeigten Gramm-/Portionsangaben aus\n- Falls kcal/Naehrwerte sichtbar: nutze diese fuer realistischere Schatzung\n- rezept: Name der Mahlzeit oder "Import aus App"\n\nFall 3 – Einkaufszettel / Zutatenliste:\n- Liste alle Zutaten mit typischen Mengen auf\n\nAllgemein:\n- Realistische Gramm pro Einheit\n- Alle Namen auf Deutsch\n- Wenn nichts erkennbar: {"rezept":"","zutaten":[]}';
 
-var DEFAULT_CHAT_PROMPT='Nutzer hat gegessen: {MSG}\nZerlege in einzelne Zutaten.\nRegeln:\n- Werden einzelne Lebensmittel genannt (z.B. "Brot mit Kaese, Senf, Schinken"): NUR die genannten Zutaten listen, nichts erganzen\n- Verwende fuer ausdruecklich genannte Lebensmittel exakt den genannten Begriff - ersetze ihn NICHT durch eine reichhaltigere oder bereits kombinierte Variante (z.B. "Kaffee" bleibt "Kaffee" / schwarz, nicht Cappuccino oder Latte; "Brot" bleibt "Brot", nicht belegtes Broetchen). Wird Milch separat genannt, gehoert sie NICHT zusaetzlich in das genannte Grundprodukt hinein\n- Wird ein Gericht oder Rezept genannt (z.B. "Hamburger", "Aperol Spritz"): typische Bestandteile als fertige Produkte aufschluesseln\n- Immer fertige Produkte, keine Rohzutaten (Butterkeks nicht Butter)\n- Immer nur 1 Einheit schatzen - Nutzer gibt Menge selbst an\n- Realistische Gramm-Schatzung fuer 1 Einheit\n- Namen auf Deutsch\n- Format: [{"name":"Deutscher Name","emoji":"Emoji","g":80}]';
+var DEFAULT_CHAT_PROMPT='Du zerlegst eine Mahlzeit in Zutaten und gibst NUR ein JSON-Array zurueck: [{"name":"Deutscher Name","emoji":"Emoji","g":80}]\n\nRegeln:\n- Werden einzelne Lebensmittel genannt: jedes GENAU so uebernehmen wie genannt - nicht umbenennen, nicht zu einer reichhaltigeren Variante zusammenfassen, nichts ergaenzen. Separat genannte Milch gehoert NICHT in ein anderes Getraenk hinein.\n- Nur bei einem echten Gericht- oder Rezeptnamen (z.B. Hamburger, Aperol Spritz) in typische fertige Bestandteile aufschluesseln.\n- Immer fertige Produkte, keine Rohzutaten (Butterkeks nicht Butter).\n- Immer nur 1 Einheit schaetzen, realistische Gramm. Namen auf Deutsch.\n\nBeispiele:\nEingabe: Kaffee mit Hafermilch und Sojamilch\nAusgabe: [{"name":"Kaffee","emoji":"☕","g":200},{"name":"Hafermilch","emoji":"🥛","g":50},{"name":"Sojamilch","emoji":"🥛","g":50}]\nEingabe: Brot mit Kaese und Schinken\nAusgabe: [{"name":"Brot","emoji":"🍞","g":50},{"name":"Kaese","emoji":"🧀","g":20},{"name":"Schinken","emoji":"🥓","g":25}]\nEingabe: Hamburger\nAusgabe: [{"name":"Burger-Broetchen","emoji":"🍔","g":80},{"name":"Rinderhackfleisch","emoji":"🥩","g":100},{"name":"Salat","emoji":"🥬","g":15},{"name":"Tomate","emoji":"🍅","g":20}]\n\nEingabe: {MSG}\nAusgabe:';
 
-var PROMPT_VERSION='5';
+var PROMPT_VERSION='6';
 function getFotoPrompt(){
   // Reset if prompt version changed
   if(localStorage.getItem('nt_prompt_ver')!==PROMPT_VERSION){

--- a/picker.js
+++ b/picker.js
@@ -1245,9 +1245,7 @@ function pickerChatKiFallback(msg){
   var content=hasPhoto
     ?[{type:'image',source:{type:'base64',media_type:'image/jpeg',data:window._pickerPhotoB64}},{type:'text',text:getChatPrompt().replace('{MSG}',msg)}]
     :[{type:'text',text:getChatPrompt().replace('{MSG}',msg)}];
-  // Sonnet auch für Text-Parse: Haiku ignorierte die Negativ-Regel "genanntes
-  // Lebensmittel nicht aufwerten" (z.B. Kaffee→Cappuccino, #127).
-  var model='claude-sonnet-4-6';
+  var model=hasPhoto?'claude-sonnet-4-6':'claude-haiku-4-5';
   callClaude(model,content,300,
     function(text){
       var raw=parseIngJSON(text);

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.184';
+var VERSION = '0.185';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur


### PR DESCRIPTION
## Issue #127 — kreative Lösung ohne stärkeres Modell

**Vorgeschichte:** v0.183 (abstrakte Negativ-Regel) half nicht — Haiku erkannte „Kaffee mit hafermilch und sojamilch" weiter als Cappuccino (deterministisch, `temperature:0`). v0.184 (Sonnet) funktionierte, war aber unerwünscht.

**Diese Lösung (v0.185):**
- **Modell zurück auf `claude-haiku-4-5`** (Foto-Chat bleibt Sonnet).
- `DEFAULT_CHAT_PROMPT` arbeitet jetzt mit **Few-Shot-Beispielen** statt nur Regeln. Kleine Modelle befolgen *Demonstrationen* deutlich zuverlässiger als abstrakte Verbote. Das erste Beispiel ist exakt der Fehlerfall (Kaffee + Hafer-/Sojamilch bleiben getrennt, kein Cappuccino); ein weiteres lehrt, dass echte Gerichtsnamen (Hamburger) *doch* aufgeschlüsselt werden.
- **Kein** Modell-Upgrade, **keine** deterministische Nachkorrektur, **keine** Lebensmittel-Tabelle — nur 3 lehrende Beispiele, die das Muster generalisieren.

`PROMPT_VERSION` 5→6, Versions-Bump 0.184→0.185, CHANGELOG, `UEBERGABE.md`.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VDPp83t5Ax1bUUUS9pe35)_