### PR TITLE
v0.192: Picker-Chat-Performance — corsproxy.io raus, OFF/Rezept-Impor…

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.191 (2026-06-20)
+**Stand:** v0.192 (2026-06-28)
 
 ## URLs
 
@@ -41,6 +41,7 @@
 - **Härtung (v0.182):** Globaler `esc()` in `index.html` + `_esc()` in `picker.js` escapen alle per `innerHTML` ausgegebenen Namen/Freitexte aus untrusted Quellen (Import-Payloads, OpenFoodFacts, KI-Antworten) → kein XSS mehr. SW `install` cacht `CORE_ASSETS` vorab (`./`,`index.html`,`picker.js`,`js/health-sync.js`,`manifest.json`,`icon.svg`, best-effort `allSettled`) → echte Offline-Erstnutzung; Offline-Fallbacks awaiten jetzt das `caches.match`-Promise korrekt. Worker `/feedback` verlangt `x-app-proxy-secret` (Client sendet `getProxySecret()`) + IP-Tages-Limit (`fbrl:<ip>:<tag>`, 30/Tag) + `mdNeutralizeBody` neutralisiert @-Mentions/#-Refs in der Beschreibung. `/workouts` paginiert via Cursor (bis 20 Seiten) + parallele KV-Reads → kein Datenverlust bei >200 Workouts. Decoder optional per `DECODER_SECRET`/`X-Decoder-Secret` absicherbar (beidseitig setzen; unset = offen). Bugfix `rememberPortion(f.name,amt)` (vorher `f.amount`=undefined). Toter Code entfernt (`toggleEye`,`shareCustomFood`,`triggerBackupDownload`,`pickerOnAdd`,`_pickerIngCallbacks`).
 - **Picker Foto-Analyse (v0.191):** `pickerAnalyze` (`picker.js`) skaliert das Foto auf **max. 1280 px** (JPEG 0.85) und ruft **`claude-sonnet-4-6`** mit `max_tokens:1024`, `temperature:0` und `getFotoPrompt()` auf. `getFotoPrompt()` liefert immer `DEFAULT_FOTO_PROMPT` (kein localStorage-Override) — Prompt-Änderungen greifen sofort, kein `PROMPT_VERSION`-Bump nötig. Prompt-Regeln: nur sichtbare Lebensmittel (keine Halluzination), Komponenten getrennt, höchstens eine verdeckte Beilage, Portions-Schätzung über Referenzgrößen, bei Screenshots angezeigte Gramm/kcal **exakt** übernehmen. `processOfflineQueue()` ruft denselben `pickerAnalyze`-Pfad → profitiert mit. Foto-Tab und Chat-mit-Foto (`claude-sonnet-4-6`) nutzen damit dasselbe aktuelle Modell.
 - **Picker KI-Fehlertexte (v0.180):** `pickerFriendlyAiError(err)` in `picker.js` mappt bekannte KI-/Proxy-Fehler (Kontingent/Billing, overloaded/rate-limit/429/529, nicht konfiguriert, offline) auf deutsche Texte; unbekannte Fehler unverändert. Genutzt in `pickerChatKiFallback` + Foto-Analyse-`onErr` (#121).
+- **OpenFoodFacts via eigenem Worker (v0.192):** Der Drittanbieter-CORS-Proxy `corsproxy.io` ist tot (Gratis-Zugang nur noch `localhost`), und OFF blockt anonyme Browser-Requests. Beides lief im Picker-Chat/-Suche zusammen → extreme Langsamkeit (jede Zutat fiel auf doppelte KI-Calls zurück). Fix: **alle** OFF-Aufrufe laufen jetzt serverseitig über den eigenen Worker — `GET /off?u=<OFF-URL>` (host-gesperrt auf `openfoodfacts.org`, korrekter `User-Agent`, OFF verlangt den). Rezept-Import-Link läuft über `GET /fetch?u=<URL>` (per `x-app-proxy-secret` abgesichert, SSRF-Guards, 512 KB Cap). Client: `offProxyUrl()`/`urlProxyUrl()` + `fetchT(url,opts,ms)` (AbortController-Timeout) in `index.html`; alle `fetch`-Stellen (`lookupNutrients`, `pickerFetchOnline`, Barcode-Lookup ×2, `recipeImportStart`, `pickerLinkImport`) sowie `callClaude` (25 s) haben jetzt harte Timeouts → ein hängender Dienst friert die App nicht mehr ein, sondern fällt schnell auf DB/KI-Schätzung zurück. **Worker muss neu deployt werden** (Action `Deploy Cloudflare Worker` bei Merge nach `main`, benötigt Repo-Secrets `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`).
 - **Sport-Sync (v0.158):** Erstes ausgelagertes Modul `js/health-sync.js` (klassisches `<script>` vor `</body>`, exportiert `window.NTHealth`). User generiert in „Mehr → Sport-Sync" ein 32-Zeichen-Token (Base58-ish, `localStorage.nt_health_token`), trägt es in eine iOS-Shortcut-Automation („wenn Training endet") oder Android HTTP Request Shortcut ein. Automation POSTet `{id, source, type, start, kcal, durationSec?, distanceM?, hrAvg?}` mit Header `X-User-Token` an Worker `POST /workout` (KV-Key `wo:<token>:<id>`, TTL 60d). PWA pollt `GET /workouts?since=<lastpoll>` bei `DOMContentLoaded` (mit 800ms Delay) und `visibilitychange→visible`, dedupliziert via `_healthId`-Marker, hängt Workouts in `S.days[<localDate>].exercise[]` an (Schema bleibt kompatibel zur manuellen Erfassung) — die existierende `burned`-Subtraktion in `renderAll()` zieht die Kalorien automatisch vom Tagesziel ab. `renderExercise()` zeigt für `_source`-Einträge ein kleines „Apple"/„Samsung"-Badge.
 
 ## Worker-Endpoints
