### PR TITLE
v0.195: Fix — KI-Badge fehlte, weil Service Worker eine alte picker.js cachte

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.194 (2026-06-29)
+**Stand:** v0.195 (2026-06-29)
 
 ## URLs
 
@@ -73,10 +73,11 @@
 
 `manifest.json`: `handle_links: "preferred"`, `launch_handler.client_mode: "navigate-existing"`.
 
-`sw.js`: SKIP-Liste enthält `workers.dev`, `is.gd`, `v.gd`, `unpkg.com`.
+`sw.js`: SKIP-Liste enthält `workers.dev`, `is.gd`, `v.gd`, `unpkg.com`. **Asset-Strategie:** `index.html` network-first, restliche `CORE_ASSETS` (u.a. `picker.js`, `js/*`) cache-first. `install` cacht die Core-Assets per `fetch(new Request(u,{cache:'reload'}))`+`c.put` (v0.195) — **nicht** `cache.add()`, da das den Browser-HTTP-Cache nutzt und sonst eine alte `picker.js` in den neuen versionierten Cache schreiben kann, während `index.html` schon aktuell ist (führte zu „Badge fehlt", weil index.html neu / picker.js alt).
 
 ## Live-Test offen
 
+- v0.195 SW-Asset-Fix: Auf bestehendem Gerät (das v0.194 mit fehlendem Badge zeigte) App neu laden → nach SW-Update (0.195) erscheint im Picker-Chat das Badge „über Anthropic · Claude Haiku" hinter „N Zutaten erkannt" (bzw. der gewählte Anbieter). Bestätigt damit, dass `picker.js` nicht mehr veraltet aus dem Cache kommt.
 - v0.194 KI-Badge (**Voraussetzung: Worker neu deployt** für Fremd-Anbieter-Modell im Badge): Eigenen Anbieter setzen → Picker-Chat/Foto/Wochenbericht zeigt am Ergebnis „über OpenAI · gpt-4o" o.ä.; bei Limit/Fehler steht „über Anthropic (Fallback) · Claude …"; ohne eigenen Anbieter „über Anthropic · Claude Haiku/Sonnet".
 - v0.193 KI-Anbieter (**Voraussetzung: Worker neu deployt** — `/ai/messages` live): Settings → 🤖 KI → Anbieter „OpenAI" wählen, gültigen Key eintragen, speichern → Picker-Chat „Brot mit Käse" liefert Zutaten über OpenAI; Foto-Analyse nutzt das stärkere Modell des Anbieters. Ungültigen/abgelaufenen Key oder „DeepSeek" + Foto → automatischer Fallback auf Anthropic (Ergebnis kommt trotzdem). Anbieter wieder auf „Anthropic (Standard)" → Key-Feld verschwindet, alles wie vorher. Ohne gesetzten Anbieter: unverändertes Verhalten.
 - v0.192 Picker Chat & Suche: **Voraussetzung: Worker neu deployt** (`/off`, `/fetch` live — `GET …/off?u=…openfoodfacts.org/cgi/search.pl?...` muss OFF-JSON liefern, nicht 403/404). Dann: „Brot mit Käse" im Chat → Zutaten kommen zügig (kein langes Hängen); Lebensmittel-Suche (Picker-Suche-Tab) zeigt Online-Treffer mit 🌐-Badge; Barcode-Scan findet Produkt; Rezept-Import per Link funktioniert wieder. Bei Worker/OFF-Ausfall: schneller Fallback auf KI-Schätzung statt Einfrieren (#137-Performance)
@@ -108,11 +109,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.190 | — | Picker Chat: Lebensmittel-Erkennung generell robust — gehärteter Prompt + Sackgassen-Fallback statt „Konnte nicht parsen" (#135) |
-| v0.191 | — | Foto-Analyse: aktuelles Modell (Sonnet 4.6), höhere Auflösung (1280px), mehr Token, geschärfter Prompt |
-| v0.192 | — | Performance: `corsproxy.io` (tot) raus → OFF/Rezept-Import über eigenen Worker (`/off`, `/fetch`) + harte Timeouts auf allen externen Calls; behebt extreme Chat-Langsamkeit |
+| v0.191 | #137 | Foto-Analyse: aktuelles Modell (Sonnet 4.6), höhere Auflösung (1280px), mehr Token, geschärfter Prompt |
+| v0.192 | #139 | Performance: `corsproxy.io` (tot) raus → OFF/Rezept-Import über eigenen Worker (`/off`, `/fetch`) + harte Timeouts; behebt extreme Chat-Langsamkeit |
 | v0.193 | #140 | Konfigurierbarer KI-Anbieter: Dropdown (OpenAI/Gemini/OpenRouter/Mistral/DeepSeek) + eigener Key in Settings, eigener Key zuerst, Fallback auf Anthropic; Worker `/ai/messages` mit Format-Übersetzung |
-| v0.194 | — | Badge „über <Anbieter · Modell>" am KI-Ergebnis (Chat, Foto, Wochenbericht); Worker liefert `_provider`/`_model`, markiert auch Anthropic-Fallback |
+| v0.194 | #141 | Badge „über <Anbieter · Modell>" am KI-Ergebnis (Chat, Foto, Wochenbericht); Worker liefert `_provider`/`_model`, markiert auch Anthropic-Fallback |
+| v0.195 | — | Fix: Service Worker cacht Core-Assets jetzt per `fetch({cache:'reload'})` statt `cache.add()` → keine alte `picker.js` mehr neben neuem `index.html` (Badge fehlte) |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -656,7 +656,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.194</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.195</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -977,7 +977,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.194</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.195</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1979,7 +1979,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.194';
+var APP_VERSION='0.195';
 var PROJECT_WORKER_BASE='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
 var PROJECT_AI_PROXY_URL=PROJECT_WORKER_BASE+'/v1/messages';
 // Konfigurierbarer KI-Anbieter: läuft über denselben Worker (Format-Übersetzung

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.194';
+var VERSION = '0.195';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur
@@ -11,11 +11,21 @@ self.addEventListener('install', function(e) {
   // Sofort aktivieren ohne auf alte Tabs zu warten
   self.skipWaiting();
   // Kern-Assets vorab cachen, damit die PWA auch bei Erst-Nutzung offline läuft.
+  // WICHTIG: {cache:'reload'} erzwingt frische Netzwerk-Kopien. Sonst kann der
+  // Browser-HTTP-Cache (GitHub Pages liefert max-age) eine ALTE Asset-Version —
+  // z.B. picker.js — in den neuen, versionierten SW-Cache schreiben, obwohl das
+  // network-first geladene index.html bereits aktuell ist. Das führte dazu, dass
+  // index.html (neu) und picker.js (alt) auseinanderliefen. cache.add() nutzt den
+  // HTTP-Cache und ist daher hier ungeeignet → manueller fetch+put mit reload.
   // Best-effort pro Asset (allSettled) — ein einzelner Fehlschlag bricht die
   // Installation nicht ab.
   e.waitUntil(
     caches.open(CACHE).then(function(c) {
-      return Promise.allSettled(CORE_ASSETS.map(function(u) { return c.add(u); }));
+      return Promise.allSettled(CORE_ASSETS.map(function(u) {
+        return fetch(new Request(u, { cache: 'reload' })).then(function(r) {
+          if (r && r.ok) return c.put(u, r);
+        });
+      }));
     }).catch(function() {})
   );
 });


### PR DESCRIPTION
## Problem

Nach dem Update auf v0.194 (KI-Badge) erschien das Badge bei manchen Geräten nicht, obwohl die Versionsanzeige bereits v0.194 zeigte.

**Ursache:** Der Service Worker lädt `index.html` **network-first** (daher sofort aktuell), die übrigen `CORE_ASSETS` inkl. `picker.js` aber **cache-first**. Beim Vorab-Cachen nutzte `install` bisher `cache.add()`, das den **Browser-HTTP-Cache** verwendet. GitHub Pages liefert Assets mit `max-age`, sodass beim Update eine **alte `picker.js`** (ohne die Badge-Render-Zeile) in den neuen versionierten SW-Cache geschrieben wurde. Ergebnis: frisches `index.html` (mit Badge-Helfern) + altes `picker.js` (ohne `_src`) → kein Badge. Das betrifft generell jedes `js/`-Asset-Update.

## Fix

`install` cacht jede Core-Asset jetzt explizit frisch:

```js
fetch(new Request(u, { cache: 'reload' })).then(r => { if (r && r.ok) return c.put(u, r); })
```

`{cache:'reload'}` umgeht den HTTP-Cache, sodass jeder neue, versionierte SW-Cache garantiert die aktuellen Asset-Versionen enthält. `index.html`/`picker.js` laufen nicht mehr auseinander. Best-effort pro Asset (`allSettled`) bleibt erhalten.

## Hinweis zur Wirkung

Reiner Plumbing-Fix — der eigentliche Badge-Code (v0.194) war korrekt. Auf einem betroffenen Gerät erscheint das Badge nach dem Update auf 0.195 (neuer SW installiert + lädt `picker.js` frisch).

## Version / Changelog

- `APP_VERSION` & `sw.js` `VERSION` 0.194 → **0.195**, sichtbare Versions-Tags (2×).
- **Kein** CHANGELOG-Eintrag (interner SW-Fix, kein neues Feature) → „Was ist neu"-Dialog bleibt für 0.195 still.
- `UEBERGABE.md`: Stand, SW-Asset-Strategie, Live-Test, Versions-Historie aktualisiert.

## Storage / Backup / OneDrive / API

- Nur `sw.js`-Caching-Logik + Versions-Bump. Keine Änderung an persistierten Daten, Worker, API oder UI-Flows.
- `node --check sw.js` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMMgM6hCkYE4Tx8ppsknaR)_