### PR TITLE
fix: Diktat-Halten nutzt Tap-Logik statt continuous-Modus (#156)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1025,7 +1025,7 @@ button,input,select,textarea{font-family:var(--fs-body);}
     </div>
     <div class="list-row" onclick="if(typeof showWhatsNew==='function')showWhatsNew();else openOv('whatsNewOv');">
       <div class="lr-ic">🎉</div>
-      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.217</div></div>
+      <div class="lr-body"><div class="lr-name">Was ist neu</div><div class="lr-sub">Beta v0.218</div></div>
       <div class="lr-val">›</div>
     </div>
   </div>
@@ -1953,7 +1953,7 @@ var S={apiKey:'',name:'Du',goal:2000,weight:0,height:0,age:0,gender:'',activity:
 var MEALS=['breakfast','lunch','dinner','snack'];
 var MEAL_NAMES={breakfast:'Frühstück',lunch:'Mittagessen',dinner:'Abendessen',snack:'Snack'};
 
-var APP_VERSION='0.217';
+var APP_VERSION='0.218';
 var PROJECT_WORKER_BASE='https://nutritrack-ai-proxy.h-jolmes.workers.dev';
 var PROJECT_AI_PROXY_URL=PROJECT_WORKER_BASE+'/v1/messages';
 // Konfigurierbarer KI-Anbieter: läuft über denselben Worker (Format-Übersetzung

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -1,6 +1,9 @@
 // NutriTrack – Versions-Changelog für den "Was ist neu"-Dialog.
 // Ausgelagert aus index.html (v0.204). Klassisches Script, exportiert window.CHANGELOG.
 window.CHANGELOG=[
+  {v:'0.218',items:[
+    {icon:'🎙️',text:'Diktat beim Gedrückthalten überarbeitet: nutzt jetzt dieselbe Erkennungslogik wie der Kurz-Tipp — dadurch keine sich aufbauenden Wortwiederholungen mehr.',where:'Mahlzeit → ＋ → Chat'},
+  ]},
   {v:'0.217',items:[
     {icon:'🎙️',text:'Diktat beim Gedrückthalten weiter verbessert: Wortdopplungen an Satzübergängen (besonders auf Android) werden jetzt zuverlässiger entfernt, absichtliche Wiederholungen bleiben möglich.',where:'Mahlzeit → ＋ → Chat'},
   ]},

--- a/picker.js
+++ b/picker.js
@@ -1358,48 +1358,35 @@ function pickerSendChat(){
 // Android Chrome: über Google-Dienste). Kein Server-Roundtrip über den Worker.
 // Bedienung (#150): kurz tippen = Start/Stopp (Auto-Stopp nach Sprechpause),
 // gedrückt halten (≥350 ms) = Push-to-Talk, Aufnahme läuft bis zum Loslassen.
+// Halten nutzt dieselbe Erkennungslogik wie Tippen (continuous:false) und
+// verkettet nur bei Sprechpausen weitere Kurz-Sessions, solange gehalten wird.
 var _pickerRec=null,_pickerRecActive=false,_pickerRecBase='',_pickerRecHold=false;
+var _pickerHoldStart='',_pickerHoldDone='';
 var _pickerHoldTimer=null,_pickerHoldStarted=false,PICKER_HOLD_MS=350;
 function _pickerSpeechCtor(){return window.SpeechRecognition||window.webkitSpeechRecognition||null;}
-// Entfernt aus `add` den Teil, der das Ende von `base` wortweise wiederholt.
-// iOS Safari liefert nach einem Session-Neustart (onend→start) bereits
-// übernommene Phrasen erneut als frische Ergebnisse (#156). Nur Overlaps ab
-// 2 Wörtern (oder komplettes add) werden gestrichen, damit absichtliche
-// Einzelwort-Wiederholungen („sehr sehr lecker") erhalten bleiben.
-function _pickerDedupOverlap(base,add){
-  if(!base||!add)return add;
-  var b=base.toLowerCase().split(/\s+/),a=add.toLowerCase().split(/\s+/);
-  var n=Math.min(b.length,a.length);
-  for(;n>0;n--){
-    if(b.slice(b.length-n).join(' ')===a.slice(0,n).join(' ')){
-      // n===1 and add has more words can be intentional repetition ("sehr sehr gut")
-      // when base itself is a single word. With longer base phrases this is
-      // usually a session-boundary duplicate and should be stripped.
-      if(n===1&&a.length>1&&b.length===1)continue;
-      return add.split(/\s+/).slice(n).join(' ');
-    }
-  }
-  return add;
-}
 function _pickerVoiceStart(hold){
   var Ctor=_pickerSpeechCtor();
   if(!Ctor)return;
   var inp=document.getElementById('pickerChatInp');
   _pickerRecBase=inp.value.trim();
   _pickerRecHold=!!hold;
+  if(_pickerRecHold){_pickerHoldStart=_pickerRecBase;_pickerHoldDone='';}
   var r=new Ctor();
-  r.lang='de-DE';r.interimResults=true;r.continuous=_pickerRecHold;r.maxAlternatives=1;
-  // Finale Transkripte der laufenden Erkennungs-Session getrennt akkumulieren:
-  // Android Chrome liefert bei continuous:true bereits finalisierte Ergebnisse
-  // in späteren Events erneut — deshalb nur ab ev.resultIndex lesen (#154).
-  // iOS Safari liefert zusätzlich denselben Result-Index mehrfach mit
-  // kumuliertem, erneut als final markiertem Transkript — deshalb Finals
-  // pro Index speichern (überschreiben statt anhängen) (#156).
+  r.lang='de-DE';r.interimResults=true;r.continuous=false;r.maxAlternatives=1;
   var finals=[];
   function _finalsJoined(){
     var out=[],i;
     for(i=0;i<finals.length;i++){if(finals[i]&&finals[i].trim())out.push(finals[i].trim());}
     return out.join(' ');
+  }
+  function _composeVoiceText(interim){
+    var session=(_finalsJoined()+(interim?' '+interim:'')).trim();
+    if(!_pickerRecHold){
+      if(!session&&!_pickerRecBase)return _pickerRecBase;
+      return ((_pickerRecBase?_pickerRecBase+' ':'')+session).replace(/\s{2,}/g,' ').trim();
+    }
+    var mid=[_pickerHoldDone,session].filter(Boolean).join(' ');
+    return [_pickerHoldStart,mid].filter(Boolean).join(' ').replace(/\s{2,}/g,' ').trim();
   }
   r.onresult=function(ev){
     var interim='';
@@ -1408,10 +1395,7 @@ function _pickerVoiceStart(hold){
       if(ev.results[i].isFinal)finals[i]=tr;
       else interim+=tr;
     }
-    var joined=_finalsJoined();
-    var raw=(joined+(interim?' '+interim:'')).trim();
-    var add=_pickerDedupOverlap(_pickerRecBase,raw);
-    inp.value=((_pickerRecBase?_pickerRecBase+' ':'')+add).trim();
+    inp.value=_composeVoiceText(interim);
     _pickerChatGrow();
   };
   r.onerror=function(ev){
@@ -1426,15 +1410,10 @@ function _pickerVoiceStart(hold){
     // 'no-speech'/'aborted' bewusst still — Button-Zustand ist schon zurückgesetzt.
   };
   r.onend=function(){
-    // iOS Safari beendet die Erkennung teils trotz continuous — im Hold-Modus
-    // neu starten, solange der Finger unten ist (Feldinhalt wird neue Basis).
+    // Halten = verkettete Tap-Sessions: abgeschlossene Phrase sichern, dann neu starten.
     if(_pickerRecHold&&_pickerRecActive&&_pickerRec===r){
-      // Nur echte Finals in die Basis übernehmen — nicht den kompletten
-      // Feldinhalt (inkl. Interim), sonst liefert die neue Session das
-      // zuletzt Gesagte erneut und der Text verdoppelt sich (#154).
-      // Overlap-Guard gegen erneut gelieferte Phrasen der Vor-Session (#156).
-      var fold=_pickerDedupOverlap(_pickerRecBase,_finalsJoined());
-      _pickerRecBase=((_pickerRecBase?_pickerRecBase+' ':'')+fold).trim();
+      var chunk=_finalsJoined();
+      if(chunk)_pickerHoldDone=(_pickerHoldDone?_pickerHoldDone+' ':'')+chunk;
       finals=[];
       try{r.start();return;}catch(e){}
     }
@@ -1457,6 +1436,7 @@ function pickerVoiceStop(){
 }
 function _pickerVoiceReset(){
   _pickerRecActive=false;_pickerRec=null;_pickerRecHold=false;
+  _pickerHoldStart='';_pickerHoldDone='';
   var mic=document.getElementById('pickerChatMic'),inp=document.getElementById('pickerChatInp');
   if(mic)mic.classList.remove('rec');
   if(inp)inp.placeholder='Was hast du gegessen?';

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // NutriTrack Service Worker
 // Version wird bei jedem Release hochgezählt - löst automatisches Update aus
-var VERSION = '0.217';
+var VERSION = '0.218';
 var CACHE = 'nt-' + VERSION;
 var SKIP = ['workers.dev','corsproxy.io','openfoodfacts.org','fonts.googleapis.com','fonts.gstatic.com','unpkg.com','esm.sh','jsdelivr.net','is.gd','v.gd'];
 // Kern-Assets, die für den Offline-Betrieb vorab gecacht werden. Relativ zur


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (#156)

Beim Gedrückthalten des 🎙️-Buttons entstanden massive Wortwiederholungen, z. B.:

> Eingabe: „Kaffee mit vielen vielen Keksen"
> Ergebnis: „Kaffee Kaffee mit Kaffee mit …"

Ursache: Halten nutzte `continuous:true` plus komplexe Dedup-/Basis-Merge-Logik bei Session-Neustarts. Dadurch wurde bei jedem neuen Erkennungs-Event der bisherige Text erneut angehängt.

## Lösung

Wie vom Nutzer vorgeschlagen: **dieselbe Erkennungslogik wie beim Kurz-Tipp**, nur das Beenden unterscheidet sich.

- **Tap & Halten:** beide `continuous:false` (bewährte Tap-Logik)
- **Gleiches `onresult`:** Finals pro Index überschreiben, nur ab `ev.resultIndex` lesen
- **Halten-Unterschied:** Bei Sprechpausen (`onend`) wird die abgeschlossene Phrase in `_pickerHoldDone` gesichert und eine neue Kurz-Session gestartet — solange der Finger unten bleibt
- **Entfernt:** `_pickerDedupOverlap` und `continuous:true`-Sonderpfad

## Version
- v0.217 → **v0.218** (`index.html`, `sw.js`, Changelog)

## Test (manuell auf Gerät)
1. Mahlzeit → ＋ → Chat → 🎙️ **halten**
2. Sprechen: „Kaffee mit vielen vielen Keksen" (mit kurzen Pausen)
3. Erwartung: genau dieser Satz, keine Wiederholungen
4. Kurz-Tipp weiterhin testen (Regression)
5. Absichtliche Wiederholung: „sehr sehr gut" sollte erhalten bleiben
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08021725-8f72-4295-bd26-d147da48a2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08021725-8f72-4295-bd26-d147da48a2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