@@ -55,6 +56,8 @@
 | `POST /feedback` | erstellt GitHub-Issue, optional Screenshot-Commit auf Branch `feedback-screenshots` |
 | `POST /workout` | Apple/Samsung Workout-Ingest (Header `X-User-Token`, KV `wo:<token>:<id>`, 60d TTL) |
 | `GET /workouts?since=<ms>` | Liste aller Workouts eines Tokens seit Timestamp (PWA-Polling) |
+| `GET /off?u=<OFF-URL>` | OpenFoodFacts-Proxy (host-gesperrt, korrekter User-Agent, 6 s Timeout) |
+| `GET /fetch?u=<URL>` | Rezept-Seiten-Proxy (Secret-gated, SSRF-Guards, 512 KB Cap, 8 s Timeout) |
 
 **Bindings/Secrets:** `ANTHROPIC_API_KEY`, `NUTRITRACK_PROXY_TOKEN`, `DECODER_URL`, `SHARE_KV` (KV `873c9976307f4af087ff8205ba957b1c`), `GITHUB_TOKEN` (fine-grained PAT, `hjolmes/nutritrack`, Issues+Contents read+write), opt. `GITHUB_REPO`.
 
@@ -72,6 +75,7 @@
 
 ## Live-Test offen
 
+- v0.192 Picker Chat & Suche: **Voraussetzung: Worker neu deployt** (`/off`, `/fetch` live — `GET …/off?u=…openfoodfacts.org/cgi/search.pl?...` muss OFF-JSON liefern, nicht 403/404). Dann: „Brot mit Käse" im Chat → Zutaten kommen zügig (kein langes Hängen); Lebensmittel-Suche (Picker-Suche-Tab) zeigt Online-Treffer mit 🌐-Badge; Barcode-Scan findet Produkt; Rezept-Import per Link funktioniert wieder. Bei Worker/OFF-Ausfall: schneller Fallback auf KI-Schätzung statt Einfrieren (#137-Performance)
 - v0.190 Picker Chat: „Weißwein", „2 Bier", „1 weiswein" (Tippfehler) und beliebige Einzel-Lebensmittel werden erfasst (Zutat erscheint, Nährwerte via DB/OpenFoodFacts/KI) — kein „Konnte nicht parsen" mehr; Mehr-Zutaten-Sätze („Brot mit Käse und Schinken") werden weiterhin korrekt zerlegt (#135)
 - v0.188 Einstellungen → Ernährung: „Eigene Präferenz" — Eingabefeld hat volle Restbreite, der „+ Hinzufügen"-Button sitzt kompakt rechts daneben (nicht mehr volle Zeile); nicht mit „Speichern ✓" unten verwechselbar (#134)
 - v0.187 Einstellungen: Mehr → ⚙️ → Tab-Bar zeigt 6 Tabs inkl. „🤖 KI" + „💾 Backup"; Proxy-Passwort + KI-Prompts nur noch unter KI; Autospeicher/Export/Import/OneDrive nur noch unter Backup; Picker-Foto-Toggle unter Ernährung; keine doppelte Lebensmittel-Liste mehr; Bibliothek (Mehr → 📚) zeigt Rezepte/Lebensmittel wie zuvor inkl. Bearbeiten/Löschen
@@ -100,11 +104,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.186 | — | Picker Chat: eigentlicher Fix — DB-Synonym „kaffee" gehörte zum schwarzen Kaffee, nicht zum Cappuccino (#127) |
 | v0.187 | #133 | Einstellungen aufgeräumt: „Daten"-Tab → „🤖 KI" + „💾 Backup", Picker-Foto-Toggle zu Ernährung, doppelte Lebensmittel-Liste raus, Hilfe-Dedup, OneDrive-Banner-Label |
 | v0.188 | — | Fix: verrutschter „+ Hinzufügen"-Button im Ernährung-Tab (war volle Breite, drückte das Eingabefeld platt) (#134) |
 | v0.190 | — | Picker Chat: Lebensmittel-Erkennung generell robust — gehärteter Prompt + Sackgassen-Fallback statt „Konnte nicht parsen" (#135) |
 | v0.191 | — | Foto-Analyse: aktuelles Modell (Sonnet 4.6), höhere Auflösung (1280px), mehr Token, geschärfter Prompt |
+| v0.192 | — | Performance: `corsproxy.io` (tot) raus → OFF/Rezept-Import über eigenen Worker (`/off`, `/fetch`) + harte Timeouts auf allen externen Calls; behebt extreme Chat-Langsamkeit |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -656,7 +656,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.191</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.192</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -976,7 +976,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.191</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.192</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1965,8 +1965,23 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.191';
-var PROJECT_AI_PROXY_URL='https://nutritrack-ai-proxy.h-jolmes.workers.dev/v1/messages';
+var APP_VERSION='0.192';
+var PROJECT_WORKER_BASE='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
+var PROJECT_AI_PROXY_URL=PROJECT_WORKER_BASE+'/v1/messages';
+// OpenFoodFacts + Rezept-Seiten laufen über den eigenen Worker statt über den
+// ausgefallenen Drittanbieter corsproxy.io. /off ist host-gesperrt auf OFF,
+// /fetch ist per Proxy-Secret abgesichert.
+function offProxyUrl(offUrl){return PROJECT_WORKER_BASE+'/off?u='+encodeURIComponent(offUrl);}
+function urlProxyUrl(u){return PROJECT_WORKER_BASE+'/fetch?u='+encodeURIComponent(u);}
+// fetch mit hartem Timeout → ein langsamer/ausgefallener Dienst friert die App
+// nicht mehr ein, sondern fällt schnell auf den jeweiligen Fallback zurück.
+function fetchT(url,opts,ms){
+  opts=opts||{};ms=ms||7000;
+  var ctrl=new AbortController();
+  var timer=setTimeout(function(){ctrl.abort();},ms);
+  opts.signal=ctrl.signal;
+  return fetch(url,opts).finally(function(){clearTimeout(timer);});
+}
 // HTML-Escaping für alle Namen/Freitexte aus untrusted Quellen (Import-Payloads,
 // OpenFoodFacts, KI-Antworten), die per innerHTML eingefügt werden — schützt vor XSS.
 function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];});}
