### PR TITLE
v0.213: Separate Foto-KI — Qwen als Standard-Vision-Anbieter

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.212 (2026-07-10) — Branch `claude/nutritrack-ux-settings-k3f2ey` (Issues #166 Ei-Fix, #156 Diktat-iOS, Mehr-Hub-Redesign, DeepSeek-Default)
+**Stand:** v0.213 (2026-07-10) — Branch `claude/nutritrack-qwen-vision-qhjlsu` (separate Foto-KI: Qwen als Standard-Vision-Anbieter)
 
 ## URLs
 
@@ -37,8 +37,8 @@
 - **Share/Import:** Sender → `POST /share` (KV, 1y) → `?s=<id>`; iOS non-standalone → `iosSwitchOv` + 📥 `openImportPaste()`. Payload `{t:'r'|'f'|'m',…}`.
 - **OneDrive (v0.159):** `_odGetToken()` löscht Tokens nur bei echten Auth-Fehlern (+ `odReconnectOv`); täglicher Autospeicher-Slot via `_odAutoSync`→`oneDriveSyncSlot`.
 - **Picker Chat (v0.175–0.190):** Lokale Fuzzy-Suche (nur Rezepte+Custom Foods, alle Tokens müssen treffen, `_pickerDbHit` für DB-Exakt-Treffer) → KI-Fallback (`DEFAULT_CHAT_PROMPT`, `PROMPT_VERSION='7'`, Few-Shot, keine Sackgasse: kurze Eingaben gehen als Einzel-Lebensmittel an `lookupNutrients`).
-- **Foto-Analyse (v0.191/v0.212):** `pickerAnalyze` skaliert auf 1280 px, `getFotoPrompt()` immer Default. Mit aktivem Fremd-Anbieter geht das Bild an dessen API (DeepSeek: Worker `vision:true`, Durchreichen gewollt), sonst/bei Fehler `claude-sonnet-4-6`. Quellen-Badge wird direkt nach der Vision-Antwort eingefroren (zeigt nicht mehr die lookupNutrients-Quelle).
-- **KI-Anbieter (v0.193–v0.212):** Mehr → 🤖 KI: Fremd-Anbieter via Worker `POST /ai/messages`; `callClaude` = `_callAiProvider` → Fallback `_callAnthropic`; Badge `aiSourceBadgeHtml()`. **Default-Provider ist `deepseek`** (Rolling-Alias `deepseek-chat` im Worker, bewusst kein Pin) — aktiv erst mit gespeichertem Key (`hasCustomAiProvider`), sonst Anthropic-Proxy; `_backupAiFields` nimmt Provider nur mit Key ins Backup. Key wandert AES-GCM-verschlüsselt (`aiKeyEnc`, Schlüssel aus Proxy-Passwort) in alle Backups, `_importAiFields` in allen 4 Restore-Pfaden.
+- **Foto-Analyse (v0.191/v0.213):** `pickerAnalyze` skaliert auf 1280 px, `getFotoPrompt()` immer Default. `callClaude` erkennt Bilder (`content` mit `type:'image'`) und routet über eine eigene Kette: (1) eigener Vision-Slot mit Key → dessen API (Default Qwen/`qwen-vl-max`), (2) Foto-KI explizit auf Anthropic → `claude-sonnet-4-6`, (3) kein Vision-Key, aber Text-Anbieter aktiv und `vision:true` → dorthin durchreichen (bewahrt v0.212-DeepSeek-Verhalten), (4) sonst Anthropic. Fallback bei Fehler/leer immer Anthropic. Quellen-Badge direkt nach der Vision-Antwort eingefroren (nicht die lookupNutrients-Quelle).
+- **KI-Anbieter (v0.193–v0.213):** Mehr → 🤖 KI: Fremd-Anbieter via Worker `POST /ai/messages`; `callClaude` = `_callAiProvider(provider,key,…)` → Fallback `_callAnthropic`; Badge `aiSourceBadgeHtml()` (`aiSourceText` strippt `(Alibaba)` → `Qwen`). **Zwei unabhängige Slots:** Text-Anbieter (`nt_ai_provider`/`nt_ai_key`, Default `deepseek`, aktiv via `hasCustomAiProvider`) und Foto-KI (`nt_ai_vision_provider`/`nt_ai_vision_key`, Default `qwen`, aktiv via `hasVisionAiProvider`). Ohne jeweiligen Key → Anthropic-Proxy. `_backupAiFields` nimmt jeden Slot nur mit eigenem Key ins Backup (`aiProvider`/`aiKeyEnc`, `aiVisionProvider`/`aiVisionKeyEnc`); Keys wandern AES-GCM-verschlüsselt (Schlüssel aus Proxy-Passwort) in alle Backups, `_importAiFields` stellt beide Slots in allen 4 Restore-Pfaden wieder her. Worker: Qwen = OpenAI-kompatibler DashScope-intl-Endpoint.
 - **OFF via Worker (v0.192):** Alle OpenFoodFacts-Calls über `GET /off?u=…`, Rezept-Import über `GET /fetch?u=…`; `fetchT` mit harten Timeouts überall.
 - **Barcode (v0.196):** `zxing-wasm` lokal (`js/zxing/`), Canvas→ImageData-Wrapper `window.ZXingWasm.readBarcodes`; zbar-wasm per esm.sh best effort; `@zxing/library` lokal als JS-Fallback.
 - **Sport-Sync (v0.158):** `js/health-sync.js` (`window.NTHealth`), Token in iOS-Shortcut/Android-HTTP-Shortcut, Worker `POST /workout` / `GET /workouts`, Einträge in `S.days[*].exercise[]` mit `_healthId`/`_source`.
@@ -77,7 +77,7 @@
 - v0.209 Ei (#166): Suche „Ei" → erster Treffer „Ei 🥚 143 kcal", dann „Ei (gekocht)", „Rührei" dahinter; Chat „2 Eier" → Zutat „Ei" (roh), nicht Rührei; „Rührei" weiterhin per Namen findbar
 - v0.210 Diktat (#156, iPhone!): 🎙️ halten, 3 Sätze mit Pausen → keine Wortdopplung; kurzer Tap unverändert; vorbefülltes Feld bleibt Präfix; absichtliche Wiederholung („sehr sehr gut") bleibt erhalten
 - v0.211 Mehr-Hub: Mehr zeigt 4 Gruppen/12 Einträge, jeder Settings-Eintrag öffnet den richtigen Tab; „Speichern ✓" aus Ziele-Tab erhält Profil-Daten; Bibliothek als eigenes Fenster: Rezept/Lebensmittel bearbeiten → speichern/löschen → zurück in der Bibliothek; Bibliothek-＋ öffnet Picker mit vorbefüllter Suche; 🔗/📥 funktionieren; Backup-Banner/-Reminder öffnen Backup-Tab; Hilfe-Texte nennen neue Pfade
-- v0.212 DeepSeek: **Worker deployen** (`wrangler deploy` in `worker/`), `GET /health` → `codeVersion:"v0.212-deepseek-default"`; Mehr → 🤖 KI zeigt „DeepSeek (Standard)" vorausgewählt; DeepSeek-Key (platform.deepseek.com) eintragen → Chat-Badge „über DeepSeek · deepseek-chat"; Foto senden → Badge zeigt tatsächliche Bild-Quelle (DeepSeek, falls deren API Bilder annimmt, sonst Anthropic-Fallback); ohne Key läuft alles über Anthropic
+- v0.213 Foto-KI/Qwen: **Worker deployen** (`wrangler deploy` in `worker/`), `GET /health` → `codeVersion:"v0.213-qwen-vision"`; Mehr → 🤖 KI zeigt Abschnitt „📷 Foto-KI" mit „Qwen (Alibaba) (Standard)" vorausgewählt + Key-Feld + Hint; Qwen-Key (Alibaba Cloud Model Studio, intl.) eintragen → Foto senden → Badge „über Qwen · qwen-vl-max"; ohne Qwen-Key → Foto an Claude; Foto-KI explizit auf Anthropic → Claude; DeepSeek-Chat (Text) unverändert über DeepSeek; Vision-Key nur verschlüsselt im Backup
 - v0.201 Stabilität: Trends-Tab öffnen → keine Konsolen-Fehler, Streak-Kachel zeigt Zahl, „📷 Offline-Fotos"-Panel erscheint bei Queue-Einträgen. Konsole: `S.days['2026-01-01']={_compressed:true,kcal:1800,water:4};saveS();` → dorthin blättern → leerer Tag statt Crash. Chat „Brot mit Käse und Schinken und Gurke" → Zutaten in genau dieser Reihenfolge
 - v0.202 Diktat (Android + iPhone): 🎙️ halten, mehrere Sätze mit Pausen sprechen → fortlaufender Text **ohne** Wiederholungen; kurzer Tap wie bisher; bestehender Text bleibt als Präfix (#154)
 - v0.203 XSS: Eigenes Lebensmittel `<img src=x onerror=alert(1)>` anlegen und eintragen → überall als Text, kein Alert; Name mit `"` → Bearbeiten-Dialog zeigt vollen Namen im Feld; `Müsli & Milch` nirgends doppelt-escaped
@@ -93,11 +93,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.208 | #164 | Mahlzeit-Fotos nach IndexedDB (`js/idb-photos.js`), Migration, Queue ohne Base64, Fotos nicht mehr im Backup (#162) |
 | v0.209 | — | „Ei" = rohes Ei mit eigenem DB-Eintrag, Rührei-Synonyme entwirrt (#166) |
 | v0.210 | — | Diktat: Finals pro Result-Index + Overlap-Guard gegen iOS-Re-Delivery (#156) |
 | v0.211 | — | Mehr-Hub: alle Settings-Bereiche als gruppierte Direkteinträge, Bibliothek als eigenes Overlay |
 | v0.212 | — | DeepSeek Standard-Anbieter (Rolling-Alias), Fotos an DeepSeek durchgereicht, Quellen-Badge-Fix |
+| v0.213 | — | Separate Foto-KI: Qwen (`qwen-vl-max`) als Standard-Vision-Anbieter mit eigenem Key/Slot, Routing-Kette in `callClaude`, eigenes Backup-Feld |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -680,7 +680,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.212</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.213</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -1025,7 +1025,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.212</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.213</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1873,8 +1873,8 @@ button,input,select,textarea{font-family:var(--fs-body);}
           <button type="button" class="seb" onclick="saveProxyPwFromSettings()">Passwort speichern ✓</button>
         </div>
         <div style="padding-top:12px;border-top:1px solid var(--br);margin-top:12px;">
-          <label class="lbl" style="margin-bottom:8px;">🤖 KI-Anbieter</label>
-          <div style="font-size:12px;color:var(--mu);line-height:1.5;margin-bottom:8px;">Wähle, an welchen KI-Anbieter die Schätzungen (Foto-Erkennung, Chat, Wochenbericht) gehen. Mit eigenem API-Key wird dieser <b>zuerst</b> genutzt; ist das Kontingent aufgebraucht oder kommt kein Ergebnis, fällt NutriTrack automatisch auf Anthropic (Standard) zurück. Der Key wird nur auf diesem Gerät gespeichert.</div>
+          <label class="lbl" style="margin-bottom:8px;">🤖 KI-Anbieter (Chat &amp; Text)</label>
+          <div style="font-size:12px;color:var(--mu);line-height:1.5;margin-bottom:8px;">Wähle, an welchen KI-Anbieter die Text-Schätzungen (Chat, Wochenbericht) gehen. Fotos steuerst du separat unter „📷 Foto-KI". Mit eigenem API-Key wird dieser <b>zuerst</b> genutzt; ist das Kontingent aufgebraucht oder kommt kein Ergebnis, fällt NutriTrack automatisch auf Anthropic (Standard) zurück. Der Key wird nur auf diesem Gerät gespeichert.</div>
           <select id="aiProviderSelect" onchange="onAiProviderChange()"
             style="width:100%;box-sizing:border-box;padding:10px 12px;border:2px solid var(--br);border-radius:10px;font-size:14px;outline:none;margin-bottom:8px;background:#fff;"></select>
           <div id="aiProviderKeyWrap" style="display:none;">
@@ -1884,6 +1884,19 @@ button,input,select,textarea{font-family:var(--fs-body);}
           </div>
           <div id="aiProviderHint" style="font-size:11px;color:var(--mu);line-height:1.5;margin-bottom:8px;"></div>
           <button type="button" class="seb" onclick="saveAiProviderSettings()">Anbieter speichern ✓</button>
+        </div>
+        <div style="padding-top:12px;border-top:1px solid var(--br);margin-top:12px;">
+          <label class="lbl" style="margin-bottom:8px;">📷 Foto-KI</label>
+          <div style="font-size:12px;color:var(--mu);line-height:1.5;margin-bottom:8px;">Wähle, welche KI deine <b>Fotos</b> erkennt. Standard ist Qwen (Alibaba) mit eigenem API-Key. Der Chat bleibt unabhängig davon bei deinem oben gewählten Anbieter. Der Key wird nur auf diesem Gerät gespeichert und wandert nur verschlüsselt ins Backup.</div>
+          <select id="aiVisionSelect" onchange="onAiVisionChange()"
+            style="width:100%;box-sizing:border-box;padding:10px 12px;border:2px solid var(--br);border-radius:10px;font-size:14px;outline:none;margin-bottom:8px;background:#fff;"></select>
+          <div id="aiVisionKeyWrap" style="display:none;">
+            <input type="password" id="aiVisionKeyInput" placeholder="API-Key des Foto-Anbieters" autocomplete="off"
+              style="width:100%;box-sizing:border-box;padding:10px 12px;border:2px solid var(--br);border-radius:10px;font-size:14px;outline:none;margin-bottom:8px;"
+              onkeydown="if(event.key==='Enter')saveAiVisionSettings()">
+          </div>
+          <div id="aiVisionHint" style="font-size:11px;color:var(--mu);line-height:1.5;margin-bottom:8px;"></div>
+          <button type="button" class="seb" onclick="saveAiVisionSettings()">Foto-KI speichern ✓</button>
         </div>
         <div style="padding-top:12px;border-top:1px solid var(--br);margin-top:12px;">
           <label class="lbl" style="margin-bottom:8px;">🛠 KI-Prompts</label>
@@ -1940,7 +1953,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.212';
+var APP_VERSION='0.213';
 var PROJECT_WORKER_BASE='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
 var PROJECT_AI_PROXY_URL=PROJECT_WORKER_BASE+'/v1/messages';
 // Konfigurierbarer KI-Anbieter: läuft über denselben Worker (Format-Übersetzung
@@ -1977,13 +1990,17 @@ function setProxySecret(pw){return _sha256hex(pw).then(function(h){localStorage.
 // Fehler oder leerem Ergebnis fällt callClaude automatisch auf Anthropic zurück.
 // Der Klartext-Key liegt nur lokal (localStorage); in Backups wandert er
 // ausschließlich AES-GCM-verschlüsselt (siehe _aiKeyEnc*-Helfer unten).
+// vision:true = Anbieter kann Fotos direkt entgegennehmen (im Worker im strong-Tier).
+// Wird sowohl für das separate Foto-KI-Routing als auch als Fallback genutzt, wenn
+// kein eigener Vision-Key gesetzt ist, aber der Text-Anbieter Bilder verarbeitet.
 var AI_PROVIDERS=[
-  {id:'anthropic',label:'Anthropic (integriert)',keyless:true,models:'Claude Haiku/Sonnet'},
-  {id:'openai',label:'OpenAI (GPT)',models:'gpt-4o-mini / gpt-4o'},
-  {id:'gemini',label:'Google Gemini',models:'gemini-2.0-flash'},
-  {id:'openrouter',label:'OpenRouter',models:'gpt-4o-mini / gpt-4o'},
-  {id:'mistral',label:'Mistral',models:'mistral-small / pixtral'},
-  {id:'deepseek',label:'DeepSeek (Standard)',models:'deepseek-chat'}
+  {id:'anthropic',label:'Anthropic (integriert)',keyless:true,models:'Claude Haiku/Sonnet',vision:true},
+  {id:'openai',label:'OpenAI (GPT)',models:'gpt-4o-mini / gpt-4o',vision:true},
+  {id:'gemini',label:'Google Gemini',models:'gemini-2.0-flash',vision:true},
+  {id:'openrouter',label:'OpenRouter',models:'gpt-4o-mini / gpt-4o',vision:true},
+  {id:'mistral',label:'Mistral',models:'mistral-small / pixtral',vision:true},
+  {id:'deepseek',label:'DeepSeek (Standard)',models:'deepseek-chat',vision:true},
+  {id:'qwen',label:'Qwen (Alibaba)',models:'qwen-vl-max',vision:true}
 ];
 function _aiProviderMeta(id){for(var i=0;i<AI_PROVIDERS.length;i++){if(AI_PROVIDERS[i].id===id)return AI_PROVIDERS[i];}return AI_PROVIDERS[0];}
 // Standard-Anbieter ist DeepSeek — aktiv wird er aber erst mit gespeichertem
@@ -1992,6 +2009,17 @@ function getAiProvider(){var p=localStorage.getItem('nt_ai_provider')||'deepseek
 function setAiProvider(p){localStorage.setItem('nt_ai_provider',_aiProviderMeta(p).id);}
 function getAiProviderKey(){return localStorage.getItem('nt_ai_key')||'';}
 function setAiProviderKey(k){if(k){localStorage.setItem('nt_ai_key',k);_aiKeyEncRefresh();}else{localStorage.removeItem('nt_ai_key');localStorage.removeItem('nt_ai_key_enc');}}
+// ── Separater Foto-KI-Slot (Vision) ──────────────────────────────────────────
+// Fotos gehen standardmäßig an einen eigenen Anbieter (Default Qwen/qwen-vl-max),
+// unabhängig vom Text-Anbieter. Eigener Key (nt_ai_vision_key), eigenes
+// verschlüsseltes Backup-Feld (nt_ai_vision_key_enc). Ohne Vision-Key greift die
+// Routing-Kette in callClaude auf Text-Anbieter (falls vision:true) bzw. Anthropic.
+function getAiVisionProvider(){var p=localStorage.getItem('nt_ai_vision_provider')||'qwen';return _aiProviderMeta(p).id;}
+function setAiVisionProvider(p){localStorage.setItem('nt_ai_vision_provider',_aiProviderMeta(p).id);}
+function getAiVisionKey(){return localStorage.getItem('nt_ai_vision_key')||'';}
+function setAiVisionKey(k){if(k){localStorage.setItem('nt_ai_vision_key',k);_aiKeyEncRefresh();}else{localStorage.removeItem('nt_ai_vision_key');localStorage.removeItem('nt_ai_vision_key_enc');}}
+// Eigener Foto-Anbieter aktiv? (≠ Anthropic UND Vision-Key hinterlegt)
+function hasVisionAiProvider(){var p=getAiVisionProvider();return p!=='anthropic'&&!!getAiVisionKey();}
 // ── KI-Key verschlüsselt in Backups (AES-GCM, Schlüssel aus dem Proxy-Passwort) ──
 // Klartext-Key (nt_ai_key) verlässt das Gerät nie. Für Backups liegt unter
 // nt_ai_key_enc eine mit PBKDF2(Proxy-Passwort)→AES-GCM verschlüsselte Kopie
@@ -2007,8 +2035,8 @@ function _aiKeyDerive(salt){
     return crypto.subtle.deriveKey({name:'PBKDF2',salt:salt,iterations:100000,hash:'SHA-256'},km,{name:'AES-GCM',length:256},false,['encrypt','decrypt']);
   });
 }
-function encryptAiKeyForBackup(){
-  var key=getAiProviderKey();
+function encryptAiKeyForBackup(plain){
+  var key=plain||getAiProviderKey();
   if(!key||!getProxySecret()||!_aiKeyCryptoOk())return Promise.resolve(null);
   var salt=crypto.getRandomValues(new Uint8Array(16)),iv=crypto.getRandomValues(new Uint8Array(12));
   return _aiKeyDerive(salt).then(function(k){
@@ -2023,48 +2051,73 @@ function decryptAiKeyFromBackup(enc){
     return crypto.subtle.decrypt({name:'AES-GCM',iv:_aiKeyB64d(enc.iv)},k,_aiKeyB64d(enc.ct));
   }).then(function(buf){return new TextDecoder().decode(buf);}).catch(function(){return null;});
 }
-// Klartext-Key vorhanden → verschlüsselte Kopie (neu) erzeugen
-function _aiKeyEncRefresh(){
-  if(!getAiProviderKey())return Promise.resolve();
-  return encryptAiKeyForBackup().then(function(enc){
-    if(enc){try{localStorage.setItem('nt_ai_key_enc',JSON.stringify(enc));}catch(e){}}
+// Klartext-Key vorhanden → verschlüsselte Kopie (neu) erzeugen — für beide Slots
+// (Text: nt_ai_key/nt_ai_key_enc · Vision: nt_ai_vision_key/nt_ai_vision_key_enc).
+function _aiKeyEncRefreshSlot(plain,encStore){
+  if(!plain)return Promise.resolve();
+  return encryptAiKeyForBackup(plain).then(function(enc){
+    if(enc){try{localStorage.setItem(encStore,JSON.stringify(enc));}catch(e){}}
   });
 }
+function _aiKeyEncRefresh(){
+  return Promise.all([
+    _aiKeyEncRefreshSlot(getAiProviderKey(),'nt_ai_key_enc'),
+    _aiKeyEncRefreshSlot(getAiVisionKey(),'nt_ai_vision_key_enc')
+  ]);
+}
 // Verschlüsselte Kopie da (z.B. aus Import), aber kein Klartext → entschlüsseln
-function _aiKeyEncTryDecrypt(){
-  if(getAiProviderKey())return Promise.resolve();
-  var raw=localStorage.getItem('nt_ai_key_enc');
+function _aiKeyEncTryDecryptSlot(hasPlain,encStore,setKey,toast){
+  if(hasPlain)return Promise.resolve();
+  var raw=localStorage.getItem(encStore);
   if(!raw)return Promise.resolve();
   var enc=null;try{enc=JSON.parse(raw);}catch(e){return Promise.resolve();}
   return decryptAiKeyFromBackup(enc).then(function(plain){
-    if(plain){setAiProviderKey(plain);showToast('🔑 KI-Anbieter-Key aus Backup übernommen ✓');}
+    if(plain){setKey(plain);showToast(toast);}
   });
+}
+function _aiKeyEncTryDecrypt(){
+  return Promise.all([
+    _aiKeyEncTryDecryptSlot(!!getAiProviderKey(),'nt_ai_key_enc',setAiProviderKey,'🔑 KI-Anbieter-Key aus Backup übernommen ✓'),
+    _aiKeyEncTryDecryptSlot(!!getAiVisionKey(),'nt_ai_vision_key_enc',setAiVisionKey,'📷 Foto-KI-Key aus Backup übernommen ✓')
+  ]);
 }
 // KI-Anbieter + verschlüsselten Key in ein Backup-Objekt aufnehmen (Klartext nie)
 function _backupAiFields(o){
   var p=getAiProvider();
   // Ohne gespeicherten Key nichts mitgeben — sonst würde der bloße
   // DeepSeek-Default jedes Backups beim Restore als explizite Wahl gepinnt.
-  if(p==='anthropic'||!getAiProviderKey())return o;
-  o.aiProvider=p;
-  try{var enc=localStorage.getItem('nt_ai_key_enc');if(enc)o.aiKeyEnc=JSON.parse(enc);}catch(e){}
+  if(p!=='anthropic'&&getAiProviderKey()){
+    o.aiProvider=p;
+    try{var enc=localStorage.getItem('nt_ai_key_enc');if(enc)o.aiKeyEnc=JSON.parse(enc);}catch(e){}
+  }
+  // Foto-KI-Slot unabhängig davon — gleiche Nicht-Pinnen-Logik (nur mit Vision-Key).
+  var vp=getAiVisionProvider();
+  if(vp!=='anthropic'&&getAiVisionKey()){
+    o.aiVisionProvider=vp;
+    try{var venc=localStorage.getItem('nt_ai_vision_key_enc');if(venc)o.aiVisionKeyEnc=JSON.parse(venc);}catch(e){}
+  }
   return o;
 }
 // Gegenstück beim Import/Restore: Anbieter setzen, Key entschlüsseln (ggf. später)
-function _importAiFields(d){
-  if(!d||!d.aiProvider)return;
+function _importAiFieldsSlot(prov,keyEnc,setProv,setKey,getKey,encStore){
+  if(!prov)return;
   try{
-    setAiProvider(d.aiProvider);
-    if(d.aiKeyEnc&&d.aiKeyEnc.ct){
-      decryptAiKeyFromBackup(d.aiKeyEnc).then(function(plain){
-        if(plain){setAiProviderKey(plain);}
-        else if(!getAiProviderKey()){
-          try{localStorage.setItem('nt_ai_key_enc',JSON.stringify(d.aiKeyEnc));}catch(e){}
+    setProv(prov);
+    if(keyEnc&&keyEnc.ct){
+      decryptAiKeyFromBackup(keyEnc).then(function(plain){
+        if(plain){setKey(plain);}
+        else if(!getKey()){
+          try{localStorage.setItem(encStore,JSON.stringify(keyEnc));}catch(e){}
           showToast('🔑 KI-Key im Backup ist verschlüsselt – nach Eingabe des Proxy-Passworts wird er automatisch übernommen',5000);
         }
       });
     }
   }catch(e){}
+}
+function _importAiFields(d){
+  if(!d)return;
+  _importAiFieldsSlot(d.aiProvider,d.aiKeyEnc,setAiProvider,setAiProviderKey,getAiProviderKey,'nt_ai_key_enc');
+  _importAiFieldsSlot(d.aiVisionProvider,d.aiVisionKeyEnc,setAiVisionProvider,setAiVisionKey,getAiVisionKey,'nt_ai_vision_key_enc');
 }
 // Eigener Anbieter aktiv? (≠ Anthropic UND Key hinterlegt)
 function hasCustomAiProvider(){var p=getAiProvider();return p!=='anthropic'&&!!getAiProviderKey();}
@@ -2449,6 +2502,56 @@ function renderAiProviderSettings(){
   var key=document.getElementById('aiProviderKeyInput');
   if(key)key.value=getAiProviderKey();
   onAiProviderChange();
+  // Foto-KI-Block mitbefüllen
+  var vsel=document.getElementById('aiVisionSelect');
+  if(vsel){
+    if(!vsel.options.length){
+      AI_PROVIDERS.filter(function(p){return p.keyless||p.vision;}).forEach(function(p){
+        var o=document.createElement('option');o.value=p.id;
+        // Anthropic = „integriert" (keyless), Qwen als Standard markieren.
+        o.textContent=p.keyless?p.label:(p.id==='qwen'?'Qwen (Alibaba) (Standard)':p.label);
+        vsel.appendChild(o);
+      });
+    }
+    vsel.value=getAiVisionProvider();
+  }
+  var vkey=document.getElementById('aiVisionKeyInput');
+  if(vkey)vkey.value=getAiVisionKey();
+  onAiVisionChange();
+}
+function onAiVisionChange(){
+  var sel=document.getElementById('aiVisionSelect');
+  var wrap=document.getElementById('aiVisionKeyWrap');
+  var hint=document.getElementById('aiVisionHint');
+  if(!sel)return;
+  var meta=_aiProviderMeta(sel.value);
+  if(wrap)wrap.style.display=meta.keyless?'none':'block';
+  if(hint){
+    if(meta.keyless){
+      hint.textContent='Fotos werden von Claude (integriert) erkannt – kein eigener Key nötig.';
+    }else{
+      var hasKey=getAiVisionProvider()===meta.id&&getAiVisionKey();
+      var saved=hasKey?' · aktiver Key gespeichert ✓':'';
+      hint.textContent='Modell '+meta.models+' · ohne Key erkennt Claude die Fotos'+saved;
+    }
+  }
+}
+function saveAiVisionSettings(){
+  var sel=document.getElementById('aiVisionSelect');
+  var key=document.getElementById('aiVisionKeyInput');
+  var p=sel?sel.value:'anthropic';
+  var meta=_aiProviderMeta(p);
+  if(meta.keyless){
+    setAiVisionProvider('anthropic');setAiVisionKey('');
+    if(key)key.value='';
+    showToast('Foto-KI: Anthropic (integriert)');
+  }else{
+    var k=key?key.value.trim():'';
+    if(!k){showToast('Bitte API-Key eingeben');return;}
+    setAiVisionProvider(p);setAiVisionKey(k);
+    showToast('Foto-KI gespeichert: '+meta.label);
+  }
+  onAiVisionChange();
 }
 function onAiProviderChange(){
   var sel=document.getElementById('aiProviderSelect');
@@ -3088,10 +3191,37 @@ function parsePhotoResponse(text){
 // ════════════════════════════════════════
 function callClaude(model,content,maxTok,onOk,onErr){
   if(!canUseAi()){onErr('KI Proxy nicht konfiguriert');return;}
-  // Eigener Anbieter konfiguriert → zuerst versuchen, bei Limit/Fehler/leerem
-  // Ergebnis transparent auf Anthropic (Standard-Proxy) zurückfallen.
+  var hasImg=Array.isArray(content)&&content.some(function(b){return b&&b.type==='image';});
+  // ── Fotos: eigener Vision-Slot vor dem Text-Anbieter ──────────────────────
+  if(hasImg){
+    // (1) Eigener Foto-Anbieter mit Key → dorthin, Fallback Anthropic.
+    if(hasVisionAiProvider()){
+      _callAiProvider(getAiVisionProvider(),getAiVisionKey(),model,content,maxTok,onOk,function(){
+        _callAnthropic(model,content,maxTok,onOk,onErr,true);
+      });
+      return;
+    }
+    // (2) Foto-KI explizit auf Anthropic gestellt → direkt Anthropic.
+    if(getAiVisionProvider()==='anthropic'){
+      _callAnthropic(model,content,maxTok,onOk,onErr,false);
+      return;
+    }
+    // (3) Kein Vision-Key, aber Text-Anbieter aktiv und bildfähig → dorthin
+    //     durchreichen (bewahrt das v0.212-Verhalten „Fotos an DeepSeek").
+    if(hasCustomAiProvider()&&_aiProviderMeta(getAiProvider()).vision){
+      _callAiProvider(getAiProvider(),getAiProviderKey(),model,content,maxTok,onOk,function(){
+        _callAnthropic(model,content,maxTok,onOk,onErr,true);
+      });
+      return;
+    }
+    // (4) sonst Anthropic.
+    _callAnthropic(model,content,maxTok,onOk,onErr,false);
+    return;
+  }
+  // ── Text: eigener Anbieter konfiguriert → zuerst versuchen, bei Limit/Fehler/
+  //    leerem Ergebnis transparent auf Anthropic (Standard-Proxy) zurückfallen.
   if(hasCustomAiProvider()){
-    _callAiProvider(getAiProvider(),model,content,maxTok,onOk,function(){
+    _callAiProvider(getAiProvider(),getAiProviderKey(),model,content,maxTok,onOk,function(){
       _callAnthropic(model,content,maxTok,onOk,onErr,true);
     });
   }else{
@@ -3112,10 +3242,10 @@ function _callAnthropic(model,content,maxTok,onOk,onErr,isFallback){
 // Ruft den gewählten Fremd-Anbieter über den Worker auf. Der Worker übersetzt
 // das Anthropic-Format und liefert es im selben Schema zurück. onErr triggert
 // im Aufrufer den Anthropic-Fallback (Limit/Fehler/Timeout/leeres Ergebnis).
-function _callAiProvider(provider,model,content,maxTok,onOk,onErr){
+function _callAiProvider(provider,key,model,content,maxTok,onOk,onErr){
   fetchT(PROJECT_AI_PROVIDER_URL,{
     method:'POST',
-    headers:{'Content-Type':'application/json','x-app-proxy-secret':getProxySecret(),'x-ai-provider':provider,'x-ai-key':getAiProviderKey()},
+    headers:{'Content-Type':'application/json','x-app-proxy-secret':getProxySecret(),'x-ai-provider':provider,'x-ai-key':key},
     body:JSON.stringify({model:model,max_tokens:maxTok,temperature:0,messages:[{role:'user',content:content}]})
   },25000).then(function(r){return r.json().then(function(d){if(!r.ok)throw new Error((d.error&&d.error.message)||d.error||('HTTP '+r.status));return d;});}).then(function(d){
     if(d.error)throw new Error(d.error.message);

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -1,6 +1,9 @@
 // NutriTrack – Versions-Changelog für den "Was ist neu"-Dialog.
 // Ausgelagert aus index.html (v0.204). Klassisches Script, exportiert window.CHANGELOG.
 window.CHANGELOG=[
+  {v:'0.213',items:[
+    {icon:'📷',text:'Neue Foto-KI-Einstellung: Fotos werden jetzt standardmäßig von Qwen (qwen-vl-max — immer automatisch die neueste Version) erkannt, mit eigenem API-Key unter Mehr → 🤖 KI. Der Chat bleibt bei deinem bisherigen Anbieter; ohne Qwen-Key erkennt weiterhin Claude die Fotos.',where:'Mehr → 🤖 KI'},
+  ]},
   {v:'0.212',items:[
     {icon:'🤖',text:'DeepSeek ist jetzt der vorausgewählte KI-Anbieter (Modell deepseek-chat — immer automatisch die neueste Version). Aktiv wird er mit eigenem API-Key unter Mehr → 🤖 KI; ohne Key läuft alles weiter über Anthropic. Auch Fotos gehen jetzt an DeepSeek — kann deren API sie nicht verarbeiten, springt automatisch Claude ein. Das Quellen-Badge unter dem Foto-Ergebnis zeigt jetzt ehrlich, wer das Bild erkannt hat.',where:'Mehr → 🤖 KI'},
   ]},

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.212';
+var VERSION = '0.213';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -848,6 +848,14 @@ const AI_PROVIDERS = {
     models: { fast: "gemini-2.0-flash", strong: "gemini-2.0-flash" },
     vision: true,
   },
+  qwen: {
+    type: "openai",
+    // OpenAI-kompatibler DashScope-Endpoint (International/Alibaba Cloud Model Studio).
+    url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+    // qwen-vl-max = rollender Alias auf das jeweils stärkste Vision-Modell (kein Pin).
+    models: { fast: "qwen-vl-max", strong: "qwen-vl-max" },
+    vision: true,
+  },
 };
 
 function payloadHasImage(messages) {
@@ -1029,7 +1037,7 @@ export default {
         feedbackConfigured: Boolean(env.GITHUB_TOKEN),
         workoutsConfigured: Boolean(env.SHARE_KV),
         decoderSecretConfigured: Boolean(env.DECODER_SECRET),
-        codeVersion: "v0.212-deepseek-default",
+        codeVersion: "v0.213-qwen-vision",
       });
     }
 


### PR DESCRIPTION
## Was

Fotos gehen jetzt an einen **eigenen, vom Text-Anbieter unabhängigen Vision-Slot** (Default **Qwen / `qwen-vl-max`**). Chat/Text bleibt beim bisherigen Anbieter (DeepSeek-Default aus v0.212). Zweiter, komplett getrennter Anbieter-Slot mit eigenem Key, eigener UI und eigener Backup-Verschlüsselung.

## Änderungen

**Worker** (`worker/src/index.js`)
- `qwen` in `AI_PROVIDERS` (OpenAI-kompatibler DashScope-**intl**-Endpoint `dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions`, `qwen-vl-max` als Rolling-Alias, `vision:true`)
- `codeVersion` → `"v0.213-qwen-vision"`

**Client** (`index.html`)
- Eigener Vision-Slot: `getAiVisionProvider/setAiVisionProvider`, `getAiVisionKey/setAiVisionKey` (`nt_ai_vision_provider`/`nt_ai_vision_key`, Default `qwen`), `hasVisionAiProvider()`
- Routing-Kette in `callClaude` bei Bild-Content: (1) Vision-Key → dessen API, Fallback Anthropic · (2) Foto-KI explizit Anthropic → Claude · (3) kein Vision-Key, aber bildfähiger Text-Anbieter → Durchreichen (bewahrt v0.212-Verhalten) · (4) sonst Anthropic
- `_callAiProvider(provider, key, …)` — Key jetzt als Parameter (beide Aufrufstellen)
- Backup: Vision-Key AES-GCM-verschlüsselt (`nt_ai_vision_key_enc`); beide Slots in `_aiKeyEncRefresh`/`_aiKeyEncTryDecrypt`/`_backupAiFields`/`_importAiFields` (Nicht-Pinnen-Logik, alle 4 Restore-Pfade)
- UI: Abschnitt „📷 Foto-KI" im KI-Panel (Select/Key/Hint), `saveAiVisionSettings()`, `onAiVisionChange()`
- `AI_PROVIDERS` um `vision`-Flags + Qwen-Eintrag erweitert; Badge strippt „(Alibaba)" → „Qwen"

**Doku/Version**: Bump auf v0.213 (`APP_VERSION`, `sw.js`, 2× sichtbarer Text, `#appVersionTag`), CHANGELOG-Eintrag in `js/changelog.js`, `UEBERGABE.md`.

## Verifikation
- `node --check` für `picker.js`, `js/changelog.js`, `worker/src/index.js` ✓
- Playwright (frisches Profil): Foto-KI-Abschnitt mit Qwen (Standard) + Key-Feld + Hint; Routing-Matrix (a–e) geprüft; `_backupAiFields` ohne/mit Vision-Key; `_importAiFields` stellt Slot wieder her ✓

## ⚠️ Worker separat deployen
Der Cloudflare Worker muss nach dem Merge separat deployt werden (`wrangler deploy` in `worker/`). Danach `GET /health` prüfen → `codeVersion: "v0.213-qwen-vision"`. Ohne Deploy kennt der Proxy `qwen` nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154wwHn98kvpDYyFi6TjwaD

---
_Generated by [Claude Code](https://claude.ai/code/session_0154wwHn98kvpDYyFi6TjwaD)_