### PR TITLE
Fix "Speicher voll": Nutzerdaten beim Speichern priorisieren (v0.215)

### DIFF
--- a/UEBERGABE.md
+++ b/UEBERGABE.md
@@ -2,7 +2,7 @@
 
 > Erste Aktion jeder Session: diese Datei lesen. Sie ist die Single Source of Truth für den aktuellen Projekt-Stand. **Knapp halten** — siehe „Pflege" unten.
 
-**Stand:** v0.214 (2026-07-10) — Branch `claude/nutritrack-qwen-vision-qhjlsu` (Foto-KI-Modell auf Qwen3-VL `qwen3-vl-plus`)
+**Stand:** v0.215 (2026-07-14) — Branch `claude/backup-storage-full-error-tbxsad` (Speicher-voll-Fix: Nutzerdaten haben Vorrang)
 
 ## URLs
 
@@ -19,6 +19,7 @@
 - **Fotos in IndexedDB (v0.208):** `js/idb-photos.js` → `window.NTPhotos` (put/get/del, DB `nt-photos`). Einträge tragen `mealPhotoId` statt Base64 (`saveMealPhoto`); Anzeige lädt asynchron nach (`_mealPhotoImgHtml`/`_hydratePhotoImgs` via `img[data-phid]`, `renderMealDetail`-`mdPhoto` direkt per `NTPhotos.get`). Boot-Migration `_migratePhotosToIdb` (Flag `nt_photos_migrated`, löscht bei IDB-Fehler nichts); nach jedem Import/Restore ruft `_migratePhotosAfterImport()` sie erneut. `deleteEntry`/`compressOldDays` löschen IDB-Fotos best effort. Offline-Foto-Queue speichert `{phid,…}` statt Base64. Ohne IndexedDB: Fallback aufs alte `mealPhoto`-Feld. **Fotos sind gerätelokal, nicht Teil der Backups.**
 - **Stabilität (v0.201):** `getDay()` behandelt komprimierte Alt-Tage (`_compressed`, aus `compressOldDays`) als read-only Leer-Tag → kein Crash beim Zurückblättern >90 Tage. `renderStreak()`-Geisteraufruf entfernt (Streak rendert `renderWeekBars`). `lookupNutrients` schreibt Ergebnisse per Index → Zutaten-Reihenfolge = Eingabe-Reihenfolge.
 - **XSS-Härtung (v0.182/v0.203):** `esc()` (`index.html`) / `_esc()` (`picker.js`) jetzt **flächendeckend** in allen Render-Pfaden, die Namen/Freitexte aus untrusted Quellen (Share-Imports, OFF, KI, Nutzereingaben) per `innerHTML`/Attribut interpolieren — inkl. `value="…"`-Attribute (editName, OneDrive-Pfad), Kochanleitungen, Chat-User-Bubble, Barcode-Code. Bei neuen innerHTML-Stellen immer `esc()` verwenden.
