### PR TITLE
v0.214: Foto-KI-Modell auf Qwen3-VL (qwen3-vl-plus)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.213 (2026-07-10) — Branch `claude/nutritrack-qwen-vision-qhjlsu` (separate Foto-KI: Qwen als Standard-Vision-Anbieter)
+**Stand:** v0.214 (2026-07-10) — Branch `claude/nutritrack-qwen-vision-qhjlsu` (Foto-KI-Modell auf Qwen3-VL `qwen3-vl-plus`)
 
 ## URLs
 
@@ -37,8 +37,8 @@
 - **Share/Import:** Sender → `POST /share` (KV, 1y) → `?s=<id>`; iOS non-standalone → `iosSwitchOv` + 📥 `openImportPaste()`. Payload `{t:'r'|'f'|'m',…}`.
 - **OneDrive (v0.159):** `_odGetToken()` löscht Tokens nur bei echten Auth-Fehlern (+ `odReconnectOv`); täglicher Autospeicher-Slot via `_odAutoSync`→`oneDriveSyncSlot`.
 - **Picker Chat (v0.175–0.190):** Lokale Fuzzy-Suche (nur Rezepte+Custom Foods, alle Tokens müssen treffen, `_pickerDbHit` für DB-Exakt-Treffer) → KI-Fallback (`DEFAULT_CHAT_PROMPT`, `PROMPT_VERSION='7'`, Few-Shot, keine Sackgasse: kurze Eingaben gehen als Einzel-Lebensmittel an `lookupNutrients`).
-- **Foto-Analyse (v0.191/v0.213):** `pickerAnalyze` skaliert auf 1280 px, `getFotoPrompt()` immer Default. `callClaude` erkennt Bilder (`content` mit `type:'image'`) und routet über eine eigene Kette: (1) eigener Vision-Slot mit Key → dessen API (Default Qwen/`qwen-vl-max`), (2) Foto-KI explizit auf Anthropic → `claude-sonnet-4-6`, (3) kein Vision-Key, aber Text-Anbieter aktiv und `vision:true` → dorthin durchreichen (bewahrt v0.212-DeepSeek-Verhalten), (4) sonst Anthropic. Fallback bei Fehler/leer immer Anthropic. Quellen-Badge direkt nach der Vision-Antwort eingefroren (nicht die lookupNutrients-Quelle).
-- **KI-Anbieter (v0.193–v0.213):** Mehr → 🤖 KI: Fremd-Anbieter via Worker `POST /ai/messages`; `callClaude` = `_callAiProvider(provider,key,…)` → Fallback `_callAnthropic`; Badge `aiSourceBadgeHtml()` (`aiSourceText` strippt `(Alibaba)` → `Qwen`). **Zwei unabhängige Slots:** Text-Anbieter (`nt_ai_provider`/`nt_ai_key`, Default `deepseek`, aktiv via `hasCustomAiProvider`) und Foto-KI (`nt_ai_vision_provider`/`nt_ai_vision_key`, Default `qwen`, aktiv via `hasVisionAiProvider`). Ohne jeweiligen Key → Anthropic-Proxy. `_backupAiFields` nimmt jeden Slot nur mit eigenem Key ins Backup (`aiProvider`/`aiKeyEnc`, `aiVisionProvider`/`aiVisionKeyEnc`); Keys wandern AES-GCM-verschlüsselt (Schlüssel aus Proxy-Passwort) in alle Backups, `_importAiFields` stellt beide Slots in allen 4 Restore-Pfaden wieder her. Worker: Qwen = OpenAI-kompatibler DashScope-intl-Endpoint.
+- **Foto-Analyse (v0.191/v0.214):** `pickerAnalyze` skaliert auf 1280 px, `getFotoPrompt()` immer Default. `callClaude` erkennt Bilder (`content` mit `type:'image'`) und routet über eine eigene Kette: (1) eigener Vision-Slot mit Key → dessen API (Default Qwen/`qwen3-vl-plus`), (2) Foto-KI explizit auf Anthropic → `claude-sonnet-4-6`, (3) kein Vision-Key, aber Text-Anbieter aktiv und `vision:true` → dorthin durchreichen (bewahrt v0.212-DeepSeek-Verhalten), (4) sonst Anthropic. Fallback bei Fehler/leer immer Anthropic. Quellen-Badge direkt nach der Vision-Antwort eingefroren (nicht die lookupNutrients-Quelle).
+- **KI-Anbieter (v0.193–v0.214):** Mehr → 🤖 KI: Fremd-Anbieter via Worker `POST /ai/messages`; `callClaude` = `_callAiProvider(provider,key,…)` → Fallback `_callAnthropic`; Badge `aiSourceBadgeHtml()` (`aiSourceText` strippt `(Alibaba)` → `Qwen`). **Zwei unabhängige Slots:** Text-Anbieter (`nt_ai_provider`/`nt_ai_key`, Default `deepseek`, aktiv via `hasCustomAiProvider`) und Foto-KI (`nt_ai_vision_provider`/`nt_ai_vision_key`, Default `qwen`, aktiv via `hasVisionAiProvider`). Ohne jeweiligen Key → Anthropic-Proxy. `_backupAiFields` nimmt jeden Slot nur mit eigenem Key ins Backup (`aiProvider`/`aiKeyEnc`, `aiVisionProvider`/`aiVisionKeyEnc`); Keys wandern AES-GCM-verschlüsselt (Schlüssel aus Proxy-Passwort) in alle Backups, `_importAiFields` stellt beide Slots in allen 4 Restore-Pfaden wieder her. Worker: Qwen = OpenAI-kompatibler DashScope-intl-Endpoint.
 - **OFF via Worker (v0.192):** Alle OpenFoodFacts-Calls über `GET /off?u=…`, Rezept-Import über `GET /fetch?u=…`; `fetchT` mit harten Timeouts überall.
 - **Barcode (v0.196):** `zxing-wasm` lokal (`js/zxing/`), Canvas→ImageData-Wrapper `window.ZXingWasm.readBarcodes`; zbar-wasm per esm.sh best effort; `@zxing/library` lokal als JS-Fallback.
 - **Sport-Sync (v0.158):** `js/health-sync.js` (`window.NTHealth`), Token in iOS-Shortcut/Android-HTTP-Shortcut, Worker `POST /workout` / `GET /workouts`, Einträge in `S.days[*].exercise[]` mit `_healthId`/`_source`.