@@ -1997,6 +2012,9 @@ function _odSlotsMetaGet(){try{return JSON.parse(localStorage.getItem('nt_od_slo
 function _odSlotsMetaSave(m){try{localStorage.setItem('nt_od_slots_meta',JSON.stringify(m));}catch(e){}}
 
 var CHANGELOG=[
+  {v:'0.192',items:[
+    {icon:'⚡',text:'Lebensmittel-Suche & Chat wieder schnell: Der externe Dienst, über den die Nährwerte von OpenFoodFacts geladen wurden, hatte seinen Gratis-Zugang abgeschaltet — dadurch wurde besonders der Picker-Chat extrem langsam. Die Nährwert-Abfrage läuft jetzt direkt über den eigenen Server, mit Zeitlimit, damit nichts mehr einfriert. Auch der Rezept-Import per Link funktioniert wieder.',where:'Picker · Chat & Suche'},
+  ]},
   {v:'0.191',items:[
     {icon:'📷',text:'Foto-Erkennung verbessert: Die Bild-Analyse nutzt jetzt das aktuelle, stärkere KI-Modell, schickt das Foto in höherer Auflösung und hat mehr Platz für Ergebnisse. Damit werden Teller mit mehreren Komponenten und App-Screenshots zuverlässiger und vollständiger erkannt.',where:'Picker · Foto'},
   ]},
@@ -2752,7 +2770,7 @@ function recipeImportStart(){
   if(!canUseAi()){showAiUnavailable();return;}
   closeOv('recipeImportOv');
   showToast('⏳ Rezept wird importiert...');
-  fetch('https://corsproxy.io/?'+encodeURIComponent(url))
+  fetchT(urlProxyUrl(url),{headers:{'x-app-proxy-secret':getProxySecret()}},9000)
     .then(function(r){return r.text();})
     .then(function(html){
       var text=html.replace(/<script[\s\S]*?<\/script>/gi,'')
@@ -3147,9 +3165,8 @@ function lookupNutrients(rawItems,onDone){
     }
     // 2. Open Food Facts
     if(isOnline){
-      var proxy='https://corsproxy.io/?';
       var url='https://world.openfoodfacts.org/cgi/search.pl?search_terms='+encodeURIComponent(name)+'&search_simple=1&action=process&json=1&page_size=5&fields=product_name,nutriments';
-      fetch(proxy+encodeURIComponent(url)).then(function(r){return r.json();})
+      fetchT(offProxyUrl(url),{},6000).then(function(r){return r.json();})
         .then(function(data){
           var prods=(data.products||[]).filter(function(p){var nm=(p.nutriments||{});return(nm['energy-kcal_100g']||nm['energy_100g']||(nm['proteins_100g']||0)+(nm['carbohydrates_100g']||0)+(nm['fat_100g']||0))>0;});
           if(prods.length>0){
@@ -3234,14 +3251,14 @@ function parsePhotoResponse(text){
 // ════════════════════════════════════════
 function callClaude(model,content,maxTok,onOk,onErr){
   if(!canUseAi()){onErr('KI Proxy nicht konfiguriert');return;}
-  fetch(PROJECT_AI_PROXY_URL,{
+  fetchT(PROJECT_AI_PROXY_URL,{
     method:'POST',
     headers:{'Content-Type':'application/json','x-app-proxy-secret':getProxySecret()},
     body:JSON.stringify({model:model,max_tokens:maxTok,temperature:0,messages:[{role:'user',content:content}]})
-  }).then(function(r){return r.json().then(function(d){if(!r.ok)throw new Error((d.error&&d.error.message)||d.error||('HTTP '+r.status));return d;});}).then(function(d){
+  },25000).then(function(r){return r.json().then(function(d){if(!r.ok)throw new Error((d.error&&d.error.message)||d.error||('HTTP '+r.status));return d;});}).then(function(d){
     if(d.error)throw new Error(d.error.message);
     onOk(d.content.map(function(c){return c.text||'';}).join(''));
-  }).catch(function(e){onErr(e.message||'Fehler');});
+  }).catch(function(e){onErr(e.name==='AbortError'?'Zeitüberschreitung – bitte erneut versuchen':(e.message||'Fehler'));});
 }
 
 // ════════════════════════════════════════

--- a/picker.js
+++ b/picker.js
@@ -122,10 +122,9 @@ function pickerFetchOnline(q){
   var btn=document.getElementById('pickerSearchBtn');
   btn.innerHTML='<span class="spin"></span>';btn.disabled=true;
   var ql=q.toLowerCase(),eng=DE_EN[ql]||null;
-  var proxy='https://corsproxy.io/?';
   var base='https://world.openfoodfacts.org/cgi/search.pl?search_simple=1&action=process&json=1&page_size=20&fields=product_name,product_name_de,nutriments,image_front_thumb_url';
   var terms=[q];if(eng)terms.push(eng);
-  var fetches=terms.map(function(t){return fetch(proxy+encodeURIComponent(base+'&search_terms='+encodeURIComponent(t))).then(function(r){return r.json();}).catch(function(){return{products:[]};});});
+  var fetches=terms.map(function(t){return fetchT(offProxyUrl(base+'&search_terms='+encodeURIComponent(t)),{},6000).then(function(r){return r.json();}).catch(function(){return{products:[]};});});
   Promise.all(fetches).then(function(res){
     var local=searchLocal(q);
     var seen={};local.forEach(function(p){seen[p.name.toLowerCase()]=true;});
@@ -832,7 +831,7 @@ function pickerFetchBarcodeForConfirm(code){
   var cached=barcodeCache[code];
   if(cached){pickerShowBcConfirm(cached);return;}
   if(!isOnline)return;
-  fetch('https://world.openfoodfacts.org/api/v0/product/'+code+'.json')
+  fetchT(offProxyUrl('https://world.openfoodfacts.org/api/v0/product/'+code+'.json'),{},6000)
     .then(function(r){return r.json();})
     .then(function(data){
       if(data.status!==1||!data.product){showToast('Barcode '+code+' nicht gefunden – bitte manuell eintragen');return;}
@@ -901,7 +900,7 @@ function pickerLookupBarcode(code){
     pickerShowBarcodeNotFound(code,'📴 Offline – nicht im Cache. Werte manuell eintragen:');
     return;
   }
-  fetch('https://world.openfoodfacts.org/api/v0/product/'+code+'.json')
+  fetchT(offProxyUrl('https://world.openfoodfacts.org/api/v0/product/'+code+'.json'),{},6000)
     .then(function(r){return r.json();})
     .then(function(data){
       if(data.status!==1||!data.product){
@@ -1358,7 +1357,7 @@ function pickerLinkImport(){
   if(!canUseAi()){showAiUnavailable();return;}
   var btn=document.getElementById('pickerLinkImportBtn');
   btn.disabled=true;btn.textContent='⏳ Laden...';btn.style.opacity='.6';
-  fetch('https://corsproxy.io/?'+encodeURIComponent(url))
+  fetchT(urlProxyUrl(url),{headers:{'x-app-proxy-secret':getProxySecret()}},9000)
     .then(function(r){return r.text();})
     .then(function(html){
       var text=html.replace(/<script[\s\S]*?<\/script>/gi,'')

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.191';
+var VERSION = '0.192';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -11,6 +11,12 @@ const MAX_BODY_BYTES = 1024 * 1024 * 4;
 const MAX_BARCODE_BODY_BYTES = 1024 * 200; // 200 KB pro Frame reicht
 const BARCODE_MODEL = "claude-haiku-4-5";
 const DECODER_TIMEOUT_MS = 1500;
+// OpenFoodFacts verlangt einen aussagekräftigen User-Agent und blockt anonyme
+// Browser-Requests; deshalb läuft jeder OFF-Aufruf serverseitig über /off.
+const OFF_USER_AGENT = "NutriTrack/1.0 (+https://hjolmes.github.io/nutritrack/; h.jolmes@jolmes.de)";
+const OFF_TIMEOUT_MS = 6000;
+const URL_FETCH_TIMEOUT_MS = 8000;
+const MAX_URL_FETCH_BYTES = 1024 * 512; // 512 KB reichen für eine Rezept-Seite
 
 function allowedOrigins(env) {
   const raw = env.ALLOWED_ORIGINS || DEFAULT_ALLOWED_ORIGINS.join(",");
@@ -703,6 +709,104 @@ async function handleShareRedirect(request, env) {
   });
 }
 
+// ─── OPENFOODFACTS PROXY ──────────────────────────────────────────────
+// Serverseitiger OFF-Aufruf mit korrektem User-Agent. Host-gesperrt auf
+// openfoodfacts.org (kein offener Proxy). Ersetzt den ausgefallenen
+// Drittanbieter corsproxy.io im Lebensmittel-/Chat-Pfad.
+async function handleOffProxy(request, origin, env) {
+  const target = new URL(request.url).searchParams.get("u") || "";
+  let t;
+  try {
+    t = new URL(target);
+  } catch (e) {
+    return jsonResponse(400, "bad_url", "Invalid 'u' parameter", origin, env);
+  }
+  if (t.protocol !== "https:" || !/(^|\.)openfoodfacts\.org$/i.test(t.hostname)) {
+    return jsonResponse(403, "host_not_allowed", "Only openfoodfacts.org is allowed", origin, env);
+  }
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), OFF_TIMEOUT_MS);
+  try {
+    const res = await fetch(t.toString(), {
+      headers: { "User-Agent": OFF_USER_AGENT, Accept: "application/json" },
+      signal: ctrl.signal,
+    });
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: {
+        ...corsHeaders(origin, env),
+        "Content-Type": res.headers.get("Content-Type") || "application/json; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  } catch (e) {
+    // Timeout/Netzwerk → leeres OFF-Resultat, damit der Client sauber auf die
+    // KI-Schätzung zurückfällt statt zu hängen.
+    return new Response(JSON.stringify({ products: [], error: "off_unavailable" }), {
+      status: 200,
+      headers: {
+        ...corsHeaders(origin, env),
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ─── URL FETCH PROXY (Rezept-Import) ──────────────────────────────────
+// Holt eine beliebige Rezept-Seite serverseitig als Text. Durch das
+// App-Proxy-Secret abgesichert (kein offener Proxy) + SSRF-Schutz + Größenlimit.
+async function handleUrlProxy(request, origin, env) {
+  const token = request.headers.get("x-app-proxy-secret") || "";
+  if (!env.NUTRITRACK_PROXY_TOKEN || token !== env.NUTRITRACK_PROXY_TOKEN) {
+    return jsonResponse(401, "unauthorized", "Invalid app proxy secret", origin, env);
+  }
+  const target = new URL(request.url).searchParams.get("u") || "";
+  let t;
+  try {
+    t = new URL(target);
+  } catch (e) {
+    return jsonResponse(400, "bad_url", "Invalid 'u' parameter", origin, env);
+  }
+  if (t.protocol !== "https:" && t.protocol !== "http:") {
+    return jsonResponse(403, "bad_scheme", "Only http(s) is allowed", origin, env);
+  }
+  const host = t.hostname.toLowerCase();
+  if (
+    host === "localhost" || host === "0.0.0.0" || host.endsWith(".internal") ||
+    /^127\./.test(host) || /^10\./.test(host) || /^192\.168\./.test(host) ||
+    /^169\.254\./.test(host) || /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+  ) {
+    return jsonResponse(403, "host_not_allowed", "Host not allowed", origin, env);
+  }
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), URL_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(t.toString(), {
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; NutriTrack/1.0)" },
+      redirect: "follow",
+      signal: ctrl.signal,
+    });
+    const raw = await res.text();
+    const body = raw.length > MAX_URL_FETCH_BYTES ? raw.slice(0, MAX_URL_FETCH_BYTES) : raw;
+    return new Response(body, {
+      status: res.status,
+      headers: {
+        ...corsHeaders(origin, env),
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (e) {
+    return jsonResponse(504, "fetch_failed", "Upstream fetch failed or timed out", origin, env);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin") || "";
@@ -722,7 +826,7 @@ export default {
         feedbackConfigured: Boolean(env.GITHUB_TOKEN),
         workoutsConfigured: Boolean(env.SHARE_KV),
         decoderSecretConfigured: Boolean(env.DECODER_SECRET),
-        codeVersion: "v0.182-hardening",
+        codeVersion: "v0.192-off-proxy",
       });
     }
 
@@ -741,6 +845,12 @@ export default {
     }
     if (request.method === "GET" && url.pathname === "/workouts") {
       return handleWorkoutList(request, origin, env);
+    }
+    if (request.method === "GET" && url.pathname === "/off") {
+      return handleOffProxy(request, origin, env);
+    }
+    if (request.method === "GET" && url.pathname === "/fetch") {
+      return handleUrlProxy(request, origin, env);
     }
     if (request.method === "GET" && url.pathname.startsWith("/share/")) {
       return handleShareLookup(request, origin, env);


### PR DESCRIPTION
…t über eigenen Worker

corsproxy.io hat den Gratis-Zugang auf localhost beschränkt und OpenFoodFacts blockt anonyme Browser-Requests. Beide Dienste sitzen im Picker-Chat/-Suche-Pfad, wodurch jede Zutat auf doppelte KI-Calls zurückfiel → extreme Langsamkeit, ohne dass am Code etwas geaendert wurde.

- Worker: neuer host-gesperrter OFF-Proxy GET /off?u= (korrekter User-Agent, 6s Timeout, leeres Resultat bei Ausfall) + secret-gated GET /fetch?u= fuer Rezept-Seiten (SSRF-Guards, 512KB Cap, 8s Timeout)
- Client: alle OFF-/Proxy-Aufrufe (lookupNutrients, pickerFetchOnline, Barcode x2, recipeImportStart, pickerLinkImport) auf den Worker umgestellt; fetchT() mit AbortController-Timeout, callClaude mit 25s Timeout → haengender Dienst friert die App nicht mehr ein, Fallback auf DB/KI-Schaetzung
- sw.js Versions-Bump, CHANGELOG + UEBERGABE aktualisiert

Hinweis: Worker muss neu deployt werden (Action Deploy Cloudflare Worker).


Claude-Session: https://claude.ai/code/session_019b8NCqaGrF72qtnj26eGxJ