+- **Speicher-Resilienz (v0.215):** `saveS()` gibt bei `QuotaExceededError` stufenweise verzichtbaren localStorage frei und versucht erneut — **Nutzerdaten (`nt_v6`) haben Vorrang** vor Autosaves/Caches (Stufe 1: `nt_autosaves` löschen; Stufe 2: `foodCache`/`barcodeCache` auf `_pruneFoodCache`/`_pruneBarcodeCache` kappen + neu schreiben; erst dann Toast). `AUTOSAVE_MAX=3` (war 5). Caches sind hart begrenzt (`FOODCACHE_MAX`/`BARCODECACHE_MAX=300`, ältester Eintrag zuerst raus), Prune läuft proaktiv in `saveX()`/`saveBarcodeCache()`. Selbstheilend: nach SW-Update speichert ein volles Gerät beim nächsten `saveS()` wieder.
 - **Backup (v0.205):** Ein Einstieg: Einstellungen → 💾 Backup. `backupNow()` (ex-`shareData`, keine Aufrufer mehr unter altem Namen) mit sichtbarer Strategie-Anzeige `#backupNowHint` (OneDrive → Share-Sheet → Datei-Download). Mehr-Hub-Eintrag, Backup-Reminder- und OneDrive-Banner öffnen alle `openBackupSettings()` (= `openSettings()`+`settSetTab('backup')`).
 - **Proxy-Gate (v0.205):** `checkProxyPwGate` respektiert `nt_gate_skipped` („Später – App ohne KI nutzen", `skipProxyPwGate()`). `verifyProxySecret()` pingt den Worker mit 1 Token: 401/403 = falsches Passwort (Gate bleibt, rote Meldung), Netzwerkfehler = neutral. Erfolgreiches Setzen (Gate oder Settings) räumt `nt_gate_skipped` weg.
 - **Picker (v0.206):** **7 Tabs** (Chat, Suche, Zuletzt, Foto, Barcode, Eigenes, Link). „Eigenes" hat Checkbox `#ownOnce` „Nur einmal eintragen" (Werte = Gesamtwerte der Portion, ehem. Quick-Tab — `pickerQuicktrack` gelöscht). **Ein** Link-Import-Codepfad: Picker-Link-Tab (`pickerLinkDetect/Import/Add`); `recipeImportOv`/`openRecipeImport`/`recipeImportDetect`/`recipeImportStart` gelöscht, Bibliothek-🔗 öffnet `openPicker(null,'link')`. `recipeImportExtractUrl` (index.html) bleibt — wird vom Link-Tab genutzt. **Live-Suche:** `pickerSearchLocalLive()` (oninput) rendert lokale Treffer sofort; Online weiterhin per Enter/Button.
@@ -74,6 +75,7 @@
 
 ## Live-Test offen
 
+- v0.215 Speicher (echtes volles Gerät der Nutzerin): App auf v0.215 aktualisieren (Reload für SW-Update) → neuen Eintrag anlegen → wird gespeichert, kein „Speicher voll"-Toast mehr; DevTools/Anwendung → localStorage: `nt_autosaves` verschwindet bei Platzmangel, `nt_v6` vorhanden; Auto-Sicherungen zeigen max. 3 Stände; Such-/Barcode-Caches wachsen nicht über 300 Einträge
 - v0.209 Ei (#166): Suche „Ei" → erster Treffer „Ei 🥚 143 kcal", dann „Ei (gekocht)", „Rührei" dahinter; Chat „2 Eier" → Zutat „Ei" (roh), nicht Rührei; „Rührei" weiterhin per Namen findbar
 - v0.210 Diktat (#156, iPhone!): 🎙️ halten, 3 Sätze mit Pausen → keine Wortdopplung; kurzer Tap unverändert; vorbefülltes Feld bleibt Präfix; absichtliche Wiederholung („sehr sehr gut") bleibt erhalten
 - v0.211 Mehr-Hub: Mehr zeigt 4 Gruppen/12 Einträge, jeder Settings-Eintrag öffnet den richtigen Tab; „Speichern ✓" aus Ziele-Tab erhält Profil-Daten; Bibliothek als eigenes Fenster: Rezept/Lebensmittel bearbeiten → speichern/löschen → zurück in der Bibliothek; Bibliothek-＋ öffnet Picker mit vorbefüllter Suche; 🔗/📥 funktionieren; Backup-Banner/-Reminder öffnen Backup-Tab; Hilfe-Texte nennen neue Pfade
@@ -93,11 +95,11 @@
 
 | Version | PR | Was |
 |---|---|---|
-| v0.210 | — | Diktat: Finals pro Result-Index + Overlap-Guard gegen iOS-Re-Delivery (#156) |
 | v0.211 | — | Mehr-Hub: alle Settings-Bereiche als gruppierte Direkteinträge, Bibliothek als eigenes Overlay |
 | v0.212 | — | DeepSeek Standard-Anbieter (Rolling-Alias), Fotos an DeepSeek durchgereicht, Quellen-Badge-Fix |
 | v0.213 | #170 | Separate Foto-KI: Qwen als Standard-Vision-Anbieter mit eigenem Key/Slot, Routing-Kette in `callClaude`, eigenes Backup-Feld |
 | v0.214 | — | Foto-KI-Modell auf Qwen3-VL (`qwen3-vl-plus`) statt Legacy-`qwen-vl-max` |
+| v0.215 | — | Speicher-voll-Fix: `saveS()` gibt bei Quota-Fehler Autosaves/Caches frei (Nutzerdaten priorisiert), Caches gekappt, `AUTOSAVE_MAX` 5→3 |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -680,7 +680,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
   <div class="hdr">
     <div class="hr">
       <div>
-        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.214</button></div>
+        <div class="logo">Hej <em id="greetName">Du</em> <button type="button" id="appVersionTag" onclick="showWhatsNew()" title="Was ist neu" style="margin-left:4px;background:var(--gl);border:1px solid var(--br);border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;color:var(--mu);letter-spacing:0.02em;cursor:pointer;vertical-align:middle;">v0.215</button></div>
         <div class="greet-sub" id="greetSub">Heute</div>
       </div>
       <div style="display:flex;gap:6px;">
@@ -1025,7 +1025,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.214</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.215</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1953,7 +1953,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.214';
+var APP_VERSION='0.215';
 var PROJECT_WORKER_BASE='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
 var PROJECT_AI_PROXY_URL=PROJECT_WORKER_BASE+'/v1/messages';
 // Konfigurierbarer KI-Anbieter: läuft über denselben Worker (Format-Übersetzung
@@ -2193,24 +2193,56 @@ function mealByTime(){var h=new Date().getHours();if(h>=5&&h<11)return'breakfast
 // ════════════════════════════════════════
 // SECTION: STORAGE
 // ════════════════════════════════════════
+// Verzichtbare Caches begrenzen, damit localStorage nicht über Monate/Jahre unbegrenzt wächst.
+var FOODCACHE_MAX=300, BARCODECACHE_MAX=300;
+function _pruneFoodCache(max){
+  var keys=Object.keys(foodCache);
+  if(keys.length<=max)return false;
+  // Älteste (kleinstes addedAt) zuerst entfernen.
+  keys.sort(function(a,b){return (foodCache[a]&&foodCache[a].addedAt||0)-(foodCache[b]&&foodCache[b].addedAt||0);});
+  keys.slice(0,keys.length-max).forEach(function(k){delete foodCache[k];});
+  return true;
+}
+function _pruneBarcodeCache(max){
+  var keys=Object.keys(barcodeCache);
+  if(keys.length<=max)return false;
+  // Keine Zeitstempel → älteste per Einfügereihenfolge entfernen.
+  keys.slice(0,keys.length-max).forEach(function(k){delete barcodeCache[k];});
+  return true;
+}
+function _lsSet(key,val){try{localStorage.setItem(key,val);return true;}catch(e){return false;}}
+// Bei QuotaExceededError verzichtbaren Speicher stufenweise freigeben – Nutzerdaten haben Vorrang.
+function _freeQuota(step){
+  if(step===1){
+    // Autosaves sind das mit Abstand grösste verzichtbare Objekt (bis zu AUTOSAVE_MAX volle States).
+    try{localStorage.removeItem('nt_autosaves');}catch(e){}
+  }else if(step===2){
+    _pruneFoodCache(FOODCACHE_MAX);_pruneBarcodeCache(BARCODECACHE_MAX);
+    saveX();saveBarcodeCache();
+  }
+}
 function saveS(){
-  try{
-    var data=JSON.stringify(S);
-    localStorage.setItem('nt_v6',data);
+  var data=JSON.stringify(S);
+  if(_lsSet('nt_v6',data)){
     // Warnung wenn >3MB (60% des Limits)
     var kb=Math.round(data.length/1024);
     if(kb>3000&&!window._storageWarnShown){
       window._storageWarnShown=true;
       setTimeout(function(){showToast('⚠️ Speicher fast voll ('+kb+'KB) – Backup erstellen!',5000);},500);
     }
-  }catch(e){
-    showToast('⚠️ Speicher voll! Bitte Backup erstellen und alte Daten löschen.');
+    return;
   }
+  // Speicher voll: verzichtbare Daten freigeben und erneut versuchen, damit die Nutzerdaten trotzdem gespeichert werden.
+  _freeQuota(1);
+  if(_lsSet('nt_v6',data))return;
+  _freeQuota(2);
+  if(_lsSet('nt_v6',data))return;
+  showToast('⚠️ Speicher voll! Bitte Backup erstellen und alte Daten löschen.');
 }
 function loadS(){try{var d=localStorage.getItem('nt_v6');if(d){Object.assign(S,JSON.parse(d));return true;}}catch(e){}return false;}
-function saveX(){try{localStorage.setItem('nt_x',JSON.stringify({fc:foodCache,cf:customFoods,rc:recipes}));}catch(e){}}
+function saveX(){_pruneFoodCache(FOODCACHE_MAX);try{localStorage.setItem('nt_x',JSON.stringify({fc:foodCache,cf:customFoods,rc:recipes}));}catch(e){}}
 function loadX(){try{var d=localStorage.getItem('nt_x');if(d){var x=JSON.parse(d);foodCache=x.fc||{};customFoods=x.cf||[];recipes=x.rc||[];}}catch(e){}}
-function saveBarcodeCache(){try{localStorage.setItem('nt_bc',JSON.stringify(barcodeCache));}catch(e){}}
+function saveBarcodeCache(){_pruneBarcodeCache(BARCODECACHE_MAX);try{localStorage.setItem('nt_bc',JSON.stringify(barcodeCache));}catch(e){}}
 function loadBarcodeCache(){try{var d=localStorage.getItem('nt_bc');if(d)barcodeCache=JSON.parse(d);}catch(e){}}
 function cacheFood(f){if(!f||!f.name)return;var k=f.name.toLowerCase().trim();foodCache[k]={name:f.name,emoji:f.emoji,per100:f.per100,addedAt:Date.now()};saveX();}
 function isAiConfigured(){return !!(PROJECT_AI_PROXY_URL&&getProxySecret());}
@@ -2380,7 +2412,7 @@ function submitProxyPw(){
     if(aiStatus)aiStatus.textContent=ok===true?'✓ Passwort geprüft':'Gespeichert (offline nicht prüfbar)';
   });
 }
-var AUTOSAVE_MAX=5;
+var AUTOSAVE_MAX=3;
 function _autosaveCreate(){
   var saves=[];
   try{saves=JSON.parse(localStorage.getItem('nt_autosaves')||'[]');}catch(e){}

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -1,6 +1,9 @@
 // NutriTrack – Versions-Changelog für den "Was ist neu"-Dialog.
 // Ausgelagert aus index.html (v0.204). Klassisches Script, exportiert window.CHANGELOG.
 window.CHANGELOG=[
+  {v:'0.215',items:[
+    {icon:'💾',text:'Fehler „Speicher voll" behoben: Wenn der Gerätespeicher knapp wurde, wurden neue Einträge teils nicht mehr gespeichert. Deine Tagebuch-Daten haben jetzt immer Vorrang — die App gibt bei Platzmangel automatisch verzichtbare Zwischenspeicher (alte Auto-Sicherungen, Such-Caches) frei, damit gespeichert wird. Auto-Sicherungen und Caches wachsen ausserdem nicht mehr unbegrenzt.',where:'automatisch'},
+  ]},
   {v:'0.214',items:[
     {icon:'📷',text:'Bessere Foto-Erkennung: Die Foto-KI nutzt jetzt Qwen3-VL (qwen3-vl-plus) statt des Vorgängermodells — schärfere Bilderkennung, weiterhin automatisch die neueste Version. Nichts zu tun; dein Qwen-Key gilt unverändert.',where:'Mehr → 🤖 KI'},
   ]},

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.214';
+var VERSION = '0.215';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur


### PR DESCRIPTION
Auf Geräten mit knappem localStorage (v. a. iOS-Safari, ~5 MB) warf
saveS() bei QuotaExceededError und verwarf die Nutzerdaten kommentarlos.
Hauptverursacher: nt_autosaves hielt bis zu 5 volle State-Kopien
(~2,4 MB), dazu unbegrenzt wachsende foodCache/barcodeCache.

- saveS() gibt bei Quota-Fehler stufenweise verzichtbaren Speicher frei
  und versucht erneut: Stufe 1 loescht nt_autosaves, Stufe 2 kappt die
  Caches und schreibt sie neu. Erst wenn beides nicht reicht, kommt der
  Toast. Tagebuch-Daten (nt_v6) haben damit immer Vorrang.
- foodCache/barcodeCache hart auf 300 Eintraege begrenzt (aeltester
  zuerst raus), Prune laeuft proaktiv in saveX()/saveBarcodeCache().
- AUTOSAVE_MAX von 5 auf 3 gesenkt.

Selbstheilend: ein bereits volles Geraet speichert nach dem SW-Update
beim naechsten saveS() wieder, ohne manuelles Aufraeumen.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P3kWuA8VDMdVuGXfCYa3je