@@ -77,7 +77,7 @@
 - v0.209 Ei (#166): Suche „Ei" → erster Treffer „Ei 🥚 143 kcal", dann „Ei (gekocht)", „Rührei" dahinter; Chat „2 Eier" → Zutat „Ei" (roh), nicht Rührei; „Rührei" weiterhin per Namen findbar
 - v0.210 Diktat (#156, iPhone!): 🎙️ halten, 3 Sätze mit Pausen → keine Wortdopplung; kurzer Tap unverändert; vorbefülltes Feld bleibt Präfix; absichtliche Wiederholung („sehr sehr gut") bleibt erhalten
 - v0.211 Mehr-Hub: Mehr zeigt 4 Gruppen/12 Einträge, jeder Settings-Eintrag öffnet den richtigen Tab; „Speichern ✓" aus Ziele-Tab erhält Profil-Daten; Bibliothek als eigenes Fenster: Rezept/Lebensmittel bearbeiten → speichern/löschen → zurück in der Bibliothek; Bibliothek-＋ öffnet Picker mit vorbefüllter Suche; 🔗/📥 funktionieren; Backup-Banner/-Reminder öffnen Backup-Tab; Hilfe-Texte nennen neue Pfade
-- v0.213 Foto-KI/Qwen: **Worker deployen** (`wrangler deploy` in `worker/`), `GET /health` → `codeVersion:"v0.213-qwen-vision"`; Mehr → 🤖 KI zeigt Abschnitt „📷 Foto-KI" mit „Qwen (Alibaba) (Standard)" vorausgewählt + Key-Feld + Hint; Qwen-Key (Alibaba Cloud Model Studio, intl.) eintragen → Foto senden → Badge „über Qwen · qwen-vl-max"; ohne Qwen-Key → Foto an Claude; Foto-KI explizit auf Anthropic → Claude; DeepSeek-Chat (Text) unverändert über DeepSeek; Vision-Key nur verschlüsselt im Backup
+- v0.214 Foto-KI/Qwen3-VL: **Worker deployen** (`wrangler deploy` in `worker/`), `GET /health` → `codeVersion:"v0.214-qwen-vision"`; Mehr → 🤖 KI zeigt Abschnitt „📷 Foto-KI" mit „Qwen (Alibaba) (Standard)" vorausgewählt, Hint nennt „Modell qwen3-vl-plus"; Qwen-Key (Alibaba Cloud Model Studio, intl.) eintragen → Foto senden → Badge „über Qwen · qwen3-vl-plus"; ohne Qwen-Key → Foto an Claude; Foto-KI explizit auf Anthropic → Claude; DeepSeek-Chat (Text) unverändert über DeepSeek; Vision-Key nur verschlüsselt im Backup
 - v0.201 Stabilität: Trends-Tab öffnen → keine Konsolen-Fehler, Streak-Kachel zeigt Zahl, „📷 Offline-Fotos"-Panel erscheint bei Queue-Einträgen. Konsole: `S.days['2026-01-01']={_compressed:true,kcal:1800,water:4};saveS();` → dorthin blättern → leerer Tag statt Crash. Chat „Brot mit Käse und Schinken und Gurke" → Zutaten in genau dieser Reihenfolge
 - v0.202 Diktat (Android + iPhone): 🎙️ halten, mehrere Sätze mit Pausen sprechen → fortlaufender Text **ohne** Wiederholungen; kurzer Tap wie bisher; bestehender Text bleibt als Präfix (#154)
 - v0.203 XSS: Eigenes Lebensmittel `<img src=x onerror=alert(1)>` anlegen und eintragen → überall als Text, kein Alert; Name mit `"` → Bearbeiten-Dialog zeigt vollen Namen im Feld; `Müsli & Milch` nirgends doppelt-escaped
@@ -93,11 +93,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.209 | — | „Ei" = rohes Ei mit eigenem DB-Eintrag, Rührei-Synonyme entwirrt (#166) |
 | v0.210 | — | Diktat: Finals pro Result-Index + Overlap-Guard gegen iOS-Re-Delivery (#156) |
 | v0.211 | — | Mehr-Hub: alle Settings-Bereiche als gruppierte Direkteinträge, Bibliothek als eigenes Overlay |
 | v0.212 | — | DeepSeek Standard-Anbieter (Rolling-Alias), Fotos an DeepSeek durchgereicht, Quellen-Badge-Fix |
-| v0.213 | — | Separate Foto-KI: Qwen (`qwen-vl-max`) als Standard-Vision-Anbieter mit eigenem Key/Slot, Routing-Kette in `callClaude`, eigenes Backup-Feld |
+| v0.213 | #170 | Separate Foto-KI: Qwen als Standard-Vision-Anbieter mit eigenem Key/Slot, Routing-Kette in `callClaude`, eigenes Backup-Feld |
+| v0.214 | — | Foto-KI-Modell auf Qwen3-VL (`qwen3-vl-plus`) statt Legacy-`qwen-vl-max` |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -680,7 +680,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.213</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.214</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -1025,7 +1025,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.213</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.214</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1953,7 +1953,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.213';
+var APP_VERSION='0.214';
 var PROJECT_WORKER_BASE='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
 var PROJECT_AI_PROXY_URL=PROJECT_WORKER_BASE+'/v1/messages';
 // Konfigurierbarer KI-Anbieter: läuft über denselben Worker (Format-Übersetzung
@@ -2000,7 +2000,7 @@ var AI_PROVIDERS=[
   {id:'openrouter',label:'OpenRouter',models:'gpt-4o-mini / gpt-4o',vision:true},
   {id:'mistral',label:'Mistral',models:'mistral-small / pixtral',vision:true},
   {id:'deepseek',label:'DeepSeek (Standard)',models:'deepseek-chat',vision:true},
-  {id:'qwen',label:'Qwen (Alibaba)',models:'qwen-vl-max',vision:true}
+  {id:'qwen',label:'Qwen (Alibaba)',models:'qwen3-vl-plus',vision:true}
 ];
 function _aiProviderMeta(id){for(var i=0;i<AI_PROVIDERS.length;i++){if(AI_PROVIDERS[i].id===id)return AI_PROVIDERS[i];}return AI_PROVIDERS[0];}
 // Standard-Anbieter ist DeepSeek — aktiv wird er aber erst mit gespeichertem
@@ -2010,7 +2010,7 @@ function setAiProvider(p){localStorage.setItem('nt_ai_provider',_aiProviderMeta(
 function getAiProviderKey(){return localStorage.getItem('nt_ai_key')||'';}
 function setAiProviderKey(k){if(k){localStorage.setItem('nt_ai_key',k);_aiKeyEncRefresh();}else{localStorage.removeItem('nt_ai_key');localStorage.removeItem('nt_ai_key_enc');}}
 // ── Separater Foto-KI-Slot (Vision) ──────────────────────────────────────────
-// Fotos gehen standardmäßig an einen eigenen Anbieter (Default Qwen/qwen-vl-max),
+// Fotos gehen standardmäßig an einen eigenen Anbieter (Default Qwen/qwen3-vl-plus),
 // unabhängig vom Text-Anbieter. Eigener Key (nt_ai_vision_key), eigenes
 // verschlüsseltes Backup-Feld (nt_ai_vision_key_enc). Ohne Vision-Key greift die
 // Routing-Kette in callClaude auf Text-Anbieter (falls vision:true) bzw. Anthropic.

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -1,6 +1,9 @@
 // NutriTrack – Versions-Changelog für den "Was ist neu"-Dialog.
 // Ausgelagert aus index.html (v0.204). Klassisches Script, exportiert window.CHANGELOG.
 window.CHANGELOG=[
+  {v:'0.214',items:[
+    {icon:'📷',text:'Bessere Foto-Erkennung: Die Foto-KI nutzt jetzt Qwen3-VL (qwen3-vl-plus) statt des Vorgängermodells — schärfere Bilderkennung, weiterhin automatisch die neueste Version. Nichts zu tun; dein Qwen-Key gilt unverändert.',where:'Mehr → 🤖 KI'},
+  ]},
   {v:'0.213',items:[
     {icon:'📷',text:'Neue Foto-KI-Einstellung: Fotos werden jetzt standardmäßig von Qwen (qwen-vl-max — immer automatisch die neueste Version) erkannt, mit eigenem API-Key unter Mehr → 🤖 KI. Der Chat bleibt bei deinem bisherigen Anbieter; ohne Qwen-Key erkennt weiterhin Claude die Fotos.',where:'Mehr → 🤖 KI'},
   ]},

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.213';
+var VERSION = '0.214';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -852,8 +852,9 @@ const AI_PROVIDERS = {
     type: "openai",
     // OpenAI-kompatibler DashScope-Endpoint (International/Alibaba Cloud Model Studio).
     url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-    // qwen-vl-max = rollender Alias auf das jeweils stärkste Vision-Modell (kein Pin).
-    models: { fast: "qwen-vl-max", strong: "qwen-vl-max" },
+    // qwen3-vl-plus = aktueller Qwen3-VL-Alias (Nachfolger des Legacy-qwen-vl-max),
+    // rollend auf die jeweils neueste Version (kein Pin).
+    models: { fast: "qwen3-vl-plus", strong: "qwen3-vl-plus" },
     vision: true,
   },
 };
@@ -1037,7 +1038,7 @@ export default {
         feedbackConfigured: Boolean(env.GITHUB_TOKEN),
         workoutsConfigured: Boolean(env.SHARE_KV),
         decoderSecretConfigured: Boolean(env.DECODER_SECRET),
-        codeVersion: "v0.213-qwen-vision",
+        codeVersion: "v0.214-qwen-vision",
       });
     }
 


### PR DESCRIPTION
## Was

Folgeänderung zu #170 (v0.213). Die Foto-KI nutzte bisher **`qwen-vl-max`** — das ist die Vorgänger-Generation und in Alibabas Doku als **Legacy** geführt. Diese PR stellt das Standard-Foto-Modell auf **`qwen3-vl-plus`** um (aktueller Qwen3-VL-Alias, deutlich bessere Bilderkennung, weiterhin rollend auf die jeweils neueste Version).

Reiner Modell-Wechsel — Routing, Vision-Slot, Key-Handling und Backup aus v0.213 bleiben unverändert. Bestehende Qwen-Keys gelten weiter.

## Änderungen

- **Worker** (`worker/src/index.js`): `qwen`-Modell `qwen-vl-max` → **`qwen3-vl-plus`** (fast + strong); `codeVersion` → `"v0.214-qwen-vision"`
- **Client** (`index.html`): `AI_PROVIDERS`-Qwen-Modell → `qwen3-vl-plus` (UI-Hint „Modell qwen3-vl-plus" folgt automatisch)
- **Version**: Bump auf v0.214 (`APP_VERSION`, `sw.js`, 2× sichtbarer Text, `#appVersionTag`), neuer CHANGELOG-Eintrag in `js/changelog.js` (v0.213-Eintrag bleibt als Historie)
- **Doku**: `UEBERGABE.md` aktualisiert (Stand, Modell-Referenzen, Live-Test, Historie)

## Verifikation
- `node --check` für `worker/src/index.js`, `js/changelog.js` ✓
- Playwright (frisches Profil): UI-Hint zeigt „Modell qwen3-vl-plus", Qwen „(Standard)" vorausgewählt; Routing-Matrix (a–e) unverändert korrekt; `_backupAiFields`/`_importAiFields` intakt; keine Konsolenfehler ✓

## ⚠️ Worker separat deployen
Nach dem Merge den Cloudflare Worker deployen (`wrangler deploy` in `worker/`). Danach `GET /health` → `codeVersion: "v0.214-qwen-vision"`. Ohne Deploy schickt der Proxy weiterhin `qwen-vl-max` (bzw. das, was v0.213 deployt hat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154wwHn98kvpDYyFi6TjwaD

---
_Generated by [Claude Code](https://claude.ai/code/session_0154wwHn98kvpDYyFi6TjwaD)_