### PR TITLE
v0.186: Kaffee→Cappuccino — echte Ursache war DB-Synonym (#127)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.185 (2026-06-19)
+**Stand:** v0.186 (2026-06-19)
 
 ## URLs
 
@@ -26,7 +26,8 @@
 - **OneDrive Reconnect (v0.159):** `_odGetToken()` unterscheidet Auth-Fehler (`invalid_grant`, `interaction_required`, `unauthorized_client`) von Netzwerkfehlern — nur bei echten Auth-Fehlern werden Tokens gelöscht + sofort `odReconnectOv`-Modal geöffnet (Bottom-Sheet, `.ov`-Klasse, `_odShowReconnect()`). Netzwerkfehler löschen Tokens nicht mehr.
 - **OneDrive Autospeicher-Fix (v0.159):** Doppelte `_odAutoSync()`-Definition entfernt — die zweite Definition (rief `oneDriveSyncUp()` auf) überschrieb die erste (rief `oneDriveSyncSlot()` auf). Jetzt wird täglich korrekt ein Autospeicher-Slot gefüllt.
 - **Picker Chat (v0.175–v0.177):** Foto-Tab und Chat-Tab vollständig entkoppelt. Chat-Nachrichten mit aktivem Foto (`window._pickerPhotoB64`) gehen als Image-Content an `claude-sonnet-4-6`; ohne Foto `claude-haiku-4-5`. Reihenfolge: `pickerSendChat` → `pickerChatLocalSearch(msg)` (tokenisierte Fuzzy-Suche **nur** über Rezepte + Custom Foods, max 6 Treffer) → Treffer als Karten via `pickerChatAddLocal(i)`; bei 0 Treffern oder Klick auf „🤖 Stattdessen KI fragen" → `pickerChatKiFallback(msg)`. Rezept-Treffer landen direkt in der Mahlzeit + `closePicker()`; per100-Treffer setzen `pickerIngredients` und rendern die Zutaten-Liste. OFT-Anbindung im Chat ist raus. Lokale Suche funktioniert offline; KI-Fallback verlangt `isOnline`.
-- **Picker Chat Prompt — Few-Shot (v0.185):** `DEFAULT_CHAT_PROMPT` (`index.html`, `PROMPT_VERSION='6'`) arbeitet mit **Few-Shot-Beispielen** statt nur abstrakter Regeln — Haiku (`temperature:0`) befolgte die reine Negativ-Regel nicht und wertete „Kaffee" zu „Cappuccino" auf (#127). Das erste Beispiel demonstriert genau diesen Fall (Kaffee + Hafer-/Sojamilch bleiben getrennt, kein Cappuccino), ein weiteres lehrt das Aufschlüsseln echter Gerichtsnamen (Hamburger → Bestandteile). Bewusst **kein** Modell-Upgrade und **keine** deterministische Nachkorrektur/Lebensmittel-Tabelle.
+- **Picker Chat „Kaffee→Cappuccino" (v0.186, eigentliche Ursache, #127):** Lag **nicht** an KI/Prompt/Modell, sondern an einem Daten-Bug in der eingebauten DB (`var DB=[…]` in `index.html`): der `Cappuccino`-Eintrag beanspruchte `s:'kaffee'` als Synonym, der schwarze Kaffee hatte nur `'coffee espresso'`. `findInLocalDB(name)` (exakter Name → Synonym → startsWith) löste „Kaffee" daher deterministisch zu Cappuccino auf und `lookupNutrients` überschreibt den Namen mit `loc.n`. Fix: `'kaffee'` zum schwarzen Kaffee verschoben, Cappuccino bekam `'milchkaffee cappucino'`. **Lehre:** Bei „falsch erkanntem" Lebensmittel zuerst `findInLocalDB`/DB-Synonyme prüfen, nicht den KI-Prompt.
+- **Picker Chat Prompt — Few-Shot (v0.185):** `DEFAULT_CHAT_PROMPT` (`index.html`, `PROMPT_VERSION='6'`) nutzt **Few-Shot-Beispiele** statt nur abstrakter Regeln (Demonstrationen wirken bei Haiku zuverlässiger). Hilft, dass die KI getrennte Lebensmittel sauber liefert und echte Gerichtsnamen aufschlüsselt — war aber nicht die Ursache von #127 (siehe DB-Fix oben).
 - **Picker Chat Fuzzy-Suche (v0.176/v0.177/v0.178):** `_pickerFold` (ä→a, ö→o, ü→u, ß→s) + `_pickerTok` (Stoppwörter: mit/und/von/der/die/das/im/in/zum/zur/an/am/auf/bei/zu/…) + `_pickerLev` (Levenshtein) + `_pickerScoreName`. **Alle** Query-Tokens müssen treffen (sonst Score 0) — kein „Joghurt Natur"-Treffer mehr für „Joghurt mit Früchten". Pro-Token-Score: === +5, startsWith +4, includes +3, Levenshtein ≤1 (Länge 5–7) bzw. ≤2 (Länge ≥8) +1–2 — kein Levenshtein unter Länge 5, sonst Distraktoren wie „kaffee"↔„waffel" (#117). Voller-Query-Substring zusätzlich +10. Rezepte werden um +10 geboostet vor Custom Foods (+6). Cache und eingebaute DB werden im Chat-Tab nicht durchsucht.
 - **Layout-Fixes (v0.167):** bnav `margin:0 14px` → `margin:0 0` (horizontale Margins verursachten 14 px Rechtsversatz bei `position:fixed`+`left:50%`+`translateX(-50%)`). iOS PWA: `focusout`-Handler setzt `window.scrollTo(0,0)` nach Tastatur-Dismiss (nur `_isIos()&&_isPwaStandalone()`).
 - **iOS Safe-Area-Top (v0.168):** `.hdr` und `#mealDetailScreen .md-head` erhalten `padding-top: calc(…px + env(safe-area-inset-top, 0px))` — Screen-Header-Buttons auf allen Screens unterhalb der iOS Status-Bar / Dynamic Island (#104).
@@ -68,7 +69,7 @@
 
 ## Live-Test offen
 
-- v0.185 Picker Chat: „Kaffee mit Hafermilch und Sojamilch" tippen → KI (Haiku, Few-Shot-Prompt) listet „Kaffee" (schwarz) + Hafermilch + Sojamilch, keinen Cappuccino (#127)
+- v0.186 Picker Chat: „Kaffee mit Hafermilch" tippen → erste Zutat ist „Kaffee (schwarz)" (≈2 kcal), **kein** Cappuccino; Cappuccino bleibt über „Cappuccino"/„Milchkaffee" auffindbar (#127)
 - v0.182 Offline: App installieren, sofort offline öffnen → lädt aus Cache (Pre-Caching); Feedback-Senden funktioniert weiter (Client sendet jetzt `x-app-proxy-secret`); Portion über Suche hinzufügen → Menge wird beim nächsten Mal vorgeschlagen (rememberPortion-Fix). Optional: Worker neu deployen (`wrangler deploy` in `worker/`); Decoder-Secret nur wenn `DECODER_SECRET` beidseitig gesetzt
 - v0.180 Picker: KI-Limit/Überlast/offline → deutsche Meldung statt englischem Roh-Text im Chat- und Foto-Tab (#121)
 - v0.181 Wiederkehrende Mahlzeit: Mahlzeit → „🔁 Wiederholen" → Mo–Fr speichern; am nächsten Werktag automatisch eingetragen (🔁-Badge); löschen an einem Tag → kommt dort nicht zurück; „Mehr → 🔁" pausieren/löschen (#122)
@@ -95,8 +96,8 @@
 | v0.181 | #124 | Wiederkehrende Mahlzeiten: automatisch an festen Wochentagen eintragen (#122) |
 | v0.182 | #125 #126 | Härtung: XSS-Escaping, SW-Pre-Caching, Feedback-Auth+Rate-Limit, /workouts-Pagination, Decoder-Secret, rememberPortion-Fix |
 | v0.183 | #128 | Picker Chat: Prompt-Regel gegen Aufwerten genannter Lebensmittel (#127) |
-| v0.184 | #130 | Picker Chat: Text-Parse kurzzeitig auf Sonnet (in v0.185 zurückgenommen) (#127) |
-| v0.185 | — | Picker Chat: Few-Shot-Prompt löst Kaffee→Cappuccino ohne stärkeres Modell, zurück auf Haiku (#127) |
+| v0.185 | #131 | Picker Chat: Few-Shot-Prompt, zurück auf Haiku (#127) |
+| v0.186 | — | Picker Chat: eigentlicher Fix — DB-Synonym „kaffee" gehörte zum schwarzen Kaffee, nicht zum Cappuccino (#127) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.185</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.186</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1937,7 +1937,7 @@ var DB=[
   {n:'Honig',e:'🍯',k:304,p:0.3,c:82,f:0,s:'honey'},{n:'Marmelade',e:'🍓',k:278,p:0.4,c:69,f:0.1,s:'jam'},
   {n:'Pizza Margherita',e:'🍕',k:266,p:11,c:33,f:10,s:'pizza'},{n:'Hamburger',e:'🍔',k:295,p:17,c:24,f:14,s:'burger'},
   {n:'Pommes Frites',e:'🍟',k:312,p:3.4,c:41,f:15,s:'pommes fries'},{n:'Döner',e:'🥙',k:250,p:15,c:25,f:10,s:'kebab'},
-  {n:'Kaffee (schwarz)',e:'☕',k:2,p:0.3,c:0,f:0,s:'coffee espresso'},{n:'Cappuccino',e:'☕',k:40,p:1.6,c:4,f:1.8,s:'kaffee'},
+  {n:'Kaffee (schwarz)',e:'☕',k:2,p:0.3,c:0,f:0,s:'coffee espresso kaffee'},{n:'Cappuccino',e:'☕',k:40,p:1.6,c:4,f:1.8,s:'milchkaffee cappucino'},
   {n:'Latte Macchiato',e:'☕',k:67,p:3.3,c:6.5,f:3.5,s:'kaffee coffee'},{n:'Tee',e:'🍵',k:1,p:0,c:0.2,f:0,s:'tea'},
   {n:'Orangensaft',e:'🧃',k:45,p:0.7,c:10,f:0.2,s:'saft juice'},{n:'Cola',e:'🥤',k:42,p:0,c:10.6,f:0,s:'coke'},
   {n:'Cola Zero',e:'🥤',k:0,p:0,c:0,f:0,s:'diet'},{n:'Bier',e:'🍺',k:43,p:0.5,c:3.5,f:0,s:'beer'},
@@ -1965,7 +1965,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.185';
+var APP_VERSION='0.186';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 // HTML-Escaping für alle Namen/Freitexte aus untrusted Quellen (Import-Payloads,
 // OpenFoodFacts, KI-Antworten), die per innerHTML eingefügt werden — schützt vor XSS.
@@ -1997,8 +1997,8 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
-  {v:'0.185',items:[
-    {icon:'🐛',text:'Picker · Chat: Die Zutaten-Erkennung versteht jetzt zuverlässig, dass genannte Lebensmittel genau so übernommen werden. „Kaffee mit Hafermilch und Sojamilch" ergibt korrekt Kaffee (schwarz) + Hafermilch + Sojamilch statt Cappuccino. (#127)',where:'Picker · Chat'},
+  {v:'0.186',items:[
+    {icon:'🐛',text:'Picker · Chat: „Kaffee" wird endlich als schwarzer Kaffee erkannt statt als Cappuccino. Ursache war ein falscher Suchbegriff in der internen Lebensmittel-Datenbank (der Cappuccino-Eintrag hatte „kaffee" als Stichwort beansprucht). (#127)',where:'Picker · Chat'},
   ]},
   {v:'0.183',items:[
     {icon:'🐛',text:'Picker · Chat: Genannte Lebensmittel werden nicht mehr eigenmächtig „aufgewertet". Tippst du z. B. „Kaffee mit Hafermilch und Sojamilch", bleibt Kaffee jetzt Kaffee (schwarz) — statt fälschlich als Cappuccino erkannt zu werden. (#127)',where:'Picker · Chat'},

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.185';
+var VERSION = '0.186';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur


### PR DESCRIPTION
## Issue #127 — die tatsächliche Ursache

Nach mehreren Anläufen (Prompt-Regel v0.183, Sonnet v0.184/rückgängig, Few-Shot v0.185) blieb „Kaffee" weiterhin Cappuccino — **byte-identisch**. Grund: Es lag nie an der KI.

**Root Cause:** In der eingebauten Lebensmittel-DB (`var DB=[…]`, `index.html`) beanspruchte der **Cappuccino**-Eintrag `s:'kaffee'` als Synonym, während „Kaffee (schwarz)" nur `'coffee espresso'` hatte. `findInLocalDB("Kaffee")` prüft exakter Name → **Synonyme** → startsWith und traf so deterministisch Cappuccino. `lookupNutrients` überschreibt anschließend den von der KI gelieferten Namen mit dem DB-Treffer (`loc.n`). Daher half weder Prompt noch Modellwechsel.

**Fix (1 Zeile Daten):** `'kaffee'` zum schwarzen Kaffee verschoben; Cappuccino bekommt `'milchkaffee cappucino'`.

Per Simulation gegen die echte DB verifiziert:
- `Kaffee` → **Kaffee (schwarz), 2 kcal** ✓
- `Cappuccino` / `Milchkaffee` → Cappuccino ✓
- `Hafermilch` / `Sojamilch` → korrekt ✓

Versions-Bump 0.185→0.186, CHANGELOG, `UEBERGABE.md` inkl. dokumentierter Ursachen-Lehre („bei falsch erkanntem Lebensmittel zuerst DB-Synonyme prüfen").

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VDPp83t5Ax1bUUUS9pe35)_