### PR TITLE
v0.191: Foto-KI verbessern — Sonnet 4.6, höhere Auflösung, schärferer Prompt

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.190 (2026-06-20)
+**Stand:** v0.191 (2026-06-20)
 
 ## URLs
 
@@ -39,6 +39,7 @@
 - **Picker Foto-Save (v0.179):** Settings-Toggle `S.savePickerPhotos` (Default off) unter „🗂 Daten → 📷 Picker-Fotos". Wenn an, ruft `_pickerSavePhotoIfWanted()` in `_pickerAdd` (vor `closePicker()`) auf — versucht zuerst `navigator.share({files:[File]})` (iOS Safari + Android Chrome unterstützen Files seit iOS 15 / Chrome 89), Fallback `<a download>` (Android: nach `Downloads/`; iOS PWA: nicht garantiert). Hinweis-Zeile `#pickerPhotoSaveHint` unter `pickerPrevWrap` zeigt Status und navigiert tippbar zu Einstellungen/Daten. Web-Capture (`<input capture>`) legt das Foto sonst weder auf iOS noch zuverlässig auf Android in die Galerie (#118).
 - **Wiederkehrende Mahlzeiten (v0.181):** `S.recurringMeals[]` = `{id,name,meal,weekdays:[0..6 JS-getDay],entries[],startDate,active}`. Anlegen über `mealDetailScreen`-CTA „🔁 Wiederholen" (`#mdRecur`→`openRecurCreate`) → `recurCreateOv` mit Wochentag-Chips (Default Mo–Fr). `applyRecurringMeals(dateKey)` fügt aktive Regeln idempotent ein: pro Tag merkt `day._recurMarks[]` angewandte Regel-IDs → keine Doppel, und gelöschte Einträge kommen am selben Tag nicht zurück. Eingefügte Einträge tragen `_recurId` (🔁-Badge in Eintrags-Listen). Hooks: Boot (`ensureRecurringForCurrentDay`), `changeDay`, `goToDay`. Verwaltung „Mehr → 🔁 Wiederkehrende Mahlzeiten" (`openRecurManage`/`recurMgmtOv`): Aktiv/Pause + Löschen. `startDate=today` → nicht rückwirkend; Zukunft ausgeschlossen.
 - **Härtung (v0.182):** Globaler `esc()` in `index.html` + `_esc()` in `picker.js` escapen alle per `innerHTML` ausgegebenen Namen/Freitexte aus untrusted Quellen (Import-Payloads, OpenFoodFacts, KI-Antworten) → kein XSS mehr. SW `install` cacht `CORE_ASSETS` vorab (`./`,`index.html`,`picker.js`,`js/health-sync.js`,`manifest.json`,`icon.svg`, best-effort `allSettled`) → echte Offline-Erstnutzung; Offline-Fallbacks awaiten jetzt das `caches.match`-Promise korrekt. Worker `/feedback` verlangt `x-app-proxy-secret` (Client sendet `getProxySecret()`) + IP-Tages-Limit (`fbrl:<ip>:<tag>`, 30/Tag) + `mdNeutralizeBody` neutralisiert @-Mentions/#-Refs in der Beschreibung. `/workouts` paginiert via Cursor (bis 20 Seiten) + parallele KV-Reads → kein Datenverlust bei >200 Workouts. Decoder optional per `DECODER_SECRET`/`X-Decoder-Secret` absicherbar (beidseitig setzen; unset = offen). Bugfix `rememberPortion(f.name,amt)` (vorher `f.amount`=undefined). Toter Code entfernt (`toggleEye`,`shareCustomFood`,`triggerBackupDownload`,`pickerOnAdd`,`_pickerIngCallbacks`).
+- **Picker Foto-Analyse (v0.191):** `pickerAnalyze` (`picker.js`) skaliert das Foto auf **max. 1280 px** (JPEG 0.85) und ruft **`claude-sonnet-4-6`** mit `max_tokens:1024`, `temperature:0` und `getFotoPrompt()` auf. `getFotoPrompt()` liefert immer `DEFAULT_FOTO_PROMPT` (kein localStorage-Override) — Prompt-Änderungen greifen sofort, kein `PROMPT_VERSION`-Bump nötig. Prompt-Regeln: nur sichtbare Lebensmittel (keine Halluzination), Komponenten getrennt, höchstens eine verdeckte Beilage, Portions-Schätzung über Referenzgrößen, bei Screenshots angezeigte Gramm/kcal **exakt** übernehmen. `processOfflineQueue()` ruft denselben `pickerAnalyze`-Pfad → profitiert mit. Foto-Tab und Chat-mit-Foto (`claude-sonnet-4-6`) nutzen damit dasselbe aktuelle Modell.
 - **Picker KI-Fehlertexte (v0.180):** `pickerFriendlyAiError(err)` in `picker.js` mappt bekannte KI-/Proxy-Fehler (Kontingent/Billing, overloaded/rate-limit/429/529, nicht konfiguriert, offline) auf deutsche Texte; unbekannte Fehler unverändert. Genutzt in `pickerChatKiFallback` + Foto-Analyse-`onErr` (#121).
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
@@ -83,6 +84,7 @@
 - v0.159 OneDrive Reconnect-Modal: Token ablaufen lassen (oder manuell `_odClearTokens()` in DevTools), dann sync triggern → `odReconnectOv` muss aufgehen; „Neu verbinden" startet PKCE-Flow neu
 - v0.160 Mehr-Screen: Bibliothek-Row tippen → öffnet direkt Bibliothek (nicht allg. Einstellungen); Einstellungen hat keinen 📚-Tab mehr; Layout auf Android korrekt
 - v0.162 Feedback-Screenshot: Picker/Overlay offen → Feedback → Screenshot → Bild zeigt aktiven Overlay, nicht mainScreen
+- v0.191 Foto-Analyse: Teller mit mehreren Komponenten (z.B. Schnitzel + Pommes + Salat) wird in getrennte Zutaten zerlegt; App-Screenshot (MyFitnessPal o.ä.) übernimmt angezeigte Gramm/kcal exakt; Modell `claude-sonnet-4-6`, 1280px, 1024 Token
 - v0.163 Chat + Foto: Foto analysieren → Chat öffnet sich → Rückfrage stellen mit Foto-Kontext möglich
 - v0.168 iOS: mealDetailScreen und alle anderen Screens — Buttons im Header tippbar trotz Dynamic Island / Status-Bar (#104)
 - v0.169 Trends: Kcal-Durchschnitt ohne heutigen Tag; KI-Bericht mit Stichpunkten + Zielrichtung + Empfehlung (#102 #103)
@@ -98,11 +100,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.185 | #131 | Picker Chat: Few-Shot-Prompt, zurück auf Haiku (#127) |
 | v0.186 | — | Picker Chat: eigentlicher Fix — DB-Synonym „kaffee" gehörte zum schwarzen Kaffee, nicht zum Cappuccino (#127) |
 | v0.187 | #133 | Einstellungen aufgeräumt: „Daten"-Tab → „🤖 KI" + „💾 Backup", Picker-Foto-Toggle zu Ernährung, doppelte Lebensmittel-Liste raus, Hilfe-Dedup, OneDrive-Banner-Label |
 | v0.188 | — | Fix: verrutschter „+ Hinzufügen"-Button im Ernährung-Tab (war volle Breite, drückte das Eingabefeld platt) (#134) |
 | v0.190 | — | Picker Chat: Lebensmittel-Erkennung generell robust — gehärteter Prompt + Sackgassen-Fallback statt „Konnte nicht parsen" (#135) |
+| v0.191 | — | Foto-Analyse: aktuelles Modell (Sonnet 4.6), höhere Auflösung (1280px), mehr Token, geschärfter Prompt |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -656,7 +656,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.190</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.191</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -976,7 +976,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.190</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.191</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1965,7 +1965,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.190';
+var APP_VERSION='0.191';
 var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
 // HTML-Escaping für alle Namen/Freitexte aus untrusted Quellen (Import-Payloads,
 // OpenFoodFacts, KI-Antworten), die per innerHTML eingefügt werden — schützt vor XSS.
@@ -1997,6 +1997,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.191',items:[
+    {icon:'📷',text:'Foto-Erkennung verbessert: Die Bild-Analyse nutzt jetzt das aktuelle, stärkere KI-Modell, schickt das Foto in höherer Auflösung und hat mehr Platz für Ergebnisse. Damit werden Teller mit mehreren Komponenten und App-Screenshots zuverlässiger und vollständiger erkannt.',where:'Picker · Foto'},
+  ]},
   {v:'0.190',items:[
     {icon:'🍷',text:'Picker · Chat erkennt jetzt zuverlässig jedes Lebensmittel — auch einzelne Begriffe und Getränke wie „Weißwein" oder „2 Bier". Die KI antwortet nicht mehr mit Ausreden, und falls doch mal nichts Brauchbares zurückkommt, wird deine Eingabe trotzdem als Lebensmittel übernommen statt mit „Konnte nicht parsen" abzubrechen. (#135)',where:'Picker · Chat'},
   ]},
@@ -2271,7 +2274,7 @@ var CHANGELOG=[
 ];
 
 // Default prompts - editable in settings
-var DEFAULT_FOTO_PROMPT='Analysiere dieses Bild auf Deutsch. Es kann ein Essensfoto ODER ein Screenshot einer Tracking-App (z.B. MyFitnessPal, Cronometer, Yazio, Samsung Health) sein.\n\nGib ein JSON-Objekt zurueck:\n{"rezept":"Gesamtgerichtname auf Deutsch","zutaten":[{"name":"Zutat auf Deutsch","emoji":"Emoji","g":GRAMM}]}\n\nFall 1 – Essensfoto:\n- zutaten: erkenne was SICHTBAR auf dem Teller/Bild liegt\n- Nenne das fertige Lebensmittel, nicht seine Rohzutaten\n- 1 Einheit schatzen (Nutzer gibt Menge selbst an)\n- Logisch notwendige Beilagen erganzen\n\nFall 2 – Screenshot einer Tracking-App oder Ernaehrungsuebersicht:\n- Lies ALLE eingetragenen Lebensmittel/Gerichte mit den angezeigten Gramm-/Portionsangaben aus\n- Falls kcal/Naehrwerte sichtbar: nutze diese fuer realistischere Schatzung\n- rezept: Name der Mahlzeit oder "Import aus App"\n\nFall 3 – Einkaufszettel / Zutatenliste:\n- Liste alle Zutaten mit typischen Mengen auf\n\nAllgemein:\n- Realistische Gramm pro Einheit\n- Alle Namen auf Deutsch\n- Wenn nichts erkennbar: {"rezept":"","zutaten":[]}';
+var DEFAULT_FOTO_PROMPT='Analysiere dieses Bild auf Deutsch. Es kann ein Essensfoto ODER ein Screenshot einer Tracking-App (z.B. MyFitnessPal, Cronometer, Yazio, Samsung Health) sein.\n\nGib NUR ein JSON-Objekt zurueck, keine Erklaerungen davor oder danach:\n{"rezept":"Gesamtgerichtname auf Deutsch","zutaten":[{"name":"Zutat auf Deutsch","emoji":"Emoji","g":GRAMM}]}\n\nFall 1 – Essensfoto:\n- Erfasse nur, was WIRKLICH sichtbar ist. Erfinde nichts, was nicht erkennbar ist.\n- Nenne das fertige Lebensmittel, nicht seine Rohzutaten (Pommes, nicht Kartoffel+Oel).\n- Trenne klar unterscheidbare Komponenten in einzelne Zutaten (z.B. Schnitzel, Pommes, Salat getrennt statt "Schnitzelteller").\n- Hoechstens EINE offensichtlich dazugehoerige, aber teils verdeckte Beilage ergaenzen (z.B. Reis unter Curry); im Zweifel weglassen.\n- Schaetze realistische Gramm pro 1 Portion anhand sichtbarer Referenzen (Teller ca. 26 cm, Gabel, Glas ca. 200 ml, Hand). Der Nutzer korrigiert die Menge selbst.\n\nFall 2 – Screenshot einer Tracking-App oder Ernaehrungsuebersicht:\n- Lies ALLE eingetragenen Lebensmittel/Gerichte aus.\n- Uebernimm angezeigte Gramm-/Portions-/kcal-Werte EXAKT wie abgebildet, nicht runden, nicht schaetzen wenn ein Wert dasteht.\n- rezept: Name der Mahlzeit oder "Import aus App".\n\nFall 3 – Einkaufszettel / Zutatenliste:\n- Liste alle Zutaten mit typischen Mengen auf.\n\nAllgemein:\n- Realistische Gramm pro Einheit. Alle Namen auf Deutsch, knapp und konkret.\n- Wenn wirklich nichts Essbares erkennbar ist: {"rezept":"","zutaten":[]}';
 
 var DEFAULT_CHAT_PROMPT='Du zerlegst eine Mahlzeit in Zutaten und gibst NUR ein JSON-Array zurueck: [{"name":"Deutscher Name","emoji":"Emoji","g":80}]\n\nRegeln:\n- Antworte AUSSCHLIESSLICH mit dem JSON-Array. NIEMALS Erklaerungen, Rueckfragen, Hinweise, Warnungen oder Ablehnungen. JEDE Eingabe wird erfasst - auch alkoholische Getraenke (Wein, Weisswein, Bier, Cocktails), Suessigkeiten oder Fast Food. Du beraetst nicht, du erfasst nur.\n- Auch ein einzelnes Lebensmittel ist eine vollstaendige, gueltige Eingabe: dann ein Array mit GENAU einem Eintrag. Niemals leer lassen.\n- Werden einzelne Lebensmittel genannt: jedes GENAU so uebernehmen wie genannt - nicht umbenennen, nicht zu einer reichhaltigeren Variante zusammenfassen, nichts ergaenzen. Separat genannte Milch gehoert NICHT in ein anderes Getraenk hinein.\n- Nur bei einem echten Gericht- oder Rezeptnamen (z.B. Hamburger, Aperol Spritz) in typische fertige Bestandteile aufschluesseln.\n- Immer fertige Produkte, keine Rohzutaten (Butterkeks nicht Butter).\n- Immer nur 1 Einheit schaetzen, realistische Gramm. Namen auf Deutsch. Tippfehler still korrigieren (weiswein -> Weisswein).\n\nBeispiele:\nEingabe: Weisswein\nAusgabe: [{"name":"Weisswein","emoji":"🍷","g":150}]\nEingabe: 2 Bier\nAusgabe: [{"name":"Bier","emoji":"🍺","g":500}]\nEingabe: Kaffee mit Hafermilch und Sojamilch\nAusgabe: [{"name":"Kaffee","emoji":"☕","g":200},{"name":"Hafermilch","emoji":"🥛","g":50},{"name":"Sojamilch","emoji":"🥛","g":50}]\nEingabe: Brot mit Kaese und Schinken\nAusgabe: [{"name":"Brot","emoji":"🍞","g":50},{"name":"Kaese","emoji":"🧀","g":20},{"name":"Schinken","emoji":"🥓","g":25}]\nEingabe: Hamburger\nAusgabe: [{"name":"Burger-Broetchen","emoji":"🍔","g":80},{"name":"Rinderhackfleisch","emoji":"🥩","g":100},{"name":"Salat","emoji":"🥬","g":15},{"name":"Tomate","emoji":"🍅","g":20}]\n\nEingabe: {MSG}\nAusgabe:';
 

--- a/picker.js
+++ b/picker.js
@@ -226,8 +226,8 @@ function pickerHandlePhoto(e){
   reader.onload=function(ev){
     var img=new Image();
     img.onload=function(){
-      // MAX 800px reicht für KI-Analyse – schneller, weniger RAM
-      var c=document.createElement('canvas'),MAX=800,w=img.width,h=img.height;
+      // MAX 1280px: genug Detail für KI-Erkennung (Teller-Komponenten, Screenshot-Zahlen) bei moderater Größe
+      var c=document.createElement('canvas'),MAX=1280,w=img.width,h=img.height;
       if(w>h){if(w>MAX){h=Math.round(h*MAX/w);w=MAX;}}else{if(h>MAX){w=Math.round(w*MAX/h);h=MAX;}}
       c.width=w;c.height=h;
       var ctx=c.getContext('2d');
@@ -1009,7 +1009,7 @@ function pickerAnalyze(){
   btn.disabled=true;btn.innerHTML='<span style="display:inline-flex;gap:5px;align-items:center;"><span class="spin"></span>KI analysiert...</span>';
   pickerSetPhotoStatus('KI analysiert das Foto...',false);
   var prompt=getFotoPrompt();
-  callClaude('claude-sonnet-4-5',[{type:'image',source:{type:'base64',media_type:'image/jpeg',data:window._pickerPhotoB64}},{type:'text',text:prompt}],600,
+  callClaude('claude-sonnet-4-6',[{type:'image',source:{type:'base64',media_type:'image/jpeg',data:window._pickerPhotoB64}},{type:'text',text:prompt}],1024,
     function(text){
       var parsed=parsePhotoResponse(text);
       btn.disabled=false;btn.textContent='📷 Erneut analysieren';

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.190';
+var VERSION = '0.191';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur


### PR DESCRIPTION
## Was

Die Foto-Analyse (`pickerAnalyze`) lief noch auf dem veralteten `claude-sonnet-4-5`, während der Chat-mit-Foto-Pfad bereits `claude-sonnet-4-6` nutzt. Drei Hebel zur besseren Bilderkennung:

- **Modell:** `claude-sonnet-4-5` → `claude-sonnet-4-6` (stärkere Bilderkennung, konsistent mit dem Chat-Pfad).
- **Auflösung & Token:** Foto-Downscale `800px → 1280px`, `max_tokens 600 → 1024`. Mehr Detail bei Tellern mit mehreren Komponenten und bei App-Screenshots (kleine Zahlen/Schrift), ohne Abschneiden langer Ergebnislisten.
- **Prompt** (`DEFAULT_FOTO_PROMPT`) geschärft: nur sichtbare Lebensmittel (keine Halluzination), klar unterscheidbare Komponenten trennen, höchstens eine verdeckte Beilage ergänzen, Portionsschätzung über Referenzgrößen, bei Screenshots angezeigte Gramm/kcal exakt übernehmen, nur JSON ohne Prosa.

`processOfflineQueue` ruft denselben `pickerAnalyze`-Pfad → profitiert mit.

## Hinweise

- Kein Opus-Fallback eingebaut (bewusste Entscheidung: nur Sonnet 4.6).
- `getFotoPrompt()` liefert immer den Default (kein localStorage-Override) → Prompt-Änderung greift sofort, kein `PROMPT_VERSION`-Bump nötig.

## Live-Test (nicht hier verifizierbar — Worker)
- Teller mit mehreren Komponenten → getrennte Zutaten
- App-Screenshot (z.B. MyFitnessPal) → angezeigte Gramm/kcal exakt
- Normales Essensfoto → plausible Mengen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGMat4GdHtH6S2D7uSspjk